### PR TITLE
Export two ASV relative abundance tables with DADA2 or QIIME2 classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+* [#313](https://github.com/nf-core/ampliseq/pull/313) - Relative abundance tables in `qiime2/rel_abundance_tables/` on ASV level were renamed and with either DADA2 (`rel-table-ASV_with-DADA2-tax.tsv`) or QIIME2 classifications (`rel-table-ASV_with-QIIME2-tax.tsv`), if available.
+
 ### `Fixed`
 
 * [#306](https://github.com/nf-core/ampliseq/pull/306) - Sample names can now be identical to basenames of read files

--- a/bin/combine_table.r
+++ b/bin/combine_table.r
@@ -10,24 +10,31 @@ table <- args[1]
 seq <- args[2]
 taxonomy <- args[3]
 
-OUT="qiime2_ASV_table.tsv"
+OUT="combined_ASV_table.tsv"
 
 #load packages, Biostrings_2.46.0
 library("Biostrings")
 
-#read required files
+#read abundance file, rename first column to ID to have that independent of DADA2/QIIME2 input
 table <- read.table(file = table, sep = '\t', comment.char = "", skip=1, header=TRUE) #X.OTU.ID
+colnames(table)[1] <- "ID"
+
+#read taxonomy file, rename first column to ID to have that independent of DADA2/QIIME2 input, also remove the additional sequence column
 tax <- read.table(file = taxonomy, sep = '\t', comment.char = "", header=TRUE) #Feature.ID
+colnames(tax)[1] <- "ID"
+tax$sequence <- NULL
+
+#read fasta file of ASV sequences
 seq <- readDNAStringSet(seq)
 seq <- data.frame(ID=names(seq), sequence=paste(seq))
 
 #check if all ids match
-if(!all(seq$ID %in% tax$Feature.ID))  {paste(seq,"and",taxonomy,"dont share all IDs, this is only ok when taxa were excluded.")}
-if(!all(seq$ID %in% table$X.OTU.ID))  {stop(paste(seq,"and",table,"dont share all IDs, exit"), call.=FALSE)}
+if(!all(seq$ID %in% tax$ID))  {paste(seq,"and",taxonomy,"dont share all IDs, this is only ok when taxa were excluded.")}
+if(!all(seq$ID %in% table$ID))  {stop(paste(seq,"and",table,"dont share all IDs, exit"), call.=FALSE)}
 
 #merge
-df <- merge(tax, seq, by.x="Feature.ID", by.y="ID", all.x=FALSE, all.y=TRUE)
-df <- merge(df, table, by.x="Feature.ID", by.y="X.OTU.ID", all=TRUE)
+df <- merge(tax, seq, by.x="ID", by.y="ID", all.x=FALSE, all.y=TRUE)
+df <- merge(df, table, by.x="ID", by.y="ID", all=TRUE)
 
 #write
 print (paste("write",OUT))

--- a/docs/output.md
+++ b/docs/output.md
@@ -141,7 +141,7 @@ Taxonomic classification with QIIME2 is typically similar to DADA2 classificatio
 
 #### Exclude taxa
 
-Removes unwanted taxa in DADA2 output sequences and abundance tables by taxonomic classification. Unwanted taxa are often off-targets generated in PCR with primers that are not perfectly specific for the target DNA. For example, PCR with commonly used primers also amplifyies mitrochindrial or chloroplast rRNA genes and therefore leads to non-bacteria products. These mitrochondria or chloroplast amplicons are removed in this step by default (`--exclude_taxa`).
+Removes unwanted taxa in DADA2 output sequences and abundance tables by taxonomic classification. Unwanted taxa are often off-targets generated in PCR with primers that are not perfectly specific for the target DNA. For example, PCR with commonly used primers also amplifyies mitrochindrial or chloroplast rRNA genes and therefore leads to non-bacteria products. These mitrochondria or chloroplast amplicons are removed in this step by default (`--exclude_taxa`). The tables are based on the computed taxonomic classification (DADA2 classification takes precedence over QIIME2 classifications).
 
 All following analysis is based on these filtered tables.
 
@@ -167,7 +167,7 @@ All following analysis is based on these filtered tables.
 
 #### Relative abundance tables
 
-Absolute abundance tables produced by the previous steps contain count data, but the compositional nature of 16S rRNA amplicon sequencing requires sequencing depth normalisation. This step computes relative abundance tables for various taxonomic levels and a detailed table for all ASVs with taxonomic classification, sequence and relative abundance for each sample. Typically used for in depth investigation of taxa abundances.
+Absolute abundance tables produced by the previous steps contain count data, but the compositional nature of 16S rRNA amplicon sequencing requires sequencing depth normalisation. This step computes relative abundance tables for various taxonomic levels and detailed tables for all ASVs with taxonomic classification, sequence and relative abundance for each sample. Typically used for in depth investigation of taxa abundances. If not specified, the tables are based on the computed taxonomic classification (DADA2 classification takes precedence over QIIME2 classifications).
 
 <details markdown="1">
 <summary>Output files</summary>
@@ -180,13 +180,14 @@ Absolute abundance tables produced by the previous steps contain count data, but
     * `rel-table-6.tsv`: Tab-separated relative abundance table at genus level.
     * `rel-table-7.tsv`: Tab-separated relative abundance table at species level.
     * `rel-table-ASV.tsv`: Tab-separated relative abundance table for all ASVs.
-    * `qiime2_ASV_table.tsv`: Tab-separated table for all ASVs with taxonomic classification, sequence and relative abundance. *NOTE: This file is based on QIIME2 taxonomic classifications, contrary to all other files that are based on DADA2 classification, if available.*
+    * `rel-table-ASV_with-DADA2-tax.tsv`: Tab-separated table for all ASVs with DADA2 taxonomic classification, sequence and relative abundance.
+    * `rel-table-ASV_with-QIIME2-tax.tsv`: Tab-separated table for all ASVs with QIIME2 taxonomic classification, sequence and relative abundance.
 
 </details>
 
 #### Barplot
 
-Produces an interactive abundance plot count tables that aids exploratory browsing the discovered taxa and their abundance in samples and allows sorting for associated meta data.
+Produces an interactive abundance plot count tables that aids exploratory browsing the discovered taxa and their abundance in samples and allows sorting for associated meta data, DADA2 classification takes precedence over QIIME2 classifications.
 
 <details markdown="1">
 <summary>Output files</summary>

--- a/modules/local/combine_table.nf
+++ b/modules/local/combine_table.nf
@@ -21,12 +21,14 @@ process COMBINE_TABLE {
     path(table)
     path(seq)
     path(tax)
+    val(outfile)
 
     output:
-    path("qiime2_ASV_table.tsv")
+    path("${outfile}")
 
     script:
     """
     combine_table.r ${table} ${seq} ${tax}
+    mv combined_ASV_table.tsv ${outfile}
     """
 }

--- a/subworkflows/local/qiime2_export.nf
+++ b/subworkflows/local/qiime2_export.nf
@@ -7,17 +7,19 @@ params.relasv_options = [:]
 params.reltax_options = [:]
 params.combine_table_options = [:]
 
-include { QIIME2_EXPORT_ABSOLUTE      } from '../../modules/local/qiime2_export_absolute' addParams( options: params.absolute_options      )
-include { QIIME2_EXPORT_RELASV        } from '../../modules/local/qiime2_export_relasv'   addParams( options: params.relasv_options        )
-include { QIIME2_EXPORT_RELTAX        } from '../../modules/local/qiime2_export_reltax'   addParams( options: params.reltax_options        )
-include { COMBINE_TABLE               } from '../../modules/local/combine_table'          addParams( options: params.combine_table_options )
+include { QIIME2_EXPORT_ABSOLUTE                } from '../../modules/local/qiime2_export_absolute' addParams( options: params.absolute_options      )
+include { QIIME2_EXPORT_RELASV                  } from '../../modules/local/qiime2_export_relasv'   addParams( options: params.relasv_options        )
+include { QIIME2_EXPORT_RELTAX                  } from '../../modules/local/qiime2_export_reltax'   addParams( options: params.reltax_options        )
+include { COMBINE_TABLE as COMBINE_TABLE_QIIME2 } from '../../modules/local/combine_table'          addParams( options: params.combine_table_options )
+include { COMBINE_TABLE as COMBINE_TABLE_DADA2  } from '../../modules/local/combine_table'          addParams( options: params.combine_table_options )
 
 workflow QIIME2_EXPORT {
     take:
     ch_asv
     ch_seq
     ch_tax
-    ch_tax_tsv
+    ch_QIIME2_tax_tsv
+    ch_DADA2_tax_tsv
 
     main:
     //export_filtered_dada_output (optional)
@@ -29,8 +31,11 @@ workflow QIIME2_EXPORT {
     //RelativeAbundanceReducedTaxa (optional)
     QIIME2_EXPORT_RELTAX ( ch_asv, ch_tax )
 
-    //combine_table.r (optional), seems similar to DADA2_table.tsv but with additionally taxonomy merged
-    COMBINE_TABLE ( QIIME2_EXPORT_RELASV.out.tsv, QIIME2_EXPORT_ABSOLUTE.out.fasta, ch_tax_tsv )
+    //combine_table.r (optional), similar to DADA2_table.tsv but with additionally taxonomy merged
+    COMBINE_TABLE_QIIME2 ( QIIME2_EXPORT_RELASV.out.tsv, QIIME2_EXPORT_ABSOLUTE.out.fasta, ch_QIIME2_tax_tsv, 'rel-table-ASV_with-QIIME2-tax.tsv' )
+
+    //combine_table.r (optional), similar to DADA2_table.tsv but with additionally taxonomy merged
+    COMBINE_TABLE_DADA2 ( QIIME2_EXPORT_RELASV.out.tsv, QIIME2_EXPORT_ABSOLUTE.out.fasta, ch_DADA2_tax_tsv, 'rel-table-ASV_with-DADA2-tax.tsv' )
 
     emit:
     abs_fasta      = QIIME2_EXPORT_ABSOLUTE.out.fasta

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -476,7 +476,7 @@ workflow AMPLISEQ {
         }
         //Export various ASV tables
         if (!params.skip_abundance_tables) {
-            QIIME2_EXPORT ( ch_asv, ch_seq, ch_tax, QIIME2_TAXONOMY.out.tsv )
+            QIIME2_EXPORT ( ch_asv, ch_seq, ch_tax, QIIME2_TAXONOMY.out.tsv, ch_dada2_tax )
         }
 
         if (!params.skip_barplot) {


### PR DESCRIPTION
I prefer to have two relative abundance tables with taxonomic classifications and sequences, for DADA2 and QIIME2 classifications. Those tables are actually the info that my customers prefer and expect but those are currently only produced for QIIME2 classifications. It is quite tedious to merge those tables manually to satisfy the expectations, so here is the automation.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
