### PR TITLE
Remove species from assignTaxonomy fasta files (Unite & GTDB)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ testing*
 .*.sw?
 .Rproj.user
 .Rhistory
+.screenrc
+ampliseq.Rproj

--- a/bin/taxref_reformat_gtdb.sh
+++ b/bin/taxref_reformat_gtdb.sh
@@ -9,7 +9,7 @@ for f in *.tar.gz; do
   tar xzf $f
 done
 
-# Write the assignTaxonomy() fasta file: gtdb_assignTaxonomy.fna
+# Write the assignTaxonomy() fasta file: assignTaxonomy.fna
 cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) \([^[]\+\) \[.*/>\2(\1\)/' | sed '/^>/s/;s__.*//' | sed 's/[a-z]__//g' | sed 's/ /_/g' > assignTaxonomy.fna
 
 # Write the assignTaxonomy() fasta file: addSpecies.fna

--- a/bin/taxref_reformat_gtdb.sh
+++ b/bin/taxref_reformat_gtdb.sh
@@ -10,7 +10,7 @@ for f in *.tar.gz; do
 done
 
 # Write the assignTaxonomy() fasta file: gtdb_assignTaxonomy.fna
-sed '/^>/s/>\([^ ]\+\) \([^[]\+\) \[.*/>\2(\1\)/' ar122*.fna bac120*.fna | sed 's/[a-z]__//g' | sed 's/ /_/g' > assignTaxonomy.fna
+cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) \([^[]\+\) \[.*/>\2(\1\)/' | sed '/^>/s/;s__.*//' | sed 's/[a-z]__//g' | sed 's/ /_/g' > assignTaxonomy.fna
 
 # Write the assignTaxonomy() fasta file: addSpecies.fna
-sed '/^>/s/>\([^ ]\+\) .*;s__\([^[]\+\) \[.*/>\1 \2/' ar122*.fna bac120*.fna > addSpecies.fna
+cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) .*;s__\([^[]\+\) \[.*/>\1 \2/' > addSpecies.fna

--- a/bin/taxref_reformat_unite.sh
+++ b/bin/taxref_reformat_unite.sh
@@ -7,7 +7,7 @@
 tar xzf *.gz
 
 # Remove leading "k__" and the like and replace space with underscore to create assignTaxonomy.fna
-sed 's/[a-z]__//g' */*.fasta | sed 's/ /_/g' > assignTaxonomy.fna
+cat */*.fasta | sed 's/;s__.*//' | sed 's/[a-z]__//g' | sed 's/ /_/g' > assignTaxonomy.fna
 
-# Create a copy 
+# Reformat to addSpecies format
 sed 's/>\([^|]\+\)|\([^|]\+|[^|]\+\)|.*/>\2 \1/' assignTaxonomy.fna | sed 's/_/ /g' > addSpecies.fna


### PR DESCRIPTION
I've updated the Unite and GTDB reformatting scripts so they remove species information. I kept the general one for you @emnilsson, since you know that better.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
