### PR TITLE
Add --skip_dada_addspecies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+* [#352](https://github.com/nf-core/ampliseq/pull/352) - `--skip_dada_addspecies` allows to skip species level classification to reduce memory requirements, incompatible with `--sbdiexport` and `--cut_its` that expect species annotation
+
 ### `Changed`
 
 ### `Fixed`

--- a/conf/test_multi.config
+++ b/conf/test_multi.config
@@ -20,6 +20,6 @@ params {
     FW_primer = "GTGYCAGCMGCCGCGGTAA"
     RV_primer = "GGACTACNVGGGTWTCTAAT"
     dada_ref_taxonomy = "rdp=18"
-    skip_dada_ref_taxonomy = true
+    skip_dada_addspecies = true
     input = "https://raw.githubusercontent.com/nf-core/test-datasets/ampliseq/samplesheets/Samplesheet_multi.tsv"
 }

--- a/conf/test_multi.config
+++ b/conf/test_multi.config
@@ -19,6 +19,7 @@ params {
     // Input data
     FW_primer = "GTGYCAGCMGCCGCGGTAA"
     RV_primer = "GGACTACNVGGGTWTCTAAT"
-    dada_ref_taxonomy = false
+    dada_ref_taxonomy = "rdp=18"
+    skip_dada_ref_taxonomy = true
     input = "https://raw.githubusercontent.com/nf-core/test-datasets/ampliseq/samplesheets/Samplesheet_multi.tsv"
 }

--- a/lib/WorkflowAmpliseq.groovy
+++ b/lib/WorkflowAmpliseq.groovy
@@ -32,6 +32,16 @@ class WorkflowAmpliseq {
             log.error "Incompatible parameters: `--qiime_tax_agglom_min` may not be greater than `--qiime_tax_agglom_max`."
             System.exit(1)
         }
+
+        if (params.skip_dada_addspecies && params.sbdiexport) {
+            log.error "Incompatible parameters: `--sbdiexport` expects species annotation and therefore excludes `--skip_dada_addspecies`."
+            System.exit(1)
+        }
+
+        if (params.skip_dada_addspecies && params.cut_its) {
+            log.error "Incompatible parameters: `--cut_its` expects species annotation and therefore excludes `--skip_dada_addspecies`."
+            System.exit(1)
+        }
     }
 
     //

--- a/nextflow.config
+++ b/nextflow.config
@@ -53,6 +53,7 @@ params {
     skip_abundance_tables = false
     skip_barplot      = false
     skip_taxonomy     = false
+    skip_dada_addspecies = false
     skip_alpha_rarefaction = false
     skip_diversity_indices = false
     skip_ancom        = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -326,6 +326,10 @@
                     "type": "boolean",
                     "description": "Skip taxonomic classification"
                 },
+                "skip_dada_addspecies": {
+                    "type": "boolean",
+                    "description": "Skip species level when using DADA2 for taxonomic classification, that reduces required memory dramatically under certain conditions. Incompatible with `--sbdiexport` and `--cut_its`"
+                },
                 "skip_barplot": {
                     "type": "boolean",
                     "description": "Skip producing barplot"

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -413,8 +413,10 @@ workflow AMPLISEQ {
         }
         if (!params.cut_its) {
             DADA2_TAXONOMY ( ch_fasta, ch_assigntax, 'ASV_tax.tsv' )
-            DADA2_ADDSPECIES ( DADA2_TAXONOMY.out.rds, ch_addspecies, 'ASV_tax_species.tsv' )
-            ch_dada2_tax = DADA2_ADDSPECIES.out.tsv
+            if (!params.skip_dada_addspecies) {
+                DADA2_ADDSPECIES ( DADA2_TAXONOMY.out.rds, ch_addspecies, 'ASV_tax_species.tsv' )
+                ch_dada2_tax = DADA2_ADDSPECIES.out.tsv
+            } else { ch_dada2_tax = DADA2_TAXONOMY.out.tsv }
         //Cut out ITS region if long ITS reads
         } else {
             ITSX_CUTASV ( ch_fasta )


### PR DESCRIPTION
DADA2's taxonomic classification on species level with `addSpecies` can be peak memory (RAM) requirement for the pipeline. Here the `--skip_dada_addspecies` is added to be able to skip that step when memory (RAM) is limiting.
However,  `--skip_dada_addspecies` is incompatible with `--cut_its` and `--sbdiexport` because those expect species level annotation currently.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
