### PR TITLE
Fixed so that cutadapt actually runs twice when --double_primer is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#187](https://github.com/nf-core/ampliseq/issues/187) - Sample ids are in incorrect order in feature-table from PacBio data
 * [#190](https://github.com/nf-core/ampliseq/pull/190) - Template update for nf-core/tools version 1.12
 * [#147](https://github.com/nf-core/ampliseq/issues/147) - Split `make_classifier` in two different processes that can be allocated different resources
-* [#197](https://github.com/nf-core/ampliseq/issues/197) - "--double_primer" does not run cutadapt twice
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#187](https://github.com/nf-core/ampliseq/issues/187) - Sample ids are in incorrect order in feature-table from PacBio data
 * [#190](https://github.com/nf-core/ampliseq/pull/190) - Template update for nf-core/tools version 1.12
 * [#147](https://github.com/nf-core/ampliseq/issues/147) - Split `make_classifier` in two different processes that can be allocated different resources
+* [#197](https://github.com/nf-core/ampliseq/issues/197) - "--double_primer" does not run cutadapt twice
 
 ### `Dependencies`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nfcore/base:1.12
+FROM nfcore/base:1.12.1
 LABEL authors="Daniel Straub, Alexander Peltzer" \
       description="Docker image containing all software requirements for the nf-core/ampliseq pipeline"
 

--- a/main.nf
+++ b/main.nf
@@ -499,7 +499,7 @@ if (!params.Q2imported){
 			in_files = single_end ? "${reads}" : "${reads[0]} ${reads[1]}"
 			"""
 			mkdir -p trimmed
-			if [[ $params.double_primer == TRUE && $discard_untrimmed == "--discard-untrimmed" ]]; then
+			if [[ ${params.double_primer} && !${params.retain_untrimmed} ]]; then
 	                        mkdir -p firstcutadapt
 				cutadapt ${primers} ${discard_untrimmed} \
 					${int_out_files} \
@@ -535,7 +535,7 @@ if (!params.Q2imported){
 			discard_untrimmed = params.retain_untrimmed ? '' : '--discard-untrimmed'
 			"""
 			mkdir -p trimmed
-			if [[ $params.double_primer == TRUE && $discard_untrimmed == "--discard-untrimmed" ]]; then
+			if [[ ${params.double_primer} && !${params.retain_untrimmed} ]]; then
 				mkdir -p firstcutadapt
 				cutadapt -g ${params.FW_primer} -G ${params.RV_primer} ${discard_untrimmed} \
 					-o firstcutadapt/$folder${params.split}${reads[0]} -p firstcutadapt/$folder${params.split}${reads[1]} \


### PR DESCRIPTION
<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
-->
Changed the if-statments in the trimming process so that if `--double_primer` is set and `--retain_untrimmed` is not set, cutadapt will be run twice on the input data. This resolves #197. I've tested the changes with `test_doubleprimers`, `test` and `test_multi` (the two latter by specifying `--double_primer`).

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/ampliseq branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/ampliseq)
