### PR TITLE
Fix --skip_fastqc and error message when no input data is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-* [#331](https://github.com/nf-core/ampliseq/issues/331) - Improve error message when no data files are found
+* [#329](https://github.com/nf-core/ampliseq/issues/329) - Improve error message when no data files are found
+* [#330](https://github.com/nf-core/ampliseq/issues/330) - Make `--skip_fastqc` usable again
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+* [#331](https://github.com/nf-core/ampliseq/issues/331) - Improve error message when no data files are found
+
 ### `Dependencies`
 
 ### `Removed`

--- a/conf/test_doubleprimers.config
+++ b/conf/test_doubleprimers.config
@@ -22,4 +22,5 @@ params {
     dada_ref_taxonomy = false
     input = "https://raw.githubusercontent.com/nf-core/test-datasets/ampliseq/samplesheets/Samplesheet_double_primer.tsv"
     trunc_qmin = 30
+    skip_fastqc = true
 }

--- a/subworkflows/local/parse_input.nf
+++ b/subworkflows/local/parse_input.nf
@@ -67,11 +67,17 @@ workflow PARSE_INPUT {
 
             //Check folders in folder when multiple_sequencing_runs
             folders = multiple_sequencing_runs ? "/*" : ""
+            error_message = "\nCannot find any reads matching: \"${input}${folders}${extension}\"\n"
+            error_message += "Please revise the input folder (\"--input\"): \"${input}\"\n"
+            error_message += "and the input file pattern (\"--extension\"): \"${extension}\"\n"
+            error_message += "*Please note: Path needs to be enclosed in quotes!*\n"
+            error_message += multiple_sequencing_runs ? "If you do not have multiple sequencing runs, please do not use \"--multiple_sequencing_runs\"!\n" : "If you have multiple sequencing runs, please add \"--multiple_sequencing_runs\"!\n"
+            error_message += "In any case, please consult the pipeline documentation.\n"
             if ( single_end ) {
                 //Get files - single end
                 Channel
                     .fromPath( input + folders + extension )
-                    .ifEmpty { exit 1, "Cannot find any reads matching: \"${input}${extension}\"\nPlease revise the input folder (\"--input\"): \"${input}\"\nand the input file pattern (\"--extension\"): \"${extension}\"\nIf you have multiple sequencing runs, please add \"--multiple_sequencing_runs\".\nNB: Path needs to be enclosed in quotes!" }
+                    .ifEmpty { exit 1, "${error_message}" }
                     .map { read ->
                             def meta = [:]
                             meta.id           = read.baseName.toString().indexOf("_") != -1 ? read.baseName.toString().take(read.baseName.toString().indexOf("_")) : read.baseName
@@ -83,7 +89,7 @@ workflow PARSE_INPUT {
                 //Get files - paired end
                 Channel
                     .fromFilePairs( input + folders + extension, size: 2 )
-                    .ifEmpty { exit 1, "Cannot find any reads matching: \"${input}${extension}\"\nPlease revise the input folder (\"--input\"): \"${input}\"\nand the input file pattern (\"--extension\"): \"${extension}\"\nIf you have multiple sequencing runs, please add \"--multiple_sequencing_runs\".\nNB: Path needs to be enclosed in quotes!" }
+                    .ifEmpty { exit 1, "${error_message}" }
                     .map { name, reads ->
                             def meta = [:]
                             meta.id           = name.toString().indexOf("_") != -1 ? name.toString().take(name.toString().indexOf("_")) : name

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -581,7 +581,9 @@ workflow AMPLISEQ {
         ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_custom_config.collect().ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
         ch_multiqc_files = ch_multiqc_files.mix(GET_SOFTWARE_VERSIONS.out.yaml.collect())
-        ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
+        if (!params.skip_fastqc) {
+            ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
+        }
 
         MULTIQC (
             ch_multiqc_files.collect()


### PR DESCRIPTION
This is to solve:
- #330 --skip_fastqc is not usable
- #329 Error message can be misleading when no raw data is found 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
