### PR TITLE
add --skip_dada_quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - [#429](https://github.com/nf-core/ampliseq/pull/429) - `--cutadapt_min_overlap` sets cutadapt's global minimum overlap (`-O`) and `--cutadapt_max_error_rate` sets cutadapt's global maximum error rate (`-e`) for trimming primer sequences.
-- [#431](https://github.com/nf-core/ampliseq/pull/431) - `--skip_dada_quality` allows to skip quality check with DADA2. This is not only allowed when `--trunclenf` and `--trunclenr` are set.
+- [#431](https://github.com/nf-core/ampliseq/pull/431) - `--skip_dada_quality` allows to skip quality check with DADA2. This is only allowed when `--trunclenf` and `--trunclenr` are set.
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - [#429](https://github.com/nf-core/ampliseq/pull/429) - `--cutadapt_min_overlap` sets cutadapt's global minimum overlap (`-O`) and `--cutadapt_max_error_rate` sets cutadapt's global maximum error rate (`-e`) for trimming primer sequences.
+- [#431](https://github.com/nf-core/ampliseq/pull/431) - `--skip_dada_quality` allows to skip quality check with DADA2. This is not only allowed when `--trunclenf` and `--trunclenr` are set.
 
 ### `Changed`
 

--- a/conf/test_multi.config
+++ b/conf/test_multi.config
@@ -21,6 +21,9 @@ params {
 
     // Input data
     skip_cutadapt = true
+    trunclenf = 200
+    trunclenr = 150
+    skip_dada_quality = true
     dada_ref_taxonomy = "rdp=18"
     skip_dada_addspecies = true
     input = "https://raw.githubusercontent.com/nf-core/test-datasets/ampliseq/samplesheets/Samplesheet_multi.tsv"

--- a/lib/WorkflowAmpliseq.groovy
+++ b/lib/WorkflowAmpliseq.groovy
@@ -23,6 +23,11 @@ class WorkflowAmpliseq {
             System.exit(1)
         }
 
+        if ( params.skip_dada_quality && (params.trunclenf == null || params.trunclenr == null) ) {
+            log.error "Incompatible parameters: `--skip_dada_quality` may not be used without setting `--trunclenf` and `--trunclenr`."
+            System.exit(1)
+        }
+
         if (params.dada_tax_agglom_min > params.dada_tax_agglom_max) {
             log.error "Incompatible parameters: `--dada_tax_agglom_min` may not be greater than `--dada_tax_agglom_max`."
             System.exit(1)

--- a/nextflow.config
+++ b/nextflow.config
@@ -56,6 +56,7 @@ params {
 
     // Skipping options
     skip_cutadapt          = false
+    skip_dada_quality      = false
     skip_barrnap           = false
     skip_qiime             = false
     skip_fastqc            = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -379,7 +379,7 @@
                 "skip_dada_quality": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Skip quality check with DADA2. This is not only allowed when `--trunclenf` and `--trunclenr` are set."
+                    "description": "Skip quality check with DADA2. Can only be skipped when `--trunclenf` and `--trunclenr` are set."
                 },
                 "skip_barrnap": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -376,6 +376,11 @@
                     "default": false,
                     "description": "Skip primer trimming with cutadapt. This is not recommended! Use only in case primer sequences were removed before and the data does not contain any primer sequences."
                 },
+                "skip_dada_quality": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Skip quality check with DADA2. This is not only allowed when `--trunclenf` and `--trunclenr` are set."
+                },
                 "skip_barrnap": {
                     "type": "boolean",
                     "default": false,

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -217,8 +217,11 @@ workflow AMPLISEQ {
             .mix ( ch_all_trimmed_rv )
             .set { ch_all_trimmed_reads }
     }
-    DADA2_QUALITY ( ch_all_trimmed_reads )
-    DADA2_QUALITY.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn it.baseName.toString().replace("WARNING ","DADA2_QUALITY: ") }
+
+    if ( !params.skip_dada_quality ) {
+        DADA2_QUALITY ( ch_all_trimmed_reads )
+        DADA2_QUALITY.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn it.baseName.toString().replace("WARNING ","DADA2_QUALITY: ") }
+    }
 
     //find truncation values in case they are not supplied
     if ( find_truncation_values ) {


### PR DESCRIPTION
Addresses user feedback that the visualization of read quality parameters can be quite resource consuming and is not always needed. 
Also, it was mentioned in https://github.com/nf-core/ampliseq/issues/422.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
