### PR TITLE
Make addSpecies optional also when using cut_its

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+* [#](https://github.com/nf-core/ampliseq/pull/) - Make `--skip_dada_addspecies` compatible with `--cut_its`
 * [#352](https://github.com/nf-core/ampliseq/pull/352) - `--skip_dada_addspecies` allows to skip species level classification to reduce memory requirements, incompatible with `--sbdiexport` and `--cut_its` that expect species annotation
 * [#354](https://github.com/nf-core/ampliseq/pull/354) - Input files and files after primer trimming with cutadapt are required to be >1KB (i.e. not empty) and either the pipeline will stop if at least one sample file fails or the failing samples will be ignored when using `--ignore_empty_input_files` or `--ignore_failed_trimming`, respectively.
 * [#364](https://github.com/nf-core/ampliseq/pull/364) - Adonis in QIIME2 for testing feature importance in beta diversity distances, `--qiime_adonis_formula` can be set to provide a custom formula.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-* [#](https://github.com/nf-core/ampliseq/pull/) - Make `--skip_dada_addspecies` compatible with `--cut_its`
-* [#352](https://github.com/nf-core/ampliseq/pull/352) - `--skip_dada_addspecies` allows to skip species level classification to reduce memory requirements, incompatible with `--sbdiexport` and `--cut_its` that expect species annotation
+* [#352](https://github.com/nf-core/ampliseq/pull/352), [#372](https://github.com/nf-core/ampliseq/pull/372) - `--skip_dada_addspecies` allows to skip species level classification to reduce memory requirements, incompatible with `--sbdiexport` that expect species annotation.
 * [#354](https://github.com/nf-core/ampliseq/pull/354) - Input files and files after primer trimming with cutadapt are required to be >1KB (i.e. not empty) and either the pipeline will stop if at least one sample file fails or the failing samples will be ignored when using `--ignore_empty_input_files` or `--ignore_failed_trimming`, respectively.
 * [#364](https://github.com/nf-core/ampliseq/pull/364) - Adonis in QIIME2 for testing feature importance in beta diversity distances, `--qiime_adonis_formula` can be set to provide a custom formula.
 * [#366](https://github.com/nf-core/ampliseq/pull/366) - New version of the SBDI-GTDB taxonomy database: v. 3. (Fixes problem with `Reverse_` added to some domain strings.)

--- a/bin/add_full_sequence_to_taxfile.py
+++ b/bin/add_full_sequence_to_taxfile.py
@@ -7,8 +7,8 @@ import pandas as pd
 import sys, os
 
 # Argument check
-if len(sys.argv) != 3:
-    exit("Usage: add_full_sequence_to_taxfile.py <ASV_tax.tsv> <ASV_seqs.fasta>")
+if len(sys.argv) != 4:
+    exit("Usage: add_full_sequence_to_taxfile.py <ASV_tax.tsv> <ASV_seqs.fasta> <outfile.tsv>")
 
 # Read tsv and remove sequence column
 taxfile = sys.argv[1]
@@ -31,10 +31,8 @@ with open(sys.argv[2], 'r') as reader:
 if (seq != "" and name != ""):
     seqs = seqs.append({'id':name, 'sequence': seq}, ignore_index=True)
 
-# Create name of results file
-outfile = taxfile.replace("ASV_ITS_", "ASV_")
-
 # Join taxonomy and full sequence, write to file
 tax = tax.set_index('ASV_ID').join(seqs.set_index('id'), how='outer')
+outfile = sys.argv[3]
 tax.to_csv(outfile, sep='\t',na_rep="", index_label="ASV_ID")
 

--- a/lib/WorkflowAmpliseq.groovy
+++ b/lib/WorkflowAmpliseq.groovy
@@ -38,10 +38,6 @@ class WorkflowAmpliseq {
             System.exit(1)
         }
 
-        if (params.skip_dada_addspecies && params.cut_its) {
-            log.error "Incompatible parameters: `--cut_its` expects species annotation and therefore excludes `--skip_dada_addspecies`."
-            System.exit(1)
-        }
     }
 
     //

--- a/modules/local/format_taxresults.nf
+++ b/modules/local/format_taxresults.nf
@@ -16,6 +16,6 @@ process FORMAT_TAXRESULTS {
 
     script:
     """
-    add_full_sequence_to_taxfile.py $taxtable $fastafile
+    add_full_sequence_to_taxfile.py $taxtable $fastafile $outfile
     """
 }

--- a/modules/local/format_taxresults.nf
+++ b/modules/local/format_taxresults.nf
@@ -8,16 +8,14 @@ process FORMAT_TAXRESULTS {
 
     input:
     path(taxtable)
-    path(taxtable_species)
     path(fastafile)
+    val(outfile)
 
     output:
-    path("ASV_tax.tsv")
-    path("ASV_tax_species.tsv"), emit: tsv
+    outfile, emit: tsv
 
     script:
     """
     add_full_sequence_to_taxfile.py $taxtable $fastafile
-    add_full_sequence_to_taxfile.py $taxtable_species $fastafile
     """
 }

--- a/modules/local/format_taxresults.nf
+++ b/modules/local/format_taxresults.nf
@@ -12,7 +12,7 @@ process FORMAT_TAXRESULTS {
     val(outfile)
 
     output:
-    outfile, emit: tsv
+    path(outfile), emit: tsv
 
     script:
     """

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -342,7 +342,7 @@
                 },
                 "skip_dada_addspecies": {
                     "type": "boolean",
-                    "description": "Skip species level when using DADA2 for taxonomic classification, that reduces required memory dramatically under certain conditions. Incompatible with `--sbdiexport` and `--cut_its`"
+                    "description": "Skip species level when using DADA2 for taxonomic classification, that reduces required memory dramatically under certain conditions. Incompatible with `--sbdiexport`"
                 },
                 "skip_barplot": {
                     "type": "boolean",

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -328,8 +328,11 @@ workflow AMPLISEQ {
             ch_versions = ch_versions.mix(ITSX_CUTASV.out.versions.ifEmpty(null))
             ch_cut_fasta = ITSX_CUTASV.out.fasta
             DADA2_TAXONOMY ( ch_cut_fasta, ch_assigntax, 'ASV_ITS_tax.tsv' )
-            DADA2_ADDSPECIES ( DADA2_TAXONOMY.out.rds, ch_addspecies, 'ASV_ITS_tax_species.tsv' )
-            FORMAT_TAXRESULTS ( DADA2_TAXONOMY.out.tsv, DADA2_ADDSPECIES.out.tsv, ch_fasta )
+            FORMAT_TAXRESULTS ( DADA2_TAXONOMY.out.tsv, ch_fasta, 'ASV_tax.tsv' )
+            if (!params.skip_dada_addspecies) {
+                DADA2_ADDSPECIES ( DADA2_TAXONOMY.out.rds, ch_addspecies, 'ASV_ITS_tax_species.tsv' )
+                FORMAT_TAXRESULTS ( DADA2_ADDSPECIES.out.tsv, ch_fasta, 'ASV_tax_species.tsv' )
+            }
             ch_dada2_tax = FORMAT_TAXRESULTS.out.tsv
         }
     }

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -97,6 +97,7 @@ include { MERGE_STATS                   } from '../modules/local/merge_stats'
 include { DADA2_TAXONOMY                } from '../modules/local/dada2_taxonomy'
 include { DADA2_ADDSPECIES              } from '../modules/local/dada2_addspecies'
 include { FORMAT_TAXRESULTS             } from '../modules/local/format_taxresults'
+include { FORMAT_TAXRESULTS as FORMAT_TAXRESULTS_ADDSP } from '../modules/local/format_taxresults'
 include { QIIME2_INSEQ                  } from '../modules/local/qiime2_inseq'
 include { QIIME2_FILTERTAXA             } from '../modules/local/qiime2_filtertaxa'
 include { QIIME2_INASV                  } from '../modules/local/qiime2_inasv'
@@ -331,9 +332,11 @@ workflow AMPLISEQ {
             FORMAT_TAXRESULTS ( DADA2_TAXONOMY.out.tsv, ch_fasta, 'ASV_tax.tsv' )
             if (!params.skip_dada_addspecies) {
                 DADA2_ADDSPECIES ( DADA2_TAXONOMY.out.rds, ch_addspecies, 'ASV_ITS_tax_species.tsv' )
-                FORMAT_TAXRESULTS ( DADA2_ADDSPECIES.out.tsv, ch_fasta, 'ASV_tax_species.tsv' )
+                FORMAT_TAXRESULTS_ADDSP ( DADA2_ADDSPECIES.out.tsv, ch_fasta, 'ASV_tax_species.tsv' )
+                ch_dada2_tax = FORMAT_TAXRESULTS_ADDSP.out.tsv
+            } else {
+                ch_dada2_tax = FORMAT_TAXRESULTS.out.tsv
             }
-            ch_dada2_tax = FORMAT_TAXRESULTS.out.tsv
         }
     }
 


### PR DESCRIPTION
<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] `CHANGELOG.md` is updated.

## Comment
This adresses issue #370
Option --skip_dada_addspecies was not compatible with --cut_its, but now this should be fixed.