### PR TITLE
Rephrase warn/error messages with empty files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#384](https://github.com/nf-core/ampliseq/pull/384) - For QIIME2 beta diversity, make directory before execution.
 * [#394](https://github.com/nf-core/ampliseq/pull/394) - Prevent simultaneous usage of `--qiime_ref_taxonomy` and `--classifier`.
 * [#402](https://github.com/nf-core/ampliseq/pull/402)- Template update for nf-core/tools version 2.3
+* [#404](https://github.com/nf-core/ampliseq/pull/404) - Rephrase error message for empty input files and empty files after trimming with cutadapt.
 
 ### `Dependencies`
 

--- a/subworkflows/local/cutadapt_workflow.nf
+++ b/subworkflows/local/cutadapt_workflow.nf
@@ -60,8 +60,12 @@ workflow CUTADAPT_WORKFLOW {
         .collect()
         .subscribe {
             samples = it.join("\n")
-            log.error "the following samples had too small file size (<1KB) after trimming with cutadapt:\n$samples\nPlease check whether the correct primer sequences for trimming were supplied. Ignore that issue and samples using `--ignore_failed_trimming`."
-            params.ignore_failed_trimming ? { log.warn "Ignoring failed samples and continue!" } : System.exit(1)
+            if (params.ignore_failed_trimming) {
+                log.warn "The following samples had too small file size (<1KB) after trimming with cutadapt:\n$samples\nIgnoring failed samples and continue!\n"
+            } else {
+                log.error "The following samples had too small file size (<1KB) after trimming with cutadapt:\n$samples\nPlease check whether the correct primer sequences for trimming were supplied. Ignore that samples using `--ignore_failed_trimming`."
+                System.exit(1)
+            }
         }
 
     emit:

--- a/subworkflows/local/parse_input.nf
+++ b/subworkflows/local/parse_input.nf
@@ -149,8 +149,12 @@ workflow PARSE_INPUT {
             .collect()
             .subscribe {
                 samples = it.join("\n")
-                log.error "At least one input file for the following sample(s) was too small (<1KB):\n$samples\nEither remove those samples or ignore that issue and samples using `--ignore_empty_input_files`."
-                params.ignore_empty_input_files ? { log.warn "Ignoring failed samples and continue!" } : System.exit(1)
+                if (params.ignore_empty_input_files) {
+                    log.warn "At least one input file for the following sample(s) was too small (<1KB):\n$samples\nIgnoring failed samples and continue!\n"
+                } else { 
+                    log.error "At least one input file for the following sample(s) was too small (<1KB):\n$samples\nEither remove those samples or ignore that samples using `--ignore_empty_input_files`."
+                    System.exit(1)
+                }
             }
     }
 

--- a/subworkflows/local/parse_input.nf
+++ b/subworkflows/local/parse_input.nf
@@ -151,7 +151,7 @@ workflow PARSE_INPUT {
                 samples = it.join("\n")
                 if (params.ignore_empty_input_files) {
                     log.warn "At least one input file for the following sample(s) was too small (<1KB):\n$samples\nIgnoring failed samples and continue!\n"
-                } else { 
+                } else {
                     log.error "At least one input file for the following sample(s) was too small (<1KB):\n$samples\nEither remove those samples or ignore that samples using `--ignore_empty_input_files`."
                     System.exit(1)
                 }


### PR DESCRIPTION
Closes https://github.com/nf-core/ampliseq/issues/399

I have rephrased the messages when encountering empty input files or empty files after trimming with cutadapt. Depending on the parameters given its either an error message or when ignoring the empty files, a warning message only.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
