### PR TITLE
Add --seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#385](https://github.com/nf-core/ampliseq/pull/385) - `--skip_cutadapt` allows to skip primer trimmimg. Consequently, `--FW_primer` and `--RV_primer` are not obligatory any more, however primer sequences are still required with `--qiime_ref_taxonomy` and `--cut_dada_ref_taxonomy` (cuts reference with primer sequences).
 * [#390](https://github.com/nf-core/ampliseq/pull/390)- Add values to option `--cut_its`, specifying which ITS part to use. Also, add option `--its_partial <x>` to allow partial ITS sequences longer than given cutoff.
+* [#395](https://github.com/nf-core/ampliseq/pull/395)- `--seed` specifies the random seed.
 
 ### `Changed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -245,6 +245,7 @@ process {
     }
 
     withName: DADA2_TAXONOMY {
+        ext.seed = params.seed
         ext.args = [
             'minBoot = 50',
             params.pacbio ? "tryRC = TRUE" :
@@ -265,6 +266,7 @@ process {
     }
 
     withName: DADA2_ADDSPECIES {
+        ext.seed = params.seed
         ext.args = [
             'allowMultiple = FALSE, n = 1e5',
             params.pacbio ? "tryRC = TRUE" :

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -245,7 +245,7 @@ process {
     }
 
     withName: DADA2_TAXONOMY {
-        ext.seed = params.seed
+        ext.seed = "${params.seed}"
         ext.args = [
             'minBoot = 50',
             params.pacbio ? "tryRC = TRUE" :
@@ -266,7 +266,7 @@ process {
     }
 
     withName: DADA2_ADDSPECIES {
-        ext.seed = params.seed
+        ext.seed = "${params.seed}"
         ext.args = [
             'allowMultiple = FALSE, n = 1e5',
             params.pacbio ? "tryRC = TRUE" :

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -20,10 +20,11 @@ process DADA2_ADDSPECIES {
 
     script:
     def args = task.ext.args ?: ''
+    def seed = task.ext.seed ?: '100'
     """
     #!/usr/bin/env Rscript
     suppressPackageStartupMessages(library(dada2))
-    set.seed(100) # Initialize random number generator for reproducibility
+    set.seed($seed) # Initialize random number generator for reproducibility
 
     taxtable <- readRDS(\"$taxtable\")
 
@@ -48,7 +49,7 @@ process DADA2_ADDSPECIES {
 
     write.table(taxa, file = \"$outfile\", sep = "\\t", row.names = FALSE, col.names = TRUE, quote = FALSE, na = '')
 
-    write.table('addSpecies\t$args', file = "addSpecies.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
+    write.table('addSpecies\t$args\nseed\t$seed', file = "addSpecies.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
     writeLines(c("\\"${task.process}\\":", paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")),paste0("    dada2: ", packageVersion("dada2")) ), "versions.yml")
     """
 }

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -20,10 +20,11 @@ process DADA2_TAXONOMY {
 
     script:
     def args = task.ext.args ?: ''
+    def seed = task.ext.seed ?: '100'
     """
     #!/usr/bin/env Rscript
     suppressPackageStartupMessages(library(dada2))
-    set.seed(100) # Initialize random number generator for reproducibility
+    set.seed($seed) # Initialize random number generator for reproducibility
 
     seq <- getSequences(\"$fasta\", collapse = TRUE, silence = FALSE)
     taxa <- assignTaxonomy(seq, \"$database\", taxLevels = c("Domain", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"), $args, multithread = $task.cpus, verbose=TRUE, outputBootstraps = TRUE)
@@ -65,7 +66,7 @@ process DADA2_TAXONOMY {
     taxa_export <- cbind( ASV_ID = tx\$ASV_ID, taxa\$tax, confidence = tx\$confidence)
     saveRDS(taxa_export, "ASV_tax.rds")
 
-    write.table('assignTaxonomy\t$args', file = "assignTaxonomy.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
+    write.table('assignTaxonomy\t$args\nseed\t$seed', file = "assignTaxonomy.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
     writeLines(c("\\"${task.process}\\":", paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")),paste0("    dada2: ", packageVersion("dada2")) ), "versions.yml")
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,6 +49,7 @@ params {
     ignore_failed_trimming = false
     ignore_empty_input_files = false
     qiime_adonis_formula = null
+    seed              = 100
 
     // Skipping options
     skip_cutadapt          = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -127,6 +127,11 @@
                     "type": "boolean",
                     "description": "If data should be exported in SBDI (Swedish biodiversity infrastructure) Excel format."
                 },
+                "seed": {
+                    "type": "integer",
+                    "default": 100,
+                    "description": "Specifies the random seed."
+                },
                 "outdir": {
                     "type": "string",
                     "description": "Path to the output directory where the results will be saved.",


### PR DESCRIPTION
Adds `--seed` with default 100.

The way I implemented it now has a drawback: when re-running the pipeline with a different `--seed` and `-resume`, the processes will not re-run and use the previous seed. Because of that, I also added the seed into the log files of the runs. The implementation follows nf-core best practice, but I can also divert and implement it in a way that it will re-run processes when resuming with a different seed.

Closes https://github.com/nf-core/ampliseq/issues/386

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
