### PR TITLE
randomize samples for DADA2's learnErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#445](https://github.com/nf-core/ampliseq/pull/445) - The minimum number of total bases to use for error rate learning by default is 1e8 (DADA2, learnErrors, nbases). Previously, samples were read in the provided order until enough reads were obtained (DADA2, learnErrors, randomize=FALSE). Now, samples are picked at random from those provided (DADA2, learnError, randomize=TRUE) and a seed is set.
+
 ### `Fixed`
 
 ### `Dependencies`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -160,8 +160,9 @@ process {
     }
 
     withName: DADA2_ERR {
+        ext.seed = "${params.seed}"
         ext.args = [
-            'nbases = 1e8, nreads = NULL, randomize = FALSE, MAX_CONSIST = 10, OMEGA_C = 0, qualityType = "Auto"',
+            'nbases = 1e8, nreads = NULL, randomize = TRUE, MAX_CONSIST = 10, OMEGA_C = 0, qualityType = "Auto"',
             params.pacbio ? "errorEstimationFunction = PacBioErrfun" : "errorEstimationFunction = loessErrfun"
         ].join(',').replaceAll('(,)*$', "")
         publishDir = [

--- a/modules/local/dada2_err.nf
+++ b/modules/local/dada2_err.nf
@@ -20,10 +20,12 @@ process DADA2_ERR {
 
     script:
     def args = task.ext.args ?: ''
+    def seed = task.ext.seed ?: '100'
     if (!meta.single_end) {
         """
         #!/usr/bin/env Rscript
         suppressPackageStartupMessages(library(dada2))
+        set.seed($seed) # Initialize random number generator for reproducibility
 
         fnFs <- sort(list.files(".", pattern = "_1.filt.fastq.gz", full.names = TRUE))
         fnRs <- sort(list.files(".", pattern = "_2.filt.fastq.gz", full.names = TRUE))
@@ -58,6 +60,7 @@ process DADA2_ERR {
         """
         #!/usr/bin/env Rscript
         suppressPackageStartupMessages(library(dada2))
+        set.seed($seed) # Initialize random number generator for reproducibility
 
         fnFs <- sort(list.files(".", pattern = ".filt.fastq.gz", full.names = TRUE))
 


### PR DESCRIPTION
As described in the CHANGELOG:

> The minimum number of total bases to use for error rate learning by default is 1e8 (DADA2, learnErrors, nbases). Previously, samples were read in the provided order until enough reads were obtained (DADA2, learnErrors, randomize=FALSE). Now, samples are picked at random from those provided (DADA2, learnError, randomize=TRUE) and a seed is set.

This is to allow larger runs (e.g. NovaSeq) to obtain random (but reproducible with a seed) samples instead of ordered input.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
