### PR TITLE
PR2 remake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#352](https://github.com/nf-core/ampliseq/pull/352) - `--skip_dada_addspecies` allows to skip species level classification to reduce memory requirements, incompatible with `--sbdiexport` and `--cut_its` that expect species annotation
 * [#354](https://github.com/nf-core/ampliseq/pull/354) - Input files and files after primer trimming with cutadapt are required to be >1KB (i.e. not empty) and either the pipeline will stop if at least one sample file fails or the failing samples will be ignored when using `--ignore_empty_input_files` or `--ignore_failed_trimming`, respectively.
 * [#364](https://github.com/nf-core/ampliseq/pull/364) - Adonis in QIIME2 for testing feature importance in beta diversity distances, `--qiime_adonis_formula` can be set to provide a custom formula.
+* [#365](https://github.com/nf-core/ampliseq/pull/365) - Dynamic taxon ranks for DADA2 `assignTaxonomy`. By default, only PR2 ranks differ from earlier versions. Update SBDI-GTDB DADA2 taxonomy database to v.3.
 
 ### `Changed`
 

--- a/bin/sbdiexport.R
+++ b/bin/sbdiexport.R
@@ -40,7 +40,9 @@ metadata        <- args[6]
 asvs <- read.delim(asvtable, sep = '\t', stringsAsFactors = FALSE)
 n_samples <- length(colnames(asvs)) - 1
 
-taxonomy <- read.delim(taxtable, sep = '\t', stringsAsFactors = FALSE)
+taxonomy <- read.delim(taxtable, sep = '\t', stringsAsFactors = FALSE) %>%
+    # Pick ranks by number, to circumvent that PR2 has different ranks than the rest
+    rename(Domain = 2, Kingdom = 3, Phylum = 4, Class = 5, Order = 6, Family = 7, Genus = 8, Species = 9)
 
 # Read the metadata table if provided, otherwise create one
 if ( ! is.na(metadata) ) {

--- a/bin/sbdiexportreannotate.R
+++ b/bin/sbdiexportreannotate.R
@@ -6,10 +6,9 @@
 # to ready for submission to the Swedish Biodiversity Data Infrastructure
 # (SBDI) as possible.
 #
-# The script expects the following input file to be present in the directory:
-# ASV_tax_species.tsv.
-#
-# It also expects the following argument: dbversion
+# The script expects the following positional arguments:
+#   1. dbversion
+#   2. Input table, e.g. ASV_tax_species.tsv.
 #
 # Author: daniel.lundin@lnu.se
 
@@ -20,9 +19,12 @@ args            <- commandArgs(trailingOnly=TRUE)
 dbversion       <- args[1]
 taxfile         <- args[2]
 
-taxonomy <- read.delim(taxfile, sep = '\t', stringsAsFactors = FALSE)
+taxonomy <- read.delim(taxfile, sep = '\t', stringsAsFactors = FALSE) %>%
+    # Pick ranks by number, to circumvent that PR2 has different ranks than the rest
+    rename(Domain = 2, Kingdom = 3, Phylum = 4, Class = 5, Order = 6, Family = 7, Genus = 8, Species = 9)
 
 taxonomy %>%
+    # I'm keeping this if the ugly renaming above proves unnecessary one day
     rename_with(tolower, Domain:Species) %>%
     rename(
         asv_id_alias = ASV_ID,

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -71,7 +71,7 @@ params {
             citation = "Cole JR, Wang Q, Fish JA, Chai B, McGarrell DM, Sun Y, Brown CT, Porras-Alfaro A, Kuske CR, Tiedje JM. Ribosomal Database Project: data and tools for high throughput rRNA analysis. Nucleic Acids Res. 2014 Jan;42(Database issue):D633-42. doi: 10.1093/nar/gkt1244. Epub 2013 Nov 27. PMID: 24288368; PMCID: PMC3965039."
             fmtscript = "taxref_reformat_standard.sh"
             dbversion = 'rdp=18/11.5'
-            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'sbdi-gtdb' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R06-RS202-1"
@@ -79,7 +79,7 @@ params {
             citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v1"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
             dbversion = 'sbdi-gtdb=R06-RS202-1'
-            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'sbdi-gtdb=R06-RS202-1' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R06-RS202-1"
@@ -87,7 +87,7 @@ params {
             citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v1"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
             dbversion = 'sbdi-gtdb=R06-RS202-1'
-            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'silva' {
             title = "Silva 138.1 prokaryotic SSU"
@@ -95,7 +95,7 @@ params {
             citation = "Quast C, Pruesse E, Yilmaz P, Gerken J, Schweer T, Yarza P, Peplies J, Glöckner FO. The SILVA ribosomal RNA gene database project: improved data processing and web-based tools. Nucleic Acids Res. 2013 Jan;41(Database issue):D590-6. doi: 10.1093/nar/gks1219. Epub 2012 Nov 28. PMID: 23193283; PMCID: PMC3531112."
             fmtscript = "taxref_reformat_standard.sh"
             dbversion = 'silva=138.1'
-            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'silva=138' {
             title = "Silva 138.1 prokaryotic SSU"
@@ -103,7 +103,7 @@ params {
             citation = "Quast C, Pruesse E, Yilmaz P, Gerken J, Schweer T, Yarza P, Peplies J, Glöckner FO. The SILVA ribosomal RNA gene database project: improved data processing and web-based tools. Nucleic Acids Res. 2013 Jan;41(Database issue):D590-6. doi: 10.1093/nar/gks1219. Epub 2012 Nov 28. PMID: 23193283; PMCID: PMC3531112."
             fmtscript = "taxref_reformat_standard.sh"
             dbversion = 'silva=138.1'
-            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'silva=132' {
             title = "Silva Project's version 132 release"
@@ -111,7 +111,7 @@ params {
             citation = "Quast C, Pruesse E, Yilmaz P, Gerken J, Schweer T, Yarza P, Peplies J, Glöckner FO. The SILVA ribosomal RNA gene database project: improved data processing and web-based tools. Nucleic Acids Res. 2013 Jan;41(Database issue):D590-6. doi: 10.1093/nar/gks1219. Epub 2012 Nov 28. PMID: 23193283; PMCID: PMC3531112."
             fmtscript = "taxref_reformat_standard.sh"
             dbversion = 'silva=132'
-            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'unite-fungi' {
             title = "UNITE general FASTA release for Fungi - Version 8.3"

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -75,18 +75,18 @@ params {
         }
         'sbdi-gtdb' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R06-RS202-1"
-            file = [ "https://scilifelab.figshare.com/ndownloader/files/28624479", "https://scilifelab.figshare.com/ndownloader/files/28624482" ]
-            citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v1"
+            file = [ "https://scilifelab.figshare.com/ndownloader/files/31370437", "https://scilifelab.figshare.com/ndownloader/files/31370434" ]
+            citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v3"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
-            dbversion = 'sbdi-gtdb=R06-RS202-1'
+            dbversion = 'sbdi-gtdb=R06-RS202-3'
             ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
-        'sbdi-gtdb=R06-RS202-1' {
+        'sbdi-gtdb=R06-RS202-3' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R06-RS202-1"
-            file = [ "https://scilifelab.figshare.com/ndownloader/files/28624479", "https://scilifelab.figshare.com/ndownloader/files/28624482" ]
-            citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v1"
+            file = [ "https://scilifelab.figshare.com/ndownloader/files/31370437", "https://scilifelab.figshare.com/ndownloader/files/31370434" ]
+            citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v3"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
-            dbversion = 'sbdi-gtdb=R06-RS202-1'
+            dbversion = 'sbdi-gtdb=R06-RS202-3'
             ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'silva' {

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -15,6 +15,7 @@ params {
             citation = "Parks DH, Chuvochina M, Waite DW, Rinke C, Skarshewski A, Chaumeil PA, Hugenholtz P. A standardized bacterial taxonomy based on genome phylogeny substantially revises the tree of life. Nat Biotechnol. 2018 Nov;36(10):996-1004. doi: 10.1038/nbt.4229. Epub 2018 Aug 27. PMID: 30148503."
             fmtscript = "taxref_reformat_gtdb.sh"
             dbversion = 'gtdb=05-RS95'
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'gtdb=06-RS202' {
             title = "GTDB - Genome Taxonomy Database - Release 06-RS202"
@@ -22,6 +23,7 @@ params {
             citation = "Parks DH, Chuvochina M, Waite DW, Rinke C, Skarshewski A, Chaumeil PA, Hugenholtz P. A standardized bacterial taxonomy based on genome phylogeny substantially revises the tree of life. Nat Biotechnol. 2018 Nov;36(10):996-1004. doi: 10.1038/nbt.4229. Epub 2018 Aug 27. PMID: 30148503."
             fmtscript = "taxref_reformat_gtdb.sh"
             dbversion = 'gtdb=06-RS202'
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'gtdb' {
             title = "GTDB - Genome Taxonomy Database - Release 06-RS202"
@@ -29,6 +31,7 @@ params {
             citation = "Parks DH, Chuvochina M, Waite DW, Rinke C, Skarshewski A, Chaumeil PA, Hugenholtz P. A standardized bacterial taxonomy based on genome phylogeny substantially revises the tree of life. Nat Biotechnol. 2018 Nov;36(10):996-1004. doi: 10.1038/nbt.4229. Epub 2018 Aug 27. PMID: 30148503."
             fmtscript = "taxref_reformat_gtdb.sh"
             dbversion = 'gtdb=06-RS202'
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'pr2' {
             title = "PR2 - Protist Reference Ribosomal Database - Version 4.14.0"
@@ -36,6 +39,7 @@ params {
             citation = "Guillou L, Bachar D, Audic S, Bass D, Berney C, Bittner L, Boutte C, Burgaud G, de Vargas C, Decelle J, Del Campo J, Dolan JR, Dunthorn M, Edvardsen B, Holzmann M, Kooistra WH, Lara E, Le Bescot N, Logares R, Mahé F, Massana R, Montresor M, Morard R, Not F, Pawlowski J, Probert I, Sauvadet AL, Siano R, Stoeck T, Vaulot D, Zimmermann P, Christen R. The Protist Ribosomal Reference database (PR2): a catalog of unicellular eukaryote small sub-unit rRNA sequences with curated taxonomy. Nucleic Acids Res. 2013 Jan;41(Database issue):D597-604. doi: 10.1093/nar/gks1160. Epub 2012 Nov 27. PMID: 23193267; PMCID: PMC3531120."
             fmtscript = "taxref_reformat_pr2.sh"
             dbversion = 'pr2=4.14.0'
+            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'pr2=4.14.0' {
             title = "PR2 - Protist Reference Ribosomal Database - Version 4.14.0"
@@ -43,6 +47,7 @@ params {
             citation = "Guillou L, Bachar D, Audic S, Bass D, Berney C, Bittner L, Boutte C, Burgaud G, de Vargas C, Decelle J, Del Campo J, Dolan JR, Dunthorn M, Edvardsen B, Holzmann M, Kooistra WH, Lara E, Le Bescot N, Logares R, Mahé F, Massana R, Montresor M, Morard R, Not F, Pawlowski J, Probert I, Sauvadet AL, Siano R, Stoeck T, Vaulot D, Zimmermann P, Christen R. The Protist Ribosomal Reference database (PR2): a catalog of unicellular eukaryote small sub-unit rRNA sequences with curated taxonomy. Nucleic Acids Res. 2013 Jan;41(Database issue):D597-604. doi: 10.1093/nar/gks1160. Epub 2012 Nov 27. PMID: 23193267; PMCID: PMC3531120."
             fmtscript = "taxref_reformat_pr2.sh"
             dbversion = 'pr2=4.14.0'
+            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'pr2=4.13.0' {
             title = "PR2 - Protist Reference Ribosomal Database - Version 4.13.0"
@@ -50,6 +55,7 @@ params {
             citation = "Guillou L, Bachar D, Audic S, Bass D, Berney C, Bittner L, Boutte C, Burgaud G, de Vargas C, Decelle J, Del Campo J, Dolan JR, Dunthorn M, Edvardsen B, Holzmann M, Kooistra WH, Lara E, Le Bescot N, Logares R, Mahé F, Massana R, Montresor M, Morard R, Not F, Pawlowski J, Probert I, Sauvadet AL, Siano R, Stoeck T, Vaulot D, Zimmermann P, Christen R. The Protist Ribosomal Reference database (PR2): a catalog of unicellular eukaryote small sub-unit rRNA sequences with curated taxonomy. Nucleic Acids Res. 2013 Jan;41(Database issue):D597-604. doi: 10.1093/nar/gks1160. Epub 2012 Nov 27. PMID: 23193267; PMCID: PMC3531120."
             fmtscript = "taxref_reformat_pr2.sh"
             dbversion = 'pr2=4.13.0'
+            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'rdp=18' {
             title = "RDP - Ribosomal Database Project - RDP trainset 18/release 11.5"
@@ -57,6 +63,7 @@ params {
             citation = "Cole JR, Wang Q, Fish JA, Chai B, McGarrell DM, Sun Y, Brown CT, Porras-Alfaro A, Kuske CR, Tiedje JM. Ribosomal Database Project: data and tools for high throughput rRNA analysis. Nucleic Acids Res. 2014 Jan;42(Database issue):D633-42. doi: 10.1093/nar/gkt1244. Epub 2013 Nov 27. PMID: 24288368; PMCID: PMC3965039."
             fmtscript = "taxref_reformat_standard.sh"
             dbversion = 'rdp=18/11.5'
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'rdp' {
             title = "RDP - Ribosomal Database Project - RDP trainset 18/release 11.5"
@@ -64,6 +71,7 @@ params {
             citation = "Cole JR, Wang Q, Fish JA, Chai B, McGarrell DM, Sun Y, Brown CT, Porras-Alfaro A, Kuske CR, Tiedje JM. Ribosomal Database Project: data and tools for high throughput rRNA analysis. Nucleic Acids Res. 2014 Jan;42(Database issue):D633-42. doi: 10.1093/nar/gkt1244. Epub 2013 Nov 27. PMID: 24288368; PMCID: PMC3965039."
             fmtscript = "taxref_reformat_standard.sh"
             dbversion = 'rdp=18/11.5'
+            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'sbdi-gtdb' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R06-RS202-1"
@@ -71,6 +79,7 @@ params {
             citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v1"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
             dbversion = 'sbdi-gtdb=R06-RS202-1'
+            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'sbdi-gtdb=R06-RS202-1' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R06-RS202-1"
@@ -78,6 +87,7 @@ params {
             citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v1"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
             dbversion = 'sbdi-gtdb=R06-RS202-1'
+            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'silva' {
             title = "Silva 138.1 prokaryotic SSU"
@@ -85,6 +95,7 @@ params {
             citation = "Quast C, Pruesse E, Yilmaz P, Gerken J, Schweer T, Yarza P, Peplies J, Glöckner FO. The SILVA ribosomal RNA gene database project: improved data processing and web-based tools. Nucleic Acids Res. 2013 Jan;41(Database issue):D590-6. doi: 10.1093/nar/gks1219. Epub 2012 Nov 28. PMID: 23193283; PMCID: PMC3531112."
             fmtscript = "taxref_reformat_standard.sh"
             dbversion = 'silva=138.1'
+            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'silva=138' {
             title = "Silva 138.1 prokaryotic SSU"
@@ -92,6 +103,7 @@ params {
             citation = "Quast C, Pruesse E, Yilmaz P, Gerken J, Schweer T, Yarza P, Peplies J, Glöckner FO. The SILVA ribosomal RNA gene database project: improved data processing and web-based tools. Nucleic Acids Res. 2013 Jan;41(Database issue):D590-6. doi: 10.1093/nar/gks1219. Epub 2012 Nov 28. PMID: 23193283; PMCID: PMC3531112."
             fmtscript = "taxref_reformat_standard.sh"
             dbversion = 'silva=138.1'
+            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'silva=132' {
             title = "Silva Project's version 132 release"
@@ -99,6 +111,7 @@ params {
             citation = "Quast C, Pruesse E, Yilmaz P, Gerken J, Schweer T, Yarza P, Peplies J, Glöckner FO. The SILVA ribosomal RNA gene database project: improved data processing and web-based tools. Nucleic Acids Res. 2013 Jan;41(Database issue):D590-6. doi: 10.1093/nar/gks1219. Epub 2012 Nov 28. PMID: 23193283; PMCID: PMC3531112."
             fmtscript = "taxref_reformat_standard.sh"
             dbversion = 'silva=132'
+            ranks = [ 'Kingdom', 'Supergroup', 'Division', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'unite-fungi' {
             title = "UNITE general FASTA release for Fungi - Version 8.3"
@@ -106,6 +119,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2021): UNITE general FASTA release for Fungi. UNITE Community. 10.15156/BIO/1280049"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = 'unite-fungi=8.3'
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'unite-fungi=8.3' {
             title = "UNITE general FASTA release for Fungi - Version 8.3"
@@ -113,6 +127,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2021): UNITE general FASTA release for Fungi. UNITE Community. 10.15156/BIO/1280049"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = 'unite-fungi=8.3'
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'unite-fungi=8.2' {
             title = "UNITE general FASTA release for Fungi - Version 8.2"
@@ -120,6 +135,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2020): UNITE general FASTA release for Fungi. UNITE Community. 10.15156/BIO/786368"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = 'unite-fungi=8.2'
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'unite-alleuk' {
             title = "UNITE general FASTA release for eukaryotes - Version 8.3"
@@ -127,6 +143,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2021): UNITE general FASTA release for eukaryotes. UNITE Community. 10.15156/BIO/1280127"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = 'unite-alleuk=8.3'
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'unite-alleuk=8.3' {
             title = "UNITE general FASTA release for eukaryotes - Version 8.3"
@@ -134,6 +151,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2021): UNITE general FASTA release for eukaryotes. UNITE Community. 10.15156/BIO/1280127"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = 'unite-alleuk=8.3'
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
         'unite-alleuk=8.2' {
             title = "UNITE general FASTA release for eukaryotes - Version 8.2"
@@ -141,6 +159,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2020): UNITE general FASTA release for eukaryotes. UNITE Community. 10.15156/BIO/786370"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = 'unite-alleuk=8.2'
+            ranks = [ 'Domain', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus' ]
         }
     }
     //QIIME2 taxonomic reference databases

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -30,21 +30,10 @@ process DADA2_ADDSPECIES {
     tx <- addSpecies(taxtable, \"$database\", $args, verbose=TRUE)
 
     # Create a table with specified column order
-    tmp <- data.frame(row.names(tx)) # To separate ASV_ID from sequence
-    taxa <- data.frame(
-        ASV_ID = tx[,"ASV_ID"],
-        Domain = tx[,"Domain"],
-        Kingdom = tx[,"Kingdom"],
-        Phylum = tx[,"Phylum"],
-        Class = tx[,"Class"],
-        Order = tx[,"Order"],
-        Family = tx[,"Family"],
-        Genus = tx[,"Genus"],
-        Species = tx[,"Species"],
-        confidence = tx[,"confidence"],
-        sequence = tmp[,],
-        row.names=row.names(tmp)
-    )
+    taxa <- data.frame(tx[,1:8])
+    taxa\$Species <- tx[,'Species']
+    taxa\$confidence <- tx[,'confidence']
+    taxa\$sequence   <- taxtable\$sequence
 
     write.table(taxa, file = \"$outfile\", sep = "\\t", row.names = FALSE, col.names = TRUE, quote = FALSE, na = '')
 

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -50,7 +50,7 @@ process DADA2_TAXONOMY {
         taxa_export[[r]]    <- tx[[sprintf("tax.%s", r)]]
     }
     taxa_export\$confidence <- tx\$confidence
-    taxa_export\$sequence   <- tx\$sequence 
+    taxa_export\$sequence   <- tx\$sequence
     row.names(taxa_export)  <- tx\$sequence
 
     write.table(taxa_export, file = \"$outfile\", sep = "\\t", row.names = FALSE, col.names = TRUE, quote = FALSE, na = '')

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -28,12 +28,12 @@ process DADA2_TAXONOMY {
     seq <- getSequences(\"$fasta\", collapse = TRUE, silence = FALSE)
     ranks = c('${params.dada_ref_databases[params.dada_ref_taxonomy]["ranks"].join("', '")}')
     taxa <- assignTaxonomy(
-        seq, 
-        \"$database\", 
+        seq,
+        \"$database\",
         taxLevels = ranks,
-        $args, 
-        multithread = $task.cpus, 
-        verbose=TRUE, 
+        $args,
+        multithread = $task.cpus,
+        verbose=TRUE,
         outputBootstraps = TRUE
     )
 
@@ -50,7 +50,7 @@ process DADA2_TAXONOMY {
         taxa_export[[r]]    <- tx[[sprintf("tax.%s", r)]]
     }
     taxa_export\$confidence <- tx\$confidence
-    taxa_export\$sequence   <- tx\$sequence  
+    taxa_export\$sequence   <- tx\$sequence 
     row.names(taxa_export)  <- tx\$sequence
 
     write.table(taxa_export, file = \"$outfile\", sep = "\\t", row.names = FALSE, col.names = TRUE, quote = FALSE, na = '')

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -51,12 +51,11 @@ process DADA2_TAXONOMY {
     }
     taxa_export\$confidence <- tx\$confidence
     taxa_export\$sequence   <- tx\$sequence  
-    row.names(taxa_export)  <- names(seq)
+    row.names(taxa_export)  <- tx\$sequence
 
     write.table(taxa_export, file = \"$outfile\", sep = "\\t", row.names = FALSE, col.names = TRUE, quote = FALSE, na = '')
 
     # Save a version with rownames for addSpecies
-    taxa_export <- cbind( ASV_ID = tx\$ASV_ID, taxa\$tax, confidence = tx\$confidence)
     saveRDS(taxa_export, "ASV_tax.rds")
 
     write.table('assignTaxonomy\t$args', file = "assignTaxonomy.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')


### PR DESCRIPTION
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

I have introduced a `ranks` parameter in `conf/ref_databases.config` that allows us to set 7 custom ranks. PR2 is the only database that got new ranks, the other remain the same as before.
(Unfortunately, it was rather difficult to fit this into the SBDI export, but since that's only for Swedish users for the moment, we can perhaps live with it as it is.)
I also updated the paths to the `sbdi-gtdb` ref. databases to version 3, that gets rid of the `Reversed:_` strings before some taxa in earlier versions.