### PR TITLE
Correcting faulty default settings

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -66,7 +66,7 @@ params {
             // standard setting can be inspected with getDadaOpt(option = NULL)
             args          = 'selfConsist = FALSE, priors = character(0), BAND_SIZE = 16, DETECT_SINGLETONS = FALSE, GAPLESS = TRUE, GAP_PENALTY = -8, GREEDY = TRUE, HOMOPOLYMER_GAP_PENALTY = NULL, KDIST_CUTOFF = 0.42, MATCH = 5, MAX_CLUST = 0, MAX_CONSIST = 10, MIN_ABUNDANCE = 1, MIN_FOLD = 1, MIN_HAMMING = 1, MISMATCH = -4, OMEGA_A = 1e-40, OMEGA_C = 1e-40, OMEGA_P = 1e-4, PSEUDO_ABUNDANCE = Inf, PSEUDO_PREVALENCE = 2, SSE = 2, USE_KMERS = TRUE, USE_QUALS = TRUE, VECTORIZED_ALIGNMENT = TRUE'
             // setting from https://rdrr.io/bioc/dada2/man/mergePairs.html & https://rdrr.io/bioc/dada2/man/nwalign.html & match = getDadaOpt("MATCH"), mismatch = getDadaOpt("MISMATCH"), gap = getDadaOpt("GAP_PENALTY"), missing from the list below is: 'band = -1'
-            args2         = 'minOverlap = 12, maxMismatch = 0, returnRejects = FALSE, propagateCol = character(0), trimOverhang = FALSE, match = 5, mismatch = -4, gap = -8, homo_gap = NULL, endsfree = TRUE, vec = FALSE'
+            args2         = 'minOverlap = 12, maxMismatch = 0, returnRejects = FALSE, propagateCol = character(0), trimOverhang = FALSE, match = 1, mismatch = -64, gap = -64, homo_gap = NULL, endsfree = TRUE, vec = FALSE'
             publish_files = ['.args.txt':'args','log':'log']
         }
         'dada2_rmchimera' {

--- a/modules/local/dada2_denoising.nf
+++ b/modules/local/dada2_denoising.nf
@@ -26,7 +26,7 @@ process DADA2_DENOISING {
     tuple val(meta), path("*.dada.rds")   , emit: denoised
     tuple val(meta), path("*.seqtab.rds") , emit: seqtab
     tuple val(meta), path("*.mergers.rds"), emit: mergers
-    tuple val(meta), path("*.dada.log")   , emit: log
+    tuple val(meta), path("*.log")        , emit: log
     path "*.version.txt"                  , emit: version
     path "*.args.txt"                     , emit: args
 


### PR DESCRIPTION
While working on a special request (somebody had a bad experimental design, the amplicon was longer than anticipated and therefore read pairs were overlapping only 9 bp instead of DADA2's minimum standard setting of 12bp), I found that the standard settings in `modules.config` for `mergePairs` is wrong. This actually did not impact normal use cases but does impact those edge cases when supplying a custom `modules.config` with modified `minOverlap` for `mergePairs` as I did (in short: it did not work). Here I correct that values.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
