### PR TITLE
Set minimum length of cutadapt output reads to 1

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -27,16 +27,16 @@ params {
             publish_dir   = "multiqc"
         }
         'cutadapt' {
-            args          = ""
+            args          = "--minimum-length 1"
             publish_files = ['log':'']
         }
         'cutadapt_readthrough' {
-            args          = ""
+            args          = "--minimum-length 1"
             suffix   = ".read-through"
             publish_files = ['log':'']
         }
         'cutadapt_doubleprimer' {
-            args          = "--discard-trimmed"
+            args          = "--discard-trimmed --minimum-length 1"
             suffix        = ".double-primer"
             publish_files = ['log':'']
         }

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -153,13 +153,13 @@ include { GET_SOFTWARE_VERSIONS         } from '../modules/local/get_software_ve
 
 if (params.pacbio) {
 	//PacBio data
-	cutadapt_options_args       = " --rc -g ${params.FW_primer}...${params.RV_primer}"
+	cutadapt_options_args       = " --rc -g ${params.FW_primer}...${params.RV_primer} --minimum-length 1"
 } else if (params.single_end) {
 	//Illumina SE
-	cutadapt_options_args       = " -g ${params.FW_primer}"
+	cutadapt_options_args       = " -g ${params.FW_primer} --minimum-length 1"
 } else {
 	//Illumina PE
-	cutadapt_options_args       = " -g ${params.FW_primer} -G ${params.RV_primer}"
+	cutadapt_options_args       = " -g ${params.FW_primer} -G ${params.RV_primer} --minimum-length 1"
 }
 
 def cutadapt_options 			= modules['cutadapt']

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -153,13 +153,13 @@ include { GET_SOFTWARE_VERSIONS         } from '../modules/local/get_software_ve
 
 if (params.pacbio) {
 	//PacBio data
-	cutadapt_options_args       = " --rc -g ${params.FW_primer}...${params.RV_primer} --minimum-length 1"
+	cutadapt_options_args       = " --rc -g ${params.FW_primer}...${params.RV_primer}"
 } else if (params.single_end) {
 	//Illumina SE
-	cutadapt_options_args       = " -g ${params.FW_primer} --minimum-length 1"
+	cutadapt_options_args       = " -g ${params.FW_primer}"
 } else {
 	//Illumina PE
-	cutadapt_options_args       = " -g ${params.FW_primer} -G ${params.RV_primer} --minimum-length 1"
+	cutadapt_options_args       = " -g ${params.FW_primer} -G ${params.RV_primer}"
 }
 
 def cutadapt_options 			= modules['cutadapt']


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

This solves the issue with DADA2 quality profiling sometimes failing. It happened on reads with a length of 0.
