### PR TITLE
filter empty files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 * [#352](https://github.com/nf-core/ampliseq/pull/352) - `--skip_dada_addspecies` allows to skip species level classification to reduce memory requirements, incompatible with `--sbdiexport` and `--cut_its` that expect species annotation
-* [#354](https://github.com/nf-core/ampliseq/pull/354) - After trimming with cutadapt, files will be checked and either the pipeline will be stopped if at least one sample fails or the failing samples will be ignored when using `--ignore_failed_samples`
+* [#354](https://github.com/nf-core/ampliseq/pull/354) - Input files and files after primer trimming with cutadapt are required to be >1KB (i.e. not empty) and either the pipeline will stop if at least one sample file fails or the failing samples will be ignored when using `--ignore_empty_input_files` or `--ignore_failed_trimming`, respectively.
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 * [#352](https://github.com/nf-core/ampliseq/pull/352) - `--skip_dada_addspecies` allows to skip species level classification to reduce memory requirements, incompatible with `--sbdiexport` and `--cut_its` that expect species annotation
+* [#354](https://github.com/nf-core/ampliseq/pull/354) - After trimming with cutadapt, files will be checked and either the pipeline will be stopped if at least one sample fails or the failing samples will be ignored when using `--ignore_failed_samples`
 
 ### `Changed`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,6 +45,7 @@ params {
     dada_tax_agglom_max = 7
     qiime_tax_agglom_min = 2
     qiime_tax_agglom_max = 6
+    ignore_failed_samples = false
 
     // Skipping options
     skip_qiime        = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,8 @@ params {
     dada_tax_agglom_max = 7
     qiime_tax_agglom_min = 2
     qiime_tax_agglom_max = 6
-    ignore_failed_samples = false
+    ignore_failed_trimming = false
+    ignore_empty_input_files = false
 
     // Skipping options
     skip_qiime        = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -287,9 +287,13 @@
             "description": "",
             "default": "",
             "properties": {
-                "ignore_failed_samples": {
+                "ignore_empty_input_files": {
                     "type": "boolean",
-                    "description": "Lack of reads for individual samples is ignored and the pipeline will continue without those samples."
+                    "description": "Too small input files size (<1KB) for individual samples is ignored and the pipeline will continue without those samples."
+                },
+                "ignore_failed_trimming": {
+                    "type": "boolean",
+                    "description": "Too small files size (<1KB) for individual samples after primer trimming (cutadapt) is ignored and the pipeline will continue without those samples."
                 },
                 "exclude_taxa": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -287,6 +287,10 @@
             "description": "",
             "default": "",
             "properties": {
+                "ignore_failed_samples": {
+                    "type": "boolean",
+                    "description": "Lack of reads for individual samples is ignored and the pipeline will continue without those samples."
+                },
                 "exclude_taxa": {
                     "type": "string",
                     "default": "mitochondria,chloroplast",

--- a/subworkflows/local/cutadapt_workflow.nf
+++ b/subworkflows/local/cutadapt_workflow.nf
@@ -56,8 +56,8 @@ workflow CUTADAPT_WORKFLOW {
     //Filter empty files
     ch_trimmed_reads
         .branch {
-            failed: it[0].single_end ? it[1].size() < 1.KB : it[1][0].size() < 1.KB
-            passed: it[0].single_end ? it[1].size() >= 1.KB : it[1][0].size() >= 1.KB
+            failed: it[0].single_end ? it[1][0].size() < 1.KB : it[1][0].size() < 1.KB || it[1][1].size() < 1.KB
+            passed: it[0].single_end ? it[1][0].size() >= 1.KB : it[1][0].size() >= 1.KB && it[1][1].size() >= 1.KB
         }
         .set { ch_trimmed_reads_result }
     ch_trimmed_reads_result.passed.set { ch_trimmed_reads_passed }

--- a/subworkflows/local/cutadapt_workflow.nf
+++ b/subworkflows/local/cutadapt_workflow.nf
@@ -66,7 +66,7 @@ workflow CUTADAPT_WORKFLOW {
         .collect()
         .subscribe {
             samples = it.join(",")
-            log.error "Samples $samples had too low read count after trimming with cutadapt. Please check whether the correct primer sequences for trimming were supplied."
+            log.error "Samples $samples had too low read count after trimming with cutadapt. Please check whether the correct primer sequences for trimming were supplied. If you want to ignore that issue and continue running the pipeline, use `--ignore_failed_samples`."
             params.ignore_failed_samples ? { log.warn "Ignoring failed samples and continue!" } : System.exit(1)
         }
 

--- a/subworkflows/local/cutadapt_workflow.nf
+++ b/subworkflows/local/cutadapt_workflow.nf
@@ -65,9 +65,9 @@ workflow CUTADAPT_WORKFLOW {
         .map { meta, reads -> [ meta.id ] }
         .collect()
         .subscribe {
-            samples = it.join(",")
-            log.error "Samples $samples had too low read count after trimming with cutadapt. Please check whether the correct primer sequences for trimming were supplied. If you want to ignore that issue and continue running the pipeline, use `--ignore_failed_samples`."
-            params.ignore_failed_samples ? { log.warn "Ignoring failed samples and continue!" } : System.exit(1)
+            samples = it.join("\n")
+            log.error "the following samples had too small file size (<1KB) after trimming with cutadapt:\n$samples\nPlease check whether the correct primer sequences for trimming were supplied. Ignore that issue and samples using `--ignore_failed_trimming`."
+            params.ignore_failed_trimming ? { log.warn "Ignoring failed samples and continue!" } : System.exit(1)
         }
 
     emit:

--- a/subworkflows/local/cutadapt_workflow.nf
+++ b/subworkflows/local/cutadapt_workflow.nf
@@ -56,8 +56,8 @@ workflow CUTADAPT_WORKFLOW {
     //Filter empty files
     ch_trimmed_reads
         .branch {
-            failed: it[0].single_end ? it[1][0].size() < 1.KB : it[1][0].size() < 1.KB || it[1][1].size() < 1.KB
-            passed: it[0].single_end ? it[1][0].size() >= 1.KB : it[1][0].size() >= 1.KB && it[1][1].size() >= 1.KB
+            failed: it[0].single_end ? it[1].size() < 1.KB : it[1][0].size() < 1.KB || it[1][1].size() < 1.KB
+            passed: it[0].single_end ? it[1].size() >= 1.KB : it[1][0].size() >= 1.KB && it[1][1].size() >= 1.KB
         }
         .set { ch_trimmed_reads_result }
     ch_trimmed_reads_result.passed.set { ch_trimmed_reads_passed }

--- a/subworkflows/local/parse_input.nf
+++ b/subworkflows/local/parse_input.nf
@@ -136,8 +136,8 @@ workflow PARSE_INPUT {
         //Filter empty files
         ch_reads
             .branch {
-                failed: it[0].single_end ? it[1].size() < 1.KB : it[1][0].size() < 1.KB || it[1][1].size() < 1.KB
-                passed: it[0].single_end ? it[1].size() >= 1.KB : it[1][0].size() >= 1.KB && it[1][1].size() >= 1.KB
+                failed: it[0].single_end ? it[1][0].size() < 1.KB : it[1][0].size() < 1.KB || it[1][1].size() < 1.KB
+                passed: it[0].single_end ? it[1][0].size() >= 1.KB : it[1][0].size() >= 1.KB && it[1][1].size() >= 1.KB
             }
             .set { ch_reads_result }
         ch_reads_result.passed.set { ch_reads_passed }

--- a/subworkflows/local/parse_input.nf
+++ b/subworkflows/local/parse_input.nf
@@ -47,7 +47,7 @@ workflow PARSE_INPUT {
     if ( is_fasta_input ) {
         // Fasta input directely for classification
         ch_fasta = Channel.fromPath(input, checkIfExists: true)
-        ch_reads = Channel.empty()
+        ch_reads_passed = Channel.empty()
     } else {
         ch_fasta = Channel.empty()
 


### PR DESCRIPTION
Closes https://github.com/nf-core/ampliseq/issues/340

Sample with input files and files after cutadapt with low read numbers (gz'ed file size < 1Kb) are removed. Either with error that stops the pipeline or it continues when using `--ignore_empty_input_files` or `--ignore_failed_trimming`. Either way, an error message with sample names will highlight what samples were failing.

I did not add a check after DADA2's quality filter filtntrim, because the error message there is actually quite clear.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
