### PR TITLE
Fix MultiQC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 * [#163](https://github.com/nf-core/ampliseq/pull/163) - Template update for nf-core/tools v1.10.2
+* [#136](https://github.com/nf-core/ampliseq/issues/136) - Pipeline fails with remote working directory
 
 ### `Dependencies`
+
+* Updated from MultiQC v1.6 to v1.9
 
 ### `Deprecated`
 

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -7,5 +7,6 @@ report_section_order:
         order: -1000
     nf-core-ampliseq-summary:
         order: -1001
-
-export_plots: true
+        
+#export_plots clashes with current MatPlotLib
+#export_plots: true

--- a/conf/base.config
+++ b/conf/base.config
@@ -22,9 +22,6 @@ process {
   withName: fastqc {
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
-  withName: multiqc {
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
-  }
   withName: make_SILVA_132_16S_classifier {
     cpus = { check_max (1 * task.attempt, 'cpus' ) }
     memory = { check_max (42.GB * task.attempt, 'memory' ) }

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 # Pipeline
 - fastqc=0.11.8
 - font-ttf-dejavu-sans-mono=2.37 #for fastqc 
-- multiqc=1.7
+- multiqc=1.9
 - unzip=6.0 #required for silva unzippping
 - r-rmarkdown=1.18
 - ncurses=6.1

--- a/main.nf
+++ b/main.nf
@@ -516,7 +516,6 @@ if (!params.Q2imported){
 		output:
 		file "*multiqc_report.html" into ch_multiqc_report
 		file "*_data"
-		file "multiqc_plots"
 
 		when:
 		!params.skip_multiqc
@@ -527,8 +526,7 @@ if (!params.Q2imported){
 		custom_config_file = params.multiqc_config ? "--config $mqc_custom_config" : ''
 		// TODO nf-core: Specify which MultiQC modules to use with -m for a faster run time
 		"""
-		##TODO, use "--force --interactive"?
-		multiqc -f $rtitle $rfilename $custom_config_file .
+		multiqc --interactive -f $rtitle $rfilename $custom_config_file .
 		"""
 	}
 


### PR DESCRIPTION
MultiQC does not work with the MatPlotLib version 3.1.0 that is required by QIIME2. MultiQC uses MatPlotLib for static images but not when creating interactive charts, therefore, the creation of static images is now prevented.
Also, errors by MultiQC are no longer ignored.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/ampliseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/ampliseq)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated