### PR TITLE
Add its1 option to cut_its

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 * [#385](https://github.com/nf-core/ampliseq/pull/385) - `--skip_cutadapt` allows to skip primer trimmimg.
-* [#390](https://github.com/nf-core/ampliseq/pull/390) - Add values to option `--cut_its`, specifying which ITS part to use. Also, add option `--its_partial <x>` to allow partial ITS sequences longer than given cutoff.
+* [#390](https://github.com/nf-core/ampliseq/pull/390), [#408](https://github.com/nf-core/ampliseq/pull/408) - Add values to option `--cut_its`, specifying which ITS part to use. Also, add option `--its_partial <x>` to allow partial ITS sequences longer than given cutoff.
 * [#395](https://github.com/nf-core/ampliseq/pull/395) - `--seed` specifies the random seed.
 * [#396](https://github.com/nf-core/ampliseq/pull/396) - Barrnap annotates ASV sequences for SSU's, it can be skipped with `--skip_barrnap`. `--filter_ssu` takes a comma separated list of "bac,arc,mito,euk" and enables SSU filtering depending on Barrnap (default: off).
 * [#397](https://github.com/nf-core/ampliseq/pull/397) - Complement README.md with links to the nf-core bytesize 25 (nf-core/ampliseq).
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#384](https://github.com/nf-core/ampliseq/pull/384) - For QIIME2 beta diversity, make directory before execution.
 * [#394](https://github.com/nf-core/ampliseq/pull/394) - Prevent simultaneous usage of `--qiime_ref_taxonomy` and `--classifier`.
-* [#402](https://github.com/nf-core/ampliseq/pull/402)- Template update for nf-core/tools version 2.3
+* [#402](https://github.com/nf-core/ampliseq/pull/402) - Template update for nf-core/tools version 2.3
 * [#405](https://github.com/nf-core/ampliseq/pull/405) - Fix omitting taxonomic filtering (QIIME2_FILTERTAXA).
 * [#404](https://github.com/nf-core/ampliseq/pull/404) - Rephrase error message for empty input files and empty files after trimming with cutadapt.
 * [#407](https://github.com/nf-core/ampliseq/pull/407) - Fix reformatting script for Unite.

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -247,7 +247,8 @@ process {
     withName: ITSX_CUTASV {
         ext.args = [
             '-t all --preserve T --date F --positions F --graphical F',
-            params.cut_its == "its2" ? "--save_regions ITS2" : "--save_regions none",
+            params.cut_its == "its1" ? "--save_regions ITS1" :
+                params.cut_its == "its2" ? "--save_regions ITS2" : "--save_regions none",
             params.its_partial != 0 ? "--partial ${params.its_partial}" : ""
         ].join(' ').trim()
         publishDir = [

--- a/docs/output.md
+++ b/docs/output.md
@@ -133,9 +133,9 @@ Optionally, the ITS region can be extracted from each ASV sequence using ITSx, a
 
 * `itsx/`
     * `ASV_ITS_seqs.full.fasta`: Fasta file with full ITS region from each ASV sequence.
-    * `ASV_ITS_seqs.ITS2.fasta`: If using --cut_its "its2"; fasta file with ITS2 region from each ASV sequence.
+    * `ASV_ITS_seqs.ITS1.fasta` or `ASV_ITS_seqs.ITS2.fasta`: If using --cut_its "its1" or --cut_its "its2"; fasta file with ITS1 or ITS2 region from each ASV sequence.
     * `ASV_ITS_seqs.full_and_partial.fasta`: If using --its_partial; fasta file with full and partial ITS regions from each ASV sequence.
-    * `ASV_ITS_seqs.ITS2.full_and_partial.fasta`: If using --cut_its "its2" and --its_partial; fasta file with complete and partial ITS2 regions from each ASV sequence.
+    * `ASV_ITS_seqs.ITS1.full_and_partial.fasta` or `ASV_ITS_seqs.ITS2.full_and_partial.fasta`: If using --cut_its "its1" or --cut_its "its2" and --its_partial; fasta file with complete and partial ITS1 or ITS2 regions from each ASV sequence.
     * `ASV_ITS_seqs.summary.txt`: Summary information from ITSx.
     * `ITSx.args.txt`: File with parameters passed to ITSx.
 * `dada2/`

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -62,12 +62,13 @@
                 },
                 "cut_its": {
                     "type": "string",
-                    "help_text": "If data is long read ITS sequences, that need to be cut to ITS region (full ITS or only ITS2) for taxonomy assignment.",
-                    "description": "Part of ITS region to use for taxonomy assignment: \"full\" or \"its2\"",
+                    "help_text": "If data is long read ITS sequences, that need to be cut to ITS region (full ITS, only ITS1, or only ITS2) for taxonomy assignment.",
+                    "description": "Part of ITS region to use for taxonomy assignment: \"full\", \"its1\", or \"its2\"",
                     "default": "none",
                     "enum": [
                         "none",
                         "full",
+                        "its1",
                         "its2"
                     ]
                 },

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -368,6 +368,9 @@ workflow AMPLISEQ {
             if (params.cut_its == "full") {
                 outfile = params.its_partial ? "ASV_ITS_seqs.full_and_partial.fasta" : "ASV_ITS_seqs.full.fasta"
             }
+            else if (params.cut_its == "its1") {
+                outfile =  params.its_partial ? "ASV_ITS_seqs.ITS1.full_and_partial.fasta" : "ASV_ITS_seqs.ITS1.fasta"
+            }
             else if (params.cut_its == "its2") {
                 outfile =  params.its_partial ? "ASV_ITS_seqs.ITS2.full_and_partial.fasta" : "ASV_ITS_seqs.ITS2.fasta"
             }


### PR DESCRIPTION
The option "its1" is added to --cut_its, in addition to "its2" and "full" that were added in #390 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
