### PR TITLE
DADA2 confidence

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -80,7 +80,7 @@ params {
             publish_files = null
         }
         'dada2_taxonomy' {
-            args          = 'minBoot = 50, outputBootstraps = FALSE, taxLevels = c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
+            args          = 'minBoot = 50, taxLevels = c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
             publish_files = ['.args.txt':'args','tsv':'']
         }
         'dada2_addspecies' {

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -12,7 +12,7 @@ params {
       fmtscript = "taxref_reformat_gtdb.sh"
     }
     'gtdb' {
-      file = [ "https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/bac120_ssu_reps.tar.gz", "https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/ar122_ssu_reps.tar.gz" ]
+      file = [ "https://data.gtdb.ecogenomic.org/releases/latest/genomic_files_reps/bac120_ssu_reps.tar.gz", "https://data.gtdb.ecogenomic.org/releases/latest/genomic_files_reps/ar122_ssu_reps.tar.gz" ]
       fmtscript = "taxref_reformat_gtdb.sh"
     }
     'pr2=4.13.0' {

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -36,20 +36,20 @@ process DADA2_ADDSPECIES {
     set.seed(100) # Initialize random number generator for reproducibility
 
     taxtable <- readRDS(\"$taxtable\")
-    t <- addSpecies(taxtable, \"$database\", $options.args, verbose=TRUE)
+    tx <- addSpecies(taxtable, \"$database\", $options.args, verbose=TRUE)
 
     # Create a table with specified column order
     taxa <- data.frame(
-        ASV_ID = t\$ASV_ID,
-        Kingdom = t\$Kingdom,
-        Phylum = t\$Phylum,
-        Class = t\$Class,
-        Order = t\$Order,
-        Family = t\$Family,
-        Genus = t\$Genus,
-        Species = t\$Species,
-        confidence = t\$confidence,
-        sequence = rownames(t)
+        ASV_ID = tx\$ASV_ID,
+        Kingdom = tx\$Kingdom,
+        Phylum = tx\$Phylum,
+        Class = tx\$Class,
+        Order = tx\$Order,
+        Family = tx\$Family,
+        Genus = tx\$Genus,
+        Species = tx\$Species,
+        confidence = tx\$confidence,
+        sequence = rownames(tx)
     )
 
     write.table(taxa, file = "ASV_tax_species.tsv", sep = "\t", row.names = FALSE, col.names = TRUE, quote = FALSE)

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -36,9 +36,22 @@ process DADA2_ADDSPECIES {
     set.seed(100) # Initialize random number generator for reproducibility
 
     taxtable <- readRDS(\"$taxtable\")
-    taxa <- addSpecies(taxtable, \"$database\", $options.args, verbose=TRUE)
-    # Put the sequence last
-    taxa <- taxa[,c(colnames(taxa)[!colnames(taxa) %in% 'sequence'], 'sequence')]
+    t <- addSpecies(taxtable, \"$database\", $options.args, verbose=TRUE)
+
+    # Create a table with specified column order
+    taxa <- data.frame(
+        ASV_ID = t\$ASV_ID,
+        Kingdom = t\$Kingdom,
+        Phylum = t\$Phylum,
+        Class = t\$Class,
+        Order = t\$Order,
+        Family = t\$Family,
+        Genus = t\$Genus,
+        Species = t\$Species,
+        confidence = t\$confidence,
+        sequence = rownames(t)
+    )
+
     write.table(taxa, file = "ASV_tax_species.tsv", sep = "\t", row.names = FALSE, col.names = TRUE, quote = FALSE)
 
     write.table('addSpecies\t$options.args', file = "addSpecies.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE)

--- a/modules/local/dada2_merge.nf
+++ b/modules/local/dada2_merge.nf
@@ -72,9 +72,7 @@ process DADA2_MERGE {
 
     # Write ASV file with ASV abundances to file
     df\$sequence <- NULL
-    rownames(df) <- df\$ASV_ID
-    df\$ASV_ID <- NULL
-    write.table(df, file = "ASV_table.tsv", sep="\t", row.names = TRUE, col.names = NA, quote = FALSE)
+    write.table(df, file = "ASV_table.tsv", sep="\t", row.names = FALSE, quote = FALSE)
 
     write.table(packageVersion("dada2"), file = "${software}.version.txt", row.names = FALSE, col.names = FALSE, quote = FALSE)
     """

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -39,9 +39,9 @@ process DADA2_TAXONOMY {
     taxa <- assignTaxonomy(seq, \"$database\", $options.args, multithread = $task.cpus, verbose=TRUE, outputBootstraps = TRUE)
 
     # Make a data frame, add ASV_ID from seq, set confidence to the bootstrap for the most specific taxon and reorder columns before writing to file
-    t <- data.frame(taxa)
-    t\$ASV_ID <- names(seq)
-    t\$confidence <- with(t, 
+    tx <- data.frame(taxa)
+    tx\$ASV_ID <- names(seq)
+    tx\$confidence <- with(tx, 
         ifelse(!is.na(tax.Genus), boot.Genus, 
             ifelse(!is.na(tax.Family), boot.Family,
                 ifelse(!is.na(tax.Order), boot.Order,
@@ -55,15 +55,15 @@ process DADA2_TAXONOMY {
         )
     )/100
     taxa <- data.frame(
-        ASV_ID = t\$ASV_ID,
-        Kingdom = t\$tax.Kingdom,
-        Phylum = t\$tax.Phylum,
-        Class = t\$tax.Class,
-        Order = t\$tax.Order,
-        Family = t\$tax.Family,
-        Genus = t\$tax.Genus,
-        confidence = t\$confidence,
-        sequence = rownames(t)
+        ASV_ID = tx\$ASV_ID,
+        Kingdom = tx\$tax.Kingdom,
+        Phylum = tx\$tax.Phylum,
+        Class = tx\$tax.Class,
+        Order = tx\$tax.Order,
+        Family = tx\$tax.Family,
+        Genus = tx\$tax.Genus,
+        confidence = tx\$confidence,
+        sequence = rownames(tx)
     )
     write.table(taxa, file = "ASV_tax.tsv", sep = "\t", row.names = FALSE, col.names = TRUE, quote = FALSE)
 

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -36,15 +36,41 @@ process DADA2_TAXONOMY {
     set.seed(100) # Initialize random number generator for reproducibility
 
     seq <- getSequences(\"$fasta\", collapse = TRUE, silence = FALSE)
-    taxa <- assignTaxonomy(seq, \"$database\", $options.args, multithread = $task.cpus, verbose=TRUE)
+    taxa <- assignTaxonomy(seq, \"$database\", $options.args, multithread = $task.cpus, verbose=TRUE, outputBootstraps = TRUE)
 
-    # Make a data frame, add ASV_ID from seq and put that first before writing to file
-    taxa <- data.frame(taxa)
-    taxa\$ASV_ID <- names(seq)
-    taxa <- taxa[, c(ncol(taxa), 2:ncol(taxa)-1)]
-    taxa\$sequence <- rownames(taxa)
-    saveRDS(taxa, "ASV_tax.rds")
+    # Make a data frame, add ASV_ID from seq, set confidence to the bootstrap for the most specific taxon and reorder columns before writing to file
+    t <- data.frame(taxa)
+    t\$ASV_ID <- names(seq)
+    t\$confidence <- with(t, 
+        ifelse(!is.na(tax.Genus), boot.Genus, 
+            ifelse(!is.na(tax.Family), boot.Family,
+                ifelse(!is.na(tax.Order), boot.Order,
+                    ifelse(!is.na(tax.Class), boot.Class,
+                        ifelse(!is.na(tax.Phylum), boot.Phylum,
+                            ifelse(!is.na(tax.Kingdom), boot.Kingdom, 0)
+                        )
+                    )
+                )
+            )
+        )
+    )/100
+    taxa <- data.frame(
+        ASV_ID = t\$ASV_ID,
+        Kingdom = t\$tax.Kingdom,
+        Phylum = t\$tax.Phylum,
+        Class = t\$tax.Class,
+        Order = t\$tax.Order,
+        Family = t\$tax.Family,
+        Genus = t\$tax.Genus,
+        confidence = t\$confidence,
+        sequence = rownames(t)
+    )
     write.table(taxa, file = "ASV_tax.tsv", sep = "\t", row.names = FALSE, col.names = TRUE, quote = FALSE)
+
+    # Save a version with rownames for addSpecies
+    rownames(taxa) <- taxa\$sequence
+    taxa\$sequence <- NULL
+    saveRDS(taxa, "ASV_tax.rds")
 
     write.table('assignTaxonomy\t$options.args', file = "assignTaxonomy.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE)
     write.table(packageVersion("dada2"), file = "${software}.version.txt", row.names = FALSE, col.names = FALSE, quote = FALSE)


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

I made a couple of updates that are somehow related:

1. Made sure ASV_ID is a header and not a "rowname" (issue #263)
2. Updated the GTDB links to the official site since the alternative was down. (@emnilsson never got these to download, but I don't have any problems.)
3. Added `confidence` to `ASV_tax.tsv` and `ASV_tax_species.tsv` (issue #243). (I chose to use the name `confidence` because that's what it was called in the 1.n series, i.e. QIIME2-based, even though bootstrap is more explanatory.)