### PR TITLE
Fix bug when sorting sample ids for feature-table.tsv (PacBio data)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 * [#182](https://github.com/nf-core/ampliseq/issues/182) - Fix input in case there are no underscores in sample IDs
+* [#187](https://github.com/nf-core/ampliseq/issues/187) - Sample ids are in incorrect order in feature-table from PacBio data
 
 ### `Dependencies`
 

--- a/bin/dada2_chimrem.r
+++ b/bin/dada2_chimrem.r
@@ -126,7 +126,7 @@ logmsg( sprintf( "Creating count tables and generating sequence file." ) )
 metadata <- read.table(opt$manifest, header = TRUE, sep = ",", colClasses = "character")
 metadata["file"] <- basename(metadata$absolute.filepath)
 nochim2 <- base:::as.data.frame(t(nochim))
-sample_ids <- metadata$sample.id[match(metadata$file,colnames(nochim2))]
+sample_ids <- metadata$sample.id[match(colnames(nochim2),metadata$file)]
 colnames(nochim2) <- sample_ids
 nochim2$seq <- row.names(nochim2)
 row.names(nochim2) <- paste0("ASV_", seq(nrow(nochim2)))


### PR DESCRIPTION
Fixed sorting in dada2_chimrem.r. This resolves issue #187. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
