### PR TITLE
PR2 and Ancom fix

### DIFF
--- a/bin/taxref_reformat_gtdb.sh
+++ b/bin/taxref_reformat_gtdb.sh
@@ -12,5 +12,5 @@ done
 # Write the assignTaxonomy() fasta file: assignTaxonomy.fna
 cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) \([^[]\+\) \[.*/>\2(\1\)/' | sed '/^>/s/;s__.*//' | sed 's/[a-z]__//g' | sed 's/ /_/g' > assignTaxonomy.fna
 
-# Write the assignTaxonomy() fasta file: addSpecies.fna
+# Write the addSpecies() fasta file: addSpecies.fna
 cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) .*;s__\([^[]\+\) \[.*/>\1 \2/' > addSpecies.fna

--- a/bin/taxref_reformat_gtdb.sh
+++ b/bin/taxref_reformat_gtdb.sh
@@ -10,7 +10,7 @@ for f in *.tar.gz; do
 done
 
 # Write the assignTaxonomy() fasta file: assignTaxonomy.fna
-cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) \([^[]\+\) \[.*/>\2(\1\)/' | sed '/^>/s/;s__.*//' | sed 's/[a-z]__//g' | sed 's/ /_/g' > assignTaxonomy.fna
+cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) \([^[]\+\) \[.*/>\2(\1\)/' | sed '/^>/s/;s__.*//' | sed 's/[a-z]__//g' | sed 's/ /_/g' | sed '/^>/s/\(Archaea\)\|\(Bacteria\)/&;&/' > assignTaxonomy.fna
 
 # Write the addSpecies() fasta file: addSpecies.fna
 cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) .*;s__\([^[]\+\) \[.*/>\1 \2/' > addSpecies.fna

--- a/bin/taxref_reformat_pr2.sh
+++ b/bin/taxref_reformat_pr2.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Handles the PR2 database.
+
+# There's a preformatted DADA2 file for assignTaxonomy() -- this is just ungzipped
+gunzip -c *dada2.fasta.gz > assignTaxonomy.fna
+
+# For addSpecies(), the UTAX file is downloaded and reformated to only contain the id and species.
+# The second two sed calls are to replace "_" with space only in the species name and not the last part of the id (overdoing it a bit, as I don't the id actually matters as long as it's unique).
+gunzip -c *UTAX.fasta.gz | sed '/^>/s/>\([^;]*\);.*,s:\(.*\)/>\1 \2/' | sed 's/_/ /g' | sed 's/ \([A-Z]\) /_\1 /' > addSpecies.fna

--- a/bin/taxref_reformat_unite.sh
+++ b/bin/taxref_reformat_unite.sh
@@ -8,7 +8,7 @@ tar xzf *.gz
 
 # Remove leading "k__" and the like, remove ranks classified as "unknown",
 # and replace space with underscore to create assignTaxonomy.fna
-cat */*.fasta | sed '/^>/s/;[ks]__.*//' | sed '/^>/s/[a-z]__unidentified//g' | sed '/^>/s/[a-z]__//g' | sed '/^>/s/ /_/g' > assignTaxonomy.fna
+cat */*.fasta | sed '/^>/s/;[ks]__.*//' | sed '/^>/s/[a-z]__unidentified//g' | sed '/^>/s/[a-z]__//g' | sed '/^>/s/ /_/g' | sed 's/>.*|/&Eukaryota;/' > assignTaxonomy.fna
 
 # Reformat to addSpecies format
 sed 's/>\([^|]\+\)|\([^|]\+|[^|]\+\)|.*/>\2 \1/' assignTaxonomy.fna | sed '/^>/s/_/ /g' > addSpecies.fna

--- a/bin/taxref_standard.sh
+++ b/bin/taxref_standard.sh
@@ -4,5 +4,5 @@
 # The file for taxonomy assignment, identified by containing "train" in the name,
 # and the file for add species, identified by containing "species" in the name, are renamed 
 
-mv *train*gz assignTaxonomy.fna.gz
+gunzip -c *train*gz | sed 's/>\([^;]*\)/>\1;\1;/' > assignTaxonomy.fna
 mv *species*gz addSpecies.fna.gz

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -87,7 +87,7 @@ params {
             args = '-t all --preserve T --date F --positions F --graphical F --save_regions none'
 	}
         'dada2_taxonomy' {
-            args          = 'minBoot = 50, taxLevels = c("Domain", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
+            args          = 'minBoot = 50'
             publish_files = ['.args.txt':'args','tsv':'']
         }
         'dada2_addspecies' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -87,7 +87,7 @@ params {
             args = '-t all --preserve T --date F --positions F --graphical F --save_regions none'
 	}
         'dada2_taxonomy' {
-            args          = 'minBoot = 50, taxLevels = c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
+            args          = 'minBoot = 50, taxLevels = c("Domain", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
             publish_files = ['.args.txt':'args','tsv':'']
         }
         'dada2_addspecies' {

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -16,11 +16,11 @@ params {
       fmtscript = "taxref_reformat_gtdb.sh"
     }
     'pr2=4.13.0' {
-      file = [ "https://github.com/pr2database/pr2database/releases/download/v4.13.0/pr2_version_4.13.0_16S_dada2.fasta.gz" ]
+      file = [ "https://github.com/pr2database/pr2database/releases/download/v4.13.0/pr2_version_4.13.0_18S_dada2.fasta.gz", "https://github.com/pr2database/pr2database/releases/download/v4.13.0/pr2_version_4.13.0_18S_UTAX.fasta.gz" ]
       fmtscript = "taxref_reformat_pr2.sh"
     }
     'pr2' {
-      file = [ "https://github.com/pr2database/pr2database/releases/download/v4.13.0/pr2_version_4.13.0_16S_dada2.fasta.gz" ]
+      file = [ "https://github.com/pr2database/pr2database/releases/download/v4.13.0/pr2_version_4.13.0_18S_dada2.fasta.gz", "https://github.com/pr2database/pr2database/releases/download/v4.13.0/pr2_version_4.13.0_18S_UTAX.fasta.gz" ]
       fmtscript = "taxref_reformat_pr2.sh"
     }
     'rdp=18' {

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -44,6 +44,7 @@ process DADA2_ADDSPECIES {
     tmp <- data.frame(row.names(tx)) # To separate ASV_ID from sequence
     taxa <- data.frame(
         ASV_ID = tx[,"ASV_ID"],
+        Domain = tx[,"Domain"],
         Kingdom = tx[,"Kingdom"],
         Phylum = tx[,"Phylum"],
         Class = tx[,"Class"],

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -47,7 +47,9 @@ process DADA2_TAXONOMY {
                 ifelse(!is.na(tax.Order), boot.Order,
                     ifelse(!is.na(tax.Class), boot.Class,
                         ifelse(!is.na(tax.Phylum), boot.Phylum,
-                            ifelse(!is.na(tax.Kingdom), boot.Kingdom, 0)
+                            ifelse(!is.na(tax.Kingdom), boot.Kingdom,
+                                ifelse(!is.na(tax.Domain), boot.Domain, 0)
+                            )
                         )
                     )
                 )
@@ -56,6 +58,7 @@ process DADA2_TAXONOMY {
     )/100
     taxa_export <- data.frame(
         ASV_ID = tx\$ASV_ID,
+        Domain = tx\$tax.Domain,
         Kingdom = tx\$tax.Kingdom,
         Phylum = tx\$tax.Phylum,
         Class = tx\$tax.Class,

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -37,7 +37,7 @@ process DADA2_TAXONOMY {
     set.seed(100) # Initialize random number generator for reproducibility
 
     seq <- getSequences(\"$fasta\", collapse = TRUE, silence = FALSE)
-    taxa <- assignTaxonomy(seq, \"$database\", $options.args, multithread = $task.cpus, verbose=TRUE, outputBootstraps = TRUE)
+    taxa <- assignTaxonomy(seq, \"$database\", taxLevels = c("Domain", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"), $options.args, multithread = $task.cpus, verbose=TRUE, outputBootstraps = TRUE)
 
     # Make a data frame, add ASV_ID from seq, set confidence to the bootstrap for the most specific taxon and reorder columns before writing to file
     tx <- data.frame(ASV_ID = names(seq), taxa, sequence = row.names(taxa\$tax), row.names = names(seq))

--- a/subworkflows/local/qiime2_ancom.nf
+++ b/subworkflows/local/qiime2_ancom.nf
@@ -29,7 +29,7 @@ workflow QIIME2_ANCOM {
         .combine( ch_taxlevel )
         .set{ ch_for_ancom_tax }
     QIIME2_ANCOM_TAX ( ch_for_ancom_tax )
-    QIIME2_ANCOM_TAX.out.ancom.subscribe { if ( it.baseName[0].toString().startsWith("WARNING") ) log.warn it.baseName[0].toString().replace("WARNING ","QIIME2_ANCOM_TAX: ").replace(" ancom_log", "") }
+    QIIME2_ANCOM_TAX.out.ancom.subscribe { if ( it.baseName[0].toString().startsWith("WARNING") ) log.warn it.baseName[0].toString().replace("WARNING ","QIIME2_ANCOM_TAX: ") }
 
     QIIME2_ANCOM_ASV ( ch_metadata.combine( QIIME2_FILTERASV.out.qza.flatten() ) )
 }

--- a/subworkflows/local/qiime2_ancom.nf
+++ b/subworkflows/local/qiime2_ancom.nf
@@ -13,7 +13,7 @@ include { QIIME2_ANCOM_ASV                 } from '../../modules/local/qiime2_an
 workflow QIIME2_ANCOM {
     take:
     ch_metadata
-	ch_asv
+    ch_asv
     ch_metacolumn_all
     ch_tax
     
@@ -29,6 +29,7 @@ workflow QIIME2_ANCOM {
         .combine( ch_taxlevel )
         .set{ ch_for_ancom_tax }
     QIIME2_ANCOM_TAX ( ch_for_ancom_tax )
+    QIIME2_ANCOM_TAX.out.ancom.subscribe { if ( it.baseName[0].toString().startsWith("WARNING") ) log.warn it.baseName[0].toString().replace("WARNING ","QIIME2_ANCOM_TAX: ").replace(" ancom_log", "") }
 
     QIIME2_ANCOM_ASV ( ch_metadata.combine( QIIME2_FILTERASV.out.qza.flatten() ) )
 }


### PR DESCRIPTION
<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

* Added a PR2 formatting script
* Made sure all formatting scripts outputs domain, kingdom etc. ranks
* Made sure Ancom processes isn't run when input table contains a single row/taxon

(A number of edited lines in the diffs are only changed to have four spaces instead of a tab to start the line. Maybe this should be made more consistently?)