### PR TITLE
change plotQualityProfile settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#432](https://github.com/nf-core/ampliseq/pull/432) - The number of records to sample from a fastq file was decreased from 5e+06 to 5e+04 for plotQualityProfile (DADA2_QUALITY), therefore a smaller subset of reads is sampled for determining `--trunlenf` and `--trunclenr`. This should make the process more robust also from larger data sets.
+
 ### `Fixed`
 
 - [#428](https://github.com/nf-core/ampliseq/pull/428) - Fixed samplesheet sampleID entries, now allows dashes.

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -118,7 +118,7 @@ process {
     }
 
     withName: DADA2_QUALITY {
-        ext.args = ", n = 5e+06, aggregate = TRUE"
+        ext.args = ", n = 5e+04, aggregate = TRUE"
         publishDir = [
             [
                 path: { "${params.outdir}/dada2/QC" },


### PR DESCRIPTION
The number of records to sample from a fastq file is herein decreased from `5e+06` to `5e+04` for plotQualityProfile (DADA2_QUALITY), therefore a smaller subset of reads is sampled for determining `--trunlenf` and `--trunclenr`. This should make the process more robust also from larger data sets.
This was also mentioned in https://github.com/nf-core/ampliseq/issues/422

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
