### PR TITLE
add --qiime_ref_taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,47 +9,47 @@ Re-wrote whole pipeline in nextflow [DSL2](https://www.nextflow.io/docs/latest/d
 
 ### `Added`
 
-* [#229](https://github.com/nf-core/mag/pull/229) - `--single_end` for single-ended Illumina data
-* [#229](https://github.com/nf-core/mag/pull/229), [#245](https://github.com/nf-core/mag/pull/245), [#267](https://github.com/nf-core/mag/pull/267)  - Taxonomic classification with DADA2
-* [#229](https://github.com/nf-core/mag/pull/229) - `--dada_ref_taxonomy` for taxonomic classification with DADA2's assignTaxonomy and addSpecies functions
-* [#278](https://github.com/nf-core/mag/pull/278) - `--qiime_ref_taxonomy` for taxonomic classification with QIIME2
-* [#239](https://github.com/nf-core/mag/pull/239) - Support of RDP database for DADA2 classification
-* [#237](https://github.com/nf-core/mag/pull/237) - Support of UNITE database for DADA2 classification
-* [#229](https://github.com/nf-core/mag/pull/229) - `--input` may point (1) at a fasta file ending with `.fasta`/`.fna`/`.fa` that will be taxonomically classified, (2) at a samples sheet ending with `.tsv` that allows analysis of multiple sequencing runs by reading the optional column `run`, or (3) at a folder input
-* [#229](https://github.com/nf-core/mag/pull/229) - `--sample_inference`, `--concatenate_reads`, `--illumina_pe_its`; please check the documentation for their function
-* [#275](https://github.com/nf-core/mag/pull/275) - Read count summary
-* [#274](https://github.com/nf-core/mag/pull/274) - `--skip_qiime` to prevent any steps that are executed with QIIME2
-* [#272](https://github.com/nf-core/mag/pull/272) - `--cut_its` to cut ASV sequence to ITS region before performing taxonomic classification with DADA2
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--single_end` for single-ended Illumina data
+* [#229](https://github.com/nf-core/ampliseq/pull/229), [#245](https://github.com/nf-core/ampliseq/pull/245), [#267](https://github.com/nf-core/ampliseq/pull/267)  - Taxonomic classification with DADA2
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--dada_ref_taxonomy` for taxonomic classification with DADA2's assignTaxonomy and addSpecies functions
+* [#278](https://github.com/nf-core/ampliseq/pull/278) - `--qiime_ref_taxonomy` for taxonomic classification with QIIME2
+* [#239](https://github.com/nf-core/ampliseq/pull/239) - Support of RDP database for DADA2 classification
+* [#237](https://github.com/nf-core/ampliseq/pull/237) - Support of UNITE database for DADA2 classification
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--input` may point (1) at a fasta file ending with `.fasta`/`.fna`/`.fa` that will be taxonomically classified, (2) at a samples sheet ending with `.tsv` that allows analysis of multiple sequencing runs by reading the optional column `run`, or (3) at a folder input
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--sample_inference`, `--concatenate_reads`, `--illumina_pe_its`; please check the documentation for their function
+* [#275](https://github.com/nf-core/ampliseq/pull/275) - Read count summary
+* [#274](https://github.com/nf-core/ampliseq/pull/274) - `--skip_qiime` to prevent any steps that are executed with QIIME2
+* [#272](https://github.com/nf-core/ampliseq/pull/272) - `--cut_its` to cut ASV sequence to ITS region before performing taxonomic classification with DADA2
 
 ### `Changed`
 
-* [#254](https://github.com/nf-core/mag/pull/254) - Updated CamelCase parameters to be lower_case_snake_case:
+* [#254](https://github.com/nf-core/ampliseq/pull/254) - Updated CamelCase parameters to be lower_case_snake_case:
   * `multipleSequencingRuns` to `multiple_sequencing_runs`
   * `minLen` to `min_len`
   * `maxLen` to `max_len`
   * `maxEE` to `max_ee`
-* [#277](https://github.com/nf-core/mag/pull/277) - Requires nextflow version `>= 21.04.0`
+* [#277](https://github.com/nf-core/ampliseq/pull/277) - Requires nextflow version `>= 21.04.0`
 
 ### `Fixed`
 
-* [#273](https://github.com/nf-core/mag/pull/273) - Template update for nf-core/tools version 1.14
+* [#273](https://github.com/nf-core/ampliseq/pull/273) - Template update for nf-core/tools version 1.14
 
 ### `Dependencies`
 
-* [#272](https://github.com/nf-core/mag/pull/272) - New dependency ITSx v1.1.3
-* [#229](https://github.com/nf-core/mag/pull/229) - Updated from cutadapt v2.8 to v3.2
-* [#229](https://github.com/nf-core/mag/pull/229) - Updated DADA2 from v1.10 to v1.18.0, now not using QIIME2 for ASV generation any more
-* [#229](https://github.com/nf-core/mag/pull/229) - Updated QIIME2 to v2021.2
+* [#272](https://github.com/nf-core/ampliseq/pull/272) - New dependency ITSx v1.1.3
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - Updated from cutadapt v2.8 to v3.2
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - Updated DADA2 from v1.10 to v1.18.0, now not using QIIME2 for ASV generation any more
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - Updated QIIME2 to v2021.2
 
 ### `Removed`
 
-* [#229](https://github.com/nf-core/mag/pull/229) - `--manifest` is superseeded by `--input` that can now also handle a sample sheet file input (required extension: `.tsv`)
-* [#229](https://github.com/nf-core/mag/pull/229) - `--Q2imported` and `untilQ2import` are removed because pausing at that point is not neccessary
-* [#229](https://github.com/nf-core/mag/pull/229) - `--split` is no longer supported, therefore all sample IDs have to be unique
-* [#229](https://github.com/nf-core/mag/pull/229) - `--classifier_removeHash` and `--qiime_timezone` became unnecessary
-* [#229](https://github.com/nf-core/mag/pull/229) - `--onlyDenoising` is deprecated in favour of `--skip_taxonomy` (which does the exact same thing)
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--manifest` is superseeded by `--input` that can now also handle a sample sheet file input (required extension: `.tsv`)
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--Q2imported` and `untilQ2import` are removed because pausing at that point is not neccessary
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--split` is no longer supported, therefore all sample IDs have to be unique
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--classifier_removeHash` and `--qiime_timezone` became unnecessary
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--onlyDenoising` is deprecated in favour of `--skip_taxonomy` (which does the exact same thing)
 * `--taxon_reference` became unnecessary
-* [#229](https://github.com/nf-core/mag/pull/229) - `--reference_database` and `--dereplication` are currently not supported any more. `--qiime_ref_taxonomy` allows now choosing a taxonomic reference
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--reference_database` and `--dereplication` are currently not supported any more. `--qiime_ref_taxonomy` allows now choosing a taxonomic reference
 
 ## nf-core/ampliseq version 1.2.0 "Teal Bronze Lion" - 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Re-wrote whole pipeline in nextflow [DSL2](https://www.nextflow.io/docs/latest/d
 * [#229](https://github.com/nf-core/ampliseq/pull/229) - `--classifier_removeHash` and `--qiime_timezone` became unnecessary
 * [#229](https://github.com/nf-core/ampliseq/pull/229) - `--onlyDenoising` is deprecated in favour of `--skip_taxonomy` (which does the exact same thing)
 * `--taxon_reference` became unnecessary
-* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--reference_database` and `--dereplication` are currently not supported any more. `--qiime_ref_taxonomy` allows now choosing a taxonomic reference
+* [#229](https://github.com/nf-core/ampliseq/pull/229) - `--reference_database` and `--dereplication` are not supported any more. `--qiime_ref_taxonomy` allows now choosing a taxonomic reference
 
 ## nf-core/ampliseq version 1.2.0 "Teal Bronze Lion" - 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Re-wrote whole pipeline in nextflow [DSL2](https://www.nextflow.io/docs/latest/d
 * [#229](https://github.com/nf-core/mag/pull/229) - `--single_end` for single-ended Illumina data
 * [#229](https://github.com/nf-core/mag/pull/229), [#245](https://github.com/nf-core/mag/pull/245), [#267](https://github.com/nf-core/mag/pull/267)  - Taxonomic classification with DADA2
 * [#229](https://github.com/nf-core/mag/pull/229) - `--dada_ref_taxonomy` for taxonomic classification with DADA2's assignTaxonomy and addSpecies functions
+* [#278](https://github.com/nf-core/mag/pull/278) - `--qiime_ref_taxonomy` for taxonomic classification with QIIME2
 * [#239](https://github.com/nf-core/mag/pull/239) - Support of RDP database for DADA2 classification
 * [#237](https://github.com/nf-core/mag/pull/237) - Support of UNITE database for DADA2 classification
 * [#229](https://github.com/nf-core/mag/pull/229) - `--input` may point (1) at a fasta file ending with `.fasta`/`.fna`/`.fa` that will be taxonomically classified, (2) at a samples sheet ending with `.tsv` that allows analysis of multiple sequencing runs by reading the optional column `run`, or (3) at a folder input
@@ -48,7 +49,7 @@ Re-wrote whole pipeline in nextflow [DSL2](https://www.nextflow.io/docs/latest/d
 * [#229](https://github.com/nf-core/mag/pull/229) - `--classifier_removeHash` and `--qiime_timezone` became unnecessary
 * [#229](https://github.com/nf-core/mag/pull/229) - `--onlyDenoising` is deprecated in favour of `--skip_taxonomy` (which does the exact same thing)
 * `--taxon_reference` became unnecessary
-* `--reference_database`, `--dereplication` are currently not supported as they are QIIME2 specific. Either a more general solution will be supported soon or QIIME2 classification will be removed.
+* [#229](https://github.com/nf-core/mag/pull/229) - `--reference_database` and `--dereplication` are currently not supported any more. `--qiime_ref_taxonomy` allows now choosing a taxonomic reference
 
 ## nf-core/ampliseq version 1.2.0 "Teal Bronze Lion" - 2021
 

--- a/bin/taxref_reformat_qiime_greengenes85.sh
+++ b/bin/taxref_reformat_qiime_greengenes85.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Select and rename files
+mv *.fasta greengenes85.fna
+mv *.txt greengenes85.tax

--- a/bin/taxref_reformat_qiime_silva138.sh
+++ b/bin/taxref_reformat_qiime_silva138.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Unzip the qza files
+unzip *seqs.qza
+unzip *tax.qza
+
+# Select and rename dynamic files
+cat */data/taxonomy.tsv > silva.tax
+cat */data/*sequences.fasta > silva.fna

--- a/bin/taxref_reformat_qiime_unite.sh
+++ b/bin/taxref_reformat_qiime_unite.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Untar the Unite file
+tar xzf *.gz
+
+# Select and rename dynamic files
+cat */*_dynamic_*.fasta > unite.fna
+cat */*_dynamic_*.txt > unite.tax

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -6,7 +6,7 @@
  */
 
 params {
-  genomes {
+  dada_ref_databases {
     'gtdb=05-RS95' {
       file = [ "https://data.ace.uq.edu.au/public/gtdb/data/releases/release95/95.0/genomic_files_reps/bac120_ssu_reps_r95.tar.gz", "https://data.ace.uq.edu.au/public/gtdb/data/releases/release95/95.0/genomic_files_reps/ar122_ssu_reps_r95.tar.gz" ]
       fmtscript = "taxref_reformat_gtdb.sh"
@@ -58,6 +58,48 @@ params {
     'unite-alleuk' {
       file = [ "https://files.plutof.ut.ee/public/orig/F9/ED/F9EDE36E5209F469056675EBD672425BC06EACB7FE0C0D18F5A13E4CA632DCFA.gz" ]
       fmtscript = "taxref_reformat_unite.sh"
+    }
+  }
+  //QIIME2 taxonomic reference databases
+  qiime_ref_databases {
+    //SILVA for QIIME2 v2021.2, see https://docs.qiime2.org/2021.2/data-resources/#silva-16s-18s-rrna
+    'silva=138' {
+      file = [ "https://data.qiime2.org/2021.2/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2021.2/common/silva-138-99-tax.qza" ]
+      citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
+      license = "https://www.arb-silva.de/silva-license-information/"
+      fmtscript = "taxref_reformat_qiime_silva138.sh"
+    }
+    'silva' {
+      file = [ "https://data.qiime2.org/2021.2/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2021.2/common/silva-138-99-tax.qza" ]
+      citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
+      license = "https://www.arb-silva.de/silva-license-information/"
+      fmtscript = "taxref_reformat_qiime_silva138.sh"
+    }
+    //UNITE for QIIME2, see https://unite.ut.ee/repository.php
+    'unite-fungi=8.2' {
+      file = [ "https://files.plutof.ut.ee/public/orig/98/AE/98AE96C6593FC9C52D1C46B96C2D9064291F4DBA625EF189FEC1CCAFCF4A1691.gz" ]
+      citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2020): UNITE QIIME release for Fungi. Version 04.02.2020. UNITE Community. https://doi.org/10.15156/BIO/786385"
+      fmtscript = "taxref_reformat_qiime_unite.sh"
+    }
+    'unite-fungi' {
+      file = [ "https://files.plutof.ut.ee/public/orig/98/AE/98AE96C6593FC9C52D1C46B96C2D9064291F4DBA625EF189FEC1CCAFCF4A1691.gz" ]
+      citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2020): UNITE QIIME release for Fungi. Version 04.02.2020. UNITE Community. https://doi.org/10.15156/BIO/786385"
+      fmtscript = "taxref_reformat_qiime_unite.sh"
+    }
+    'unite-alleuk=8.2' {
+      file = [ "https://files.plutof.ut.ee/public/orig/6E/0E/6E0EDD5592003B47C70A1B384C3C784AA32B726AC861CD7E2BD22AEB0278675E.gz" ]
+      citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2020): UNITE QIIME release for eukaryotes. Version 04.02.2020. UNITE Community. https://doi.org/10.15156/BIO/786386"
+      fmtscript = "taxref_reformat_qiime_unite.sh"
+    }
+    'unite-alleuk' {
+      file = [ "https://files.plutof.ut.ee/public/orig/6E/0E/6E0EDD5592003B47C70A1B384C3C784AA32B726AC861CD7E2BD22AEB0278675E.gz" ]
+      citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2020): UNITE QIIME release for eukaryotes. Version 04.02.2020. UNITE Community. https://doi.org/10.15156/BIO/786386"
+      fmtscript = "taxref_reformat_qiime_unite.sh"
+    }
+    'greengenes85' {
+      file = [ "https://data.qiime2.org/2021.2/tutorials/training-feature-classifiers/85_otus.fasta", "https://data.qiime2.org/2021.2/tutorials/training-feature-classifiers/85_otu_taxonomy.txt" ]
+      citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
+      fmtscript = "taxref_reformat_qiime_greengenes85.sh"
     }
   }
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -22,8 +22,7 @@ params {
   input = "https://github.com/nf-core/test-datasets/raw/ampliseq/samplesheets/Samplesheet.tsv"
   metadata = "https://github.com/nf-core/test-datasets/raw/ampliseq/samplesheets/Metadata.tsv"
   dada_ref_taxonomy = "rdp=18"
-  fasta_to_classifier = "https://data.qiime2.org/2021.2/tutorials/training-feature-classifiers/85_otus.fasta"
-  tax_to_classifier = "https://data.qiime2.org/2021.2/tutorials/training-feature-classifiers/85_otu_taxonomy.txt"
+  qiime_ref_taxonomy = "greengenes85"
 
   //this is to remove low abundance ASVs to reduce runtime of downstream processes 
   min_samples = 2

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -17,8 +17,7 @@ params {
   input = "https://github.com/nf-core/test-datasets/raw/ampliseq/samplesheets/Samplesheet_full.tsv"
   metadata = "https://github.com/nf-core/test-datasets/raw/ampliseq/samplesheets/Metadata_full.tsv"
   dada_ref_taxonomy = "rdp"
-  fasta_to_classifier = "https://data.qiime2.org/2021.2/tutorials/training-feature-classifiers/85_otus.fasta"
-  tax_to_classifier = "https://data.qiime2.org/2021.2/tutorials/training-feature-classifiers/85_otu_taxonomy.txt"
+  qiime_ref_taxonomy = "greengenes85"
   trunc_qmin = 35
 
   //this is to remove very low abundance and low prevalence ASVs to reduce runtime of downstream processes 

--- a/modules/local/format_taxonomy_qiime.nf
+++ b/modules/local/format_taxonomy_qiime.nf
@@ -1,4 +1,4 @@
-process FORMAT_TAXONOMY {
+process FORMAT_TAXONOMY_QIIME {
     label 'process_low'
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
@@ -12,11 +12,11 @@ process FORMAT_TAXONOMY {
     path(database)
     
     output:
-    path( "*assignTaxonomy.fna*" ), emit: assigntax
-    path( "*addSpecies.fna*"), emit: addspecies
+    path( "*.tax" ), emit: tax
+    path( "*.fna" ), emit: fasta
 
     script:
     """
-    ${params.dada_ref_databases[params.dada_ref_taxonomy]["fmtscript"]}
+    ${params.qiime_ref_databases[params.qiime_ref_taxonomy]["fmtscript"]}
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,9 +52,7 @@ params {
 
   //Database specific parameters
   dada_ref_taxonomy = "silva=138"
-  // TODO Expected to be overwritten by taxonomic database changes, this is for QIIME2 only. DADA2 taxonomic classification uses "conf/ref_databases.config"
-  tax_to_classifier = ""
-  fasta_to_classifier = ""
+  qiime_ref_taxonomy = ""
 
   // Boilerplate options
   outdir            = './results'
@@ -78,7 +76,7 @@ params {
   singularity_pull_docker_container = false
   validate_params   = true
   show_hidden_params = false
-  schema_ignore_params = 'genomes,modules'
+  schema_ignore_params = 'dada_ref_databases,qiime_ref_databases,modules'
 
   // Defaults only, expecting to be overwritten
   max_memory        = 128.GB

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -195,21 +195,15 @@
                     "description": "Name of database, and optionally also version number, that are supported, see conf/ref_databases.config",
                     "default": "silva=138"
                 },
+                "qiime_ref_taxonomy": {
+                    "type": "string",
+                    "help_text": "Choose any of the databases that are supported, see conf/ref_databases.config, and optionally also specify the version. This will download the desired database.",
+                    "description": "Name of database, and optionally also version number, that are supported, see conf/ref_databases.config.\nIf both, `--dada_ref_taxonomy` and `--qiime_ref_taxonomy` are used, DADA2 classification will be used for downstream analysis."
+                },
                 "classifier": {
                     "type": "string",
                     "description": "Path to QIIME2 trained classifier file (typically *-classifier.qza)",
-                    "help_text": "If you have trained a compatible classifier before, from sources such as SILVA (https://www.arb-silva.de/), Greengenes (http://greengenes.secondgenome.com/downloads) or RDP (https://rdp.cme.msu.edu/). \n\nFor example:\n\n```bash\n--classifier \"FW_primer-RV_primer-classifier.qza\"\n```\n\nPlease note the following requirements:\n\n1. The path must be enclosed in quotes\n2. The classifier is a Naive Bayes classifier produced by \"qiime feature-classifier fit-classifier-naive-bayes\" (e.g. by this pipeline or from (https://docs.qiime2.org/2019.10/data-resources/))\n3. The primer pair for the amplicon PCR and the computing of the classifier are exactly the same (or fulllength, potentially lower performance)\n4. The classifier has to be trained by the same version of scikit-learn as this version of the pipeline uses (0.21.2)",
-                    "hidden": true
-                },
-                "tax_to_classifier": {
-                    "type": "string",
-                    "description": "Path to file with taxonomies for taxonomic classification with QIIME2",
-                    "hidden": true
-                },
-                "fasta_to_classifier": {
-                    "type": "string",
-                    "description": "Path to file with sequences in fasta format for taxonomic classification with QIIME2",
-                    "hidden": true
+                    "help_text": "If you have trained a compatible classifier before, from sources such as SILVA (https://www.arb-silva.de/), Greengenes (http://greengenes.secondgenome.com/downloads) or RDP (https://rdp.cme.msu.edu/). \n\nFor example:\n\n```bash\n--classifier \"FW_primer-RV_primer-classifier.qza\"\n```\n\nPlease note the following requirements:\n\n1. The path must be enclosed in quotes\n2. The classifier is a Naive Bayes classifier produced by `qiime feature-classifier fit-classifier-naive-bayes` (e.g. by this pipeline)\n3. The primer pair for the amplicon PCR and the computing of the classifier are exactly the same (or full-length, potentially lower performance)\n4. The classifier has to be trained by the same version of scikit-learn as this version of the pipeline uses"
                 }
             },
             "fa_icon": "fas fa-database"

--- a/subworkflows/local/qiime2_preptax.nf
+++ b/subworkflows/local/qiime2_preptax.nf
@@ -4,19 +4,20 @@
 
 params.options = [:]
 
-include { QIIME2_EXTRACT } from '../../modules/local/qiime2_extract' addParams( options: params.options )
-include { QIIME2_TRAIN   } from '../../modules/local/qiime2_train'   addParams( options: params.options )
+include { FORMAT_TAXONOMY_QIIME } from '../../modules/local/format_taxonomy_qiime'
+include { QIIME2_EXTRACT        } from '../../modules/local/qiime2_extract' addParams( options: params.options )
+include { QIIME2_TRAIN          } from '../../modules/local/qiime2_train'   addParams( options: params.options )
 
 workflow QIIME2_PREPTAX {
     take:
-	ch_fasta_to_classifier //channel path
-	ch_tax_to_classifier //channel path
+	ch_dada_ref_taxonomy //channel, list of files
 	FW_primer //val
 	RV_primer //val
     
     main:
-	ch_ref_database = ch_fasta_to_classifier.combine(ch_tax_to_classifier)
+	FORMAT_TAXONOMY_QIIME ( ch_dada_ref_taxonomy )
 
+	ch_ref_database = FORMAT_TAXONOMY_QIIME.out.fasta.combine(FORMAT_TAXONOMY_QIIME.out.tax)
 	ch_ref_database
 		.map {
 			db ->

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -416,7 +416,7 @@ workflow AMPLISEQ {
 		} else if ( params.dada_ref_taxonomy ) {
 			log.info "Use DADA2 taxonomy classification"
 			ch_tax = QIIME2_INTAX ( ch_dada2_tax ).qza
-		} else if ( qiime_ref_taxonomy || params.classifier ) {
+		} else if ( params.qiime_ref_taxonomy || params.classifier ) {
 			log.info "Use QIIME2 taxonomy classification"
 			ch_tax = QIIME2_TAXONOMY.out.qza
 		} else { 


### PR DESCRIPTION
This is supposed to solve #261 
I added a parameter `--qiime_ref_taxonomy` alongside `--dada_ref_taxonomy` which works essentially identical.
Currently, I added `silva`, `unite-fungi`, `unite-alleuk`, and for quick runs `greengenes85`. Default is not using QIIME2 classification. Test profile includes `greengenes85`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
