### PR TITLE
Add SH information to sbdi export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#444](https://github.com/nf-core/ampliseq/pull/444) - Updated parameter documentation.
 
 ### `Fixed`
+
 - [#448](https://github.com/nf-core/ampliseq/pull/448) - Updated SBDI export scripts to include Unite species hypothesis information if available.
 
 ### `Dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#444](https://github.com/nf-core/ampliseq/pull/444) - Updated parameter documentation.
 
 ### `Fixed`
+- [#448](https://github.com/nf-core/ampliseq/pull/448) - Updated SBDI export scripts to include Unite species hypothesis information if available.
 
 ### `Dependencies`
 

--- a/bin/add_sh_to_taxonomy.py
+++ b/bin/add_sh_to_taxonomy.py
@@ -3,7 +3,7 @@
 
 # Adds UNITE species hypothesis (SH) information to ASV table based on vsearch usearch_global results in blast6 format.
 #
-# Usage: add_sh_to_taxonomy.py <seq2sh.tsv> <SHs.tax> <tax.tsv> <blastout.tab> <outfile> [--species]
+# Usage: add_sh_to_taxonomy.py <seq2sh.tsv> <SHs.tax> <tax.tsv> <blastout.tab> <outfile>
 #   Input:
 #          <seq2sh.tsv>   : List with sequence to SH matchings, SH level 1.5, for each sequence in
 #                           the database used by vsearch. Each row should contain database sequence
@@ -15,8 +15,6 @@
 
 import sys
 import pandas as pd
-
-with_species = False
 
 # Argument check
 if len(sys.argv) != 6:
@@ -32,6 +30,8 @@ seq2sh = pd.read_csv(sys.argv[1], sep='\t', header=None, index_col=0, skiprows=N
 shtax = pd.read_csv(sys.argv[2], sep='\t', header=None, index_col=0, skiprows=None, compression='bz2')
 # Replace taxonid with Domain = "Eukaryota"
 shtax.loc[:,1] = 'Eukaryota'
+# Remove genus from species name
+shtax.loc[:,8] = shtax.loc[:,8].str.split(" ",1).str[1]
 
 # Read taxonomy table
 # Determine number of taxonomy levels from header

--- a/bin/sbdiexport.R
+++ b/bin/sbdiexport.R
@@ -115,9 +115,12 @@ emof %>% write_tsv("emof.tsv", na = '')
 # asv-table
 asvtax <- asvs %>%
     inner_join(taxonomy, by = 'ASV_ID') %>%
+    mutate(SH = if("SH" %in% colnames(.)) SH else '') %>%
+    relocate(SH, .after = Species) %>%
     rename_with(tolower, Domain:Species) %>%
     rename(
         specificEpithet = species,
+        otu = SH,
         asv_id_alias = ASV_ID,
         DNA_sequence = sequence
     ) %>%
@@ -125,9 +128,9 @@ asvtax <- asvs %>%
         domain = str_remove(domain, 'Reversed:_'),
         associatedSequences = '',
         infraspecificEpithet = '',
-        otu = '',
         kingdom = ifelse(is.na(kingdom), 'Unassigned', kingdom)
     ) %>%
+    relocate(otu, .after = infraspecificEpithet) %>%
     relocate(DNA_sequence:associatedSequences, .before = domain) %>%
     select(-confidence, -domain) %>%
     write_tsv("asv-table.tsv", na = '')

--- a/bin/sbdiexportreannotate.R
+++ b/bin/sbdiexportreannotate.R
@@ -2,20 +2,17 @@
 
 # sbdiexportreannotate.R
 #
-# A script that collates taxonomy data from Ampliseq to produce an Excel file as close
-# to ready for submission to the Swedish Biodiversity Data Infrastructure
-# (SBDI) as possible.
+# A script that collates taxonomy data from Ampliseq to produce an updated
+# annotation tsv file as close to ready for submission to the Swedish
+# Biodiversity Data Infrastructure (SBDI) as possible.
 #
-# The script expects the following input file to be present in the directory:
-# ASV_tax_species.tsv.
-#
-# It also expects the following argument: dbversion
+# The script expects the following arguments: dbversion, ASV_tax_species.tsv
 #
 # Author: daniel.lundin@lnu.se
 
 suppressPackageStartupMessages(library(tidyverse))
 
-# Get the library layout and primers from the command line
+# Get dbversion and taxonomy file from the command line
 args            <- commandArgs(trailingOnly=TRUE)
 dbversion       <- args[1]
 taxfile         <- args[2]
@@ -23,45 +20,51 @@ taxfile         <- args[2]
 taxonomy <- read.delim(taxfile, sep = '\t', stringsAsFactors = FALSE)
 
 taxonomy %>%
+    mutate(SH = if("SH" %in% colnames(.)) SH else '') %>%
+    relocate(SH, .after = Species) %>%
     rename_with(tolower, Domain:Species) %>%
     rename(
         asv_id_alias = ASV_ID,
         asv_sequence = sequence,
         specificEpithet = species,
+        otu = SH,
         annotation_confidence = confidence
     ) %>%
     mutate(
         infraspecificEpithet = '',
-        otu = '',
         domain = str_remove(domain, 'Reversed:_'),
         scientificName = case_when(
-            !is.na(specificEpithet) ~ sprintf("%s %s", genus, specificEpithet),
-            !is.na(genus)           ~ sprintf("%s", genus),
-            !is.na(family)          ~ sprintf("%s", family),
-            !is.na(order)           ~ sprintf("%s", order),
-            !is.na(class)           ~ sprintf("%s", class),
-            !is.na(phylum)          ~ sprintf("%s", phylum),
-            !is.na(kingdom)          ~ sprintf("%s", kingdom),
-            TRUE                    ~ 'Unassigned'
+            !(is.na(specificEpithet) | specificEpithet == '') ~ sprintf("%s %s", genus, specificEpithet),
+            !(is.na(genus)   | genus == '')                   ~ sprintf("%s", genus),
+            !(is.na(family)  | family == '')                  ~ sprintf("%s", family),
+            !(is.na(order)   | order == '')                   ~ sprintf("%s", order),
+            !(is.na(class)   | class == '')                   ~ sprintf("%s", class),
+            !(is.na(phylum)  | phylum == '')                  ~ sprintf("%s", phylum),
+            !(is.na(kingdom) | kingdom == '')                 ~ sprintf("%s", kingdom),
+            TRUE                                              ~ 'Unassigned'
         ),
         taxonRank = case_when(
-            !is.na(specificEpithet) ~ 'species',
-            !is.na(genus)           ~ 'genus',
-            !is.na(family)          ~ 'family',
-            !is.na(order)           ~ 'order',
-            !is.na(class)           ~ 'class',
-            !is.na(phylum)          ~ 'phylum',
-            !is.na(kingdom)         ~ 'kingdom',
-            TRUE                    ~ 'kingdom'
+            !(is.na(specificEpithet) | specificEpithet == '') ~ 'species',
+            !(is.na(genus)   | genus == '')                   ~ 'genus',
+            !(is.na(family)  | family == '')                  ~ 'family',
+            !(is.na(order)   | order == '')                   ~ 'order',
+            !(is.na(class)   | class == '')                   ~ 'class',
+            !(is.na(phylum)  | phylum == '')                  ~ 'phylum',
+            !(is.na(kingdom) | kingdom == '')                 ~ 'kingdom',
+            TRUE                                              ~ 'kingdom'
         ),
         date_identified = as.character(lubridate::today()),
         reference_db = dbversion,
-        annotation_algorithm = 'DADA2:assignTaxonomy:addSpecies',
+        annotation_algorithm = case_when(
+            (!(is.na(otu) | otu == '')) ~ 'DADA2:assignTaxonomy:addSpecies,Ampliseq:addsh',
+            TRUE                        ~ 'DADA2:assignTaxonomy:addSpecies'
+        ),
         identification_references = 'https://docs.biodiversitydata.se/analyse-data/molecular-tools/#taxonomy-annotation',
         taxon_remarks = '',
         kingdom = ifelse(is.na(kingdom), 'Unassigned', kingdom)
     ) %>%
     relocate(asv_sequence, .after = asv_id_alias) %>%
     relocate(infraspecificEpithet:identification_references, .after = specificEpithet) %>%
+    relocate(otu, .after = infraspecificEpithet) %>%
     select(-domain) %>%
     write_tsv("annotation.tsv", na = '')

--- a/bin/sbdiexportreannotate.R
+++ b/bin/sbdiexportreannotate.R
@@ -56,7 +56,7 @@ taxonomy %>%
         date_identified = as.character(lubridate::today()),
         reference_db = dbversion,
         annotation_algorithm = case_when(
-            (!(is.na(otu) | otu == '')) ~ 'DADA2:assignTaxonomy:addSpecies,Ampliseq:addsh',
+            (!(is.na(otu) | otu == '')) ~ 'Ampliseq:addsh',
             TRUE                        ~ 'DADA2:assignTaxonomy:addSpecies'
         ),
         identification_references = 'https://docs.biodiversitydata.se/analyse-data/molecular-tools/#taxonomy-annotation',

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -601,9 +601,9 @@ workflow AMPLISEQ {
     // MODULE: Export data in SBDI's (Swedish biodiversity infrastructure) format
     //
     if ( params.sbdiexport ) {
-        SBDIEXPORT ( ch_dada2_asv, DADA2_ADDSPECIES.out.tsv, ch_metadata  )
+        SBDIEXPORT ( ch_dada2_asv, ch_dada2_tax, ch_metadata  )
         ch_versions = ch_versions.mix(SBDIEXPORT.out.versions.first())
-        SBDIEXPORTREANNOTATE ( DADA2_ADDSPECIES.out.tsv )
+        SBDIEXPORTREANNOTATE ( ch_dada2_tax )
     }
 
     CUSTOM_DUMPSOFTWAREVERSIONS (

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -601,7 +601,7 @@ workflow AMPLISEQ {
     // MODULE: Export data in SBDI's (Swedish biodiversity infrastructure) format
     //
     if ( params.sbdiexport ) {
-        SBDIEXPORT ( ch_dada2_asv, ch_dada2_tax, ch_metadata  )
+        SBDIEXPORT ( ch_dada2_asv, ch_dada2_tax, ch_metadata )
         ch_versions = ch_versions.mix(SBDIEXPORT.out.versions.first())
         SBDIEXPORTREANNOTATE ( ch_dada2_tax )
     }


### PR DESCRIPTION
Modified SBDI-export scripts to add SH information, if available. 
Input channels to SBDIEXPORT and SBDIEXPORTREANNOTATE are changed from DADA2_ADDSPECIES.out.tsv to ch_dada2_tax to capture the SH information. The tests I've done run as expected, but please let me know if you think this change will break anything.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
