### PR TITLE
error message when using --sbdiexport and --skip_taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-* [#376](https://github.com/nf-core/ampliseq/pull/376)- An error message will occur when `--sbdiexport` is used with `--skip_taxonomy` or `--skip_dada_addspecies`
+* [#377](https://github.com/nf-core/ampliseq/pull/377)- An error message will occur when `--sbdiexport` is used with `--skip_taxonomy` or `--skip_dada_addspecies`
 * [#375](https://github.com/nf-core/ampliseq/pull/375)- Updated documentation regarding not using curly brackets in `--extension` with `--single_end`
 * [#362](https://github.com/nf-core/ampliseq/pull/362)- Template update for nf-core/tools version 2.2, now requires nextflow version `>= 21.10.3`
 * [#374](https://github.com/nf-core/ampliseq/pull/374)- Cutadapt results can be now also viwed in the MultiQC report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+* [#376](https://github.com/nf-core/ampliseq/pull/376)- An error message will occur when `--sbdiexport` is used with `--skip_taxonomy` or `--skip_dada_addspecies`
 * [#375](https://github.com/nf-core/ampliseq/pull/375)- Updated documentation regarding not using curly brackets in `--extension` with `--single_end`
 * [#362](https://github.com/nf-core/ampliseq/pull/362)- Template update for nf-core/tools version 2.2, now requires nextflow version `>= 21.10.3`
 * [#374](https://github.com/nf-core/ampliseq/pull/374)- Cutadapt results can be now also viwed in the MultiQC report

--- a/docs/output.md
+++ b/docs/output.md
@@ -295,12 +295,12 @@ PICRUSt2 is preferentially applied to filtered data by QIIME2 but will use DADA2
 
 ### SBDI export
 
-You can use the `--sbdiexport` flag (or `sbdiexport = true` in a nextflow config file) to generate tab separated files in preparation for submission to the [Swedish Biodiversity Infrastructure (SBDI)](https://biodiversitydata.se/).
+You can use the `--sbdiexport` flag (or `sbdiexport: true` in a nextflow parameter file using `-params-file` in yml format) to generate tab separated files in preparation for submission to the [Swedish Biodiversity Infrastructure (SBDI)](https://biodiversitydata.se/).
 
 Tables are generated from the DADA2 denoising and taxonomy assignment steps.
 Each table, except `annotation.tsv`, corresponds to one tab in the [submission template](https://asv-portal.biodiversitydata.se/submit).
 See [`docs/usage.md`](docs/usage.md) for further information.
-Most of the fields in the template will not be populated by the export process, but if you run Ampliseq with a sample metadata table (`--metadata`) any fields corresponding to a field in the template will be used.
+Most of the fields in the template will not be populated by the export process, but if you run nf-core/ampliseq with a sample metadata table (`--metadata`) any fields corresponding to a field in the template will be used.
 
 <details markdown="1">
 <summary>Output files</summary>

--- a/lib/WorkflowAmpliseq.groovy
+++ b/lib/WorkflowAmpliseq.groovy
@@ -38,6 +38,11 @@ class WorkflowAmpliseq {
             System.exit(1)
         }
 
+        if (params.skip_taxonomy && params.sbdiexport) {
+            log.error "Incompatible parameters: `--sbdiexport` expects taxa annotation and therefore excludes `--skip_taxonomy`."
+            System.exit(1)
+        }
+
     }
 
     //

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -338,7 +338,7 @@
                 },
                 "skip_taxonomy": {
                     "type": "boolean",
-                    "description": "Skip taxonomic classification"
+                    "description": "Skip taxonomic classification. Incompatible with `--sbdiexport`"
                 },
                 "skip_dada_addspecies": {
                     "type": "boolean",


### PR DESCRIPTION
Using `--sbdiexport` and `--skip_taxonomy` lead to an error, because sbdiexport expect taxonomy classifications. I have added here a parameter check with a proper error message.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
