### PR TITLE
Fix taxref_reformat_unite.sh

### DIFF
--- a/bin/taxref_reformat_unite.sh
+++ b/bin/taxref_reformat_unite.sh
@@ -8,7 +8,7 @@ tar xzf *gz
 
 # Remove leading "k__" and the like, remove ranks classified as "unknown",
 # and replace space with underscore to create assignTaxonomy.fna
-cat */*.fasta | sed '/^>/s/;[ks]__.*//' | sed '/^>/s/[a-z]__unidentified//g' | sed '/^>/s/[a-z]__//g' | sed '/^>/s/ /_/g' | sed 's/>.*|/&Eukaryota;/' > assignTaxonomy.fna
+cat */*[[:digit:]].fasta | sed '/^>/s/;[ks]__.*//' | sed '/^>/s/[a-z]__unidentified//g' | sed '/^>/s/[a-z]__//g' | sed '/^>/s/ /_/g' | sed 's/>.*|/&Eukaryota;/' > assignTaxonomy.fna
 
 # Reformat to addSpecies format
 sed 's/>\([^|]\+\)|\([^|]\+|[^|]\+\)|.*/>\2 \1/' assignTaxonomy.fna | sed '/^>/s/_/ /g' > addSpecies.fna


### PR DESCRIPTION
Fix taxref_reformat_unite.sh so it uses just the SH fasta file, and ignores the dev file present in the same folder after download from Unite. Thjs adresses #406 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
