### PR TITLE
fix --metadata_category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#451](https://github.com/nf-core/ampliseq/pull/451) - Pairwise statistics will be now performed on a subset of metadata columns specified with `--metadata_category` instead of ignoring that setting.
+- [#451](https://github.com/nf-core/ampliseq/pull/451) - Replace busybox with Ubuntu base image for GCP support.
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#448](https://github.com/nf-core/ampliseq/pull/448) - Pairwise statistics will be now performed on a subset of metadata columns specified with `--metadata_category` instead of ignoring that setting.
+- [#451](https://github.com/nf-core/ampliseq/pull/451) - Pairwise statistics will be now performed on a subset of metadata columns specified with `--metadata_category` instead of ignoring that setting.
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#448](https://github.com/nf-core/ampliseq/pull/448) - Pairwise statistics will be now performed on a subset of metadata columns specified with `--metadata_category` instead of ignoring that setting.
+
 ### `Dependencies`
 
 ### `Removed`

--- a/modules/local/format_taxonomy.nf
+++ b/modules/local/format_taxonomy.nf
@@ -3,8 +3,8 @@ process FORMAT_TAXONOMY {
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
-        'biocontainers/biocontainers:v1.2.0_cv1' }"
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'ubuntu:20.04' }"
 
     input:
     path(database)

--- a/modules/local/format_taxonomy_qiime.nf
+++ b/modules/local/format_taxonomy_qiime.nf
@@ -4,8 +4,8 @@ process FORMAT_TAXONOMY_QIIME {
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
-        'biocontainers/biocontainers:v1.2.0_cv1' }"
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'ubuntu:20.04' }"
 
     input:
     path(database)

--- a/modules/local/metadata_all.nf
+++ b/modules/local/metadata_all.nf
@@ -9,24 +9,17 @@ process METADATA_ALL {
 
     input:
     path(metadata)
-    val(metadata_category)
 
     output:
     stdout
 
     script:
-    if( !metadata_category ) {
-        """
-        metadata_all.r ${metadata}
+    """
+    metadata_all.r ${metadata}
 
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            R: \$(R --version 2>&1 | sed -n 1p | sed 's/R version //' | sed 's/ (.*//')
-        END_VERSIONS
-        """
-    } else {
-        """
-        printf ${metadata_category}
-        """
-    }
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        R: \$(R --version 2>&1 | sed -n 1p | sed 's/R version //' | sed 's/ (.*//')
+    END_VERSIONS
+    """
 }

--- a/modules/local/qiime2_diversity_alpha.nf
+++ b/modules/local/qiime2_diversity_alpha.nf
@@ -6,38 +6,26 @@ process QIIME2_DIVERSITY_ALPHA {
     container "quay.io/qiime2/core:2021.8"
 
     input:
-    tuple path(metadata), path(core), val(category)
+    tuple path(metadata), path(core)
 
     output:
     path("alpha_diversity/*"), emit: alpha
     path "versions.yml"      , emit: versions
 
     script:
-    if ( category.length() > 0 ) {
-        """
-        export XDG_CONFIG_HOME="\${PWD}/HOME"
+    """
+    export XDG_CONFIG_HOME="\${PWD}/HOME"
 
-        qiime diversity alpha-group-significance \
-            --i-alpha-diversity ${core} \
-            --m-metadata-file ${metadata} \
-            --o-visualization ${core.baseName}-vis.qzv
-        qiime tools export --input-path ${core.baseName}-vis.qzv \
-            --output-path "alpha_diversity/${core.baseName}"
+    qiime diversity alpha-group-significance \
+        --i-alpha-diversity ${core} \
+        --m-metadata-file ${metadata} \
+        --o-visualization ${core.baseName}-vis.qzv
+    qiime tools export --input-path ${core.baseName}-vis.qzv \
+        --output-path "alpha_diversity/${core.baseName}"
 
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            qiime2: \$( qiime --version | sed -e "s/q2cli version //g" | tr -d '`' | sed -e "s/Run qiime info for more version details.//g" )
-        END_VERSIONS
-        """
-    } else {
-        """
-        mkdir alpha_diversity
-        echo "" > "alpha_diversity/WARNING No column in ${metadata.baseName} seemed suitable.txt"
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            qiime2: \$( qiime --version | sed -e "s/q2cli version //g" | tr -d '`' | sed -e "s/Run qiime info for more version details.//g" )
-        END_VERSIONS
-        """
-    }
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        qiime2: \$( qiime --version | sed -e "s/q2cli version //g" | tr -d '`' | sed -e "s/Run qiime info for more version details.//g" )
+    END_VERSIONS
+    """
 }

--- a/modules/local/qiime2_diversity_beta.nf
+++ b/modules/local/qiime2_diversity_beta.nf
@@ -1,5 +1,5 @@
 process QIIME2_DIVERSITY_BETA {
-    tag "${core.baseName}"
+    tag "${core.baseName} - ${category}"
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
@@ -13,37 +13,21 @@ process QIIME2_DIVERSITY_BETA {
     path "versions.yml"     , emit: versions
 
     script:
-    if ( category.length() > 0 ) {
-        """
-        export XDG_CONFIG_HOME="\${PWD}/HOME"
+    """
+    export XDG_CONFIG_HOME="\${PWD}/HOME"
 
-        IFS=',' read -r -a metacategory <<< \"$category\"
-        for j in \"\${metacategory[@]}\"
-        do
-            qiime diversity beta-group-significance \
-                --i-distance-matrix ${core} \
-                --m-metadata-file ${metadata} \
-                --m-metadata-column \"\$j\" \
-                --o-visualization ${core.baseName}-\$j.qzv \
-                --p-pairwise
-            qiime tools export --input-path ${core.baseName}-\$j.qzv \
-                --output-path beta_diversity/${core.baseName}-\$j
-        done
+    qiime diversity beta-group-significance \
+        --i-distance-matrix ${core} \
+        --m-metadata-file ${metadata} \
+        --m-metadata-column \"${category}\" \
+        --o-visualization ${core.baseName}-${category}.qzv \
+        --p-pairwise
+    qiime tools export --input-path ${core.baseName}-${category}.qzv \
+        --output-path beta_diversity/${core.baseName}-${category}
 
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            qiime2: \$( qiime --version | sed -e "s/q2cli version //g" | tr -d '`' | sed -e "s/Run qiime info for more version details.//g" )
-        END_VERSIONS
-        """
-    } else {
-        """
-        mkdir beta_diversity
-        echo "" > "beta_diversity/WARNING No column in ${metadata.baseName} seemed suitable.txt"
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            qiime2: \$( qiime --version | sed -e "s/q2cli version //g" | tr -d '`' | sed -e "s/Run qiime info for more version details.//g" )
-        END_VERSIONS
-        """
-    }
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        qiime2: \$( qiime --version | sed -e "s/q2cli version //g" | tr -d '`' | sed -e "s/Run qiime info for more version details.//g" )
+    END_VERSIONS
+    """
 }

--- a/modules/local/rename_raw_data_files.nf
+++ b/modules/local/rename_raw_data_files.nf
@@ -4,8 +4,8 @@ process RENAME_RAW_DATA_FILES {
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
-        'biocontainers/biocontainers:v1.2.0_cv1' }"
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(reads)

--- a/subworkflows/local/qiime2_ancom.nf
+++ b/subworkflows/local/qiime2_ancom.nf
@@ -17,12 +17,16 @@ workflow QIIME2_ANCOM {
 
     main:
     //Filter ASV table to get rid of samples that have no metadata values
-    QIIME2_FILTERASV ( ch_metadata, ch_asv, ch_metacolumn_all )
+    ch_metadata
+        .combine( ch_asv )
+        .combine( ch_metacolumn_all )
+        .set{ ch_for_filterasv }
+    QIIME2_FILTERASV ( ch_for_filterasv )
 
     //ANCOM on various taxonomic levels
     ch_taxlevel = Channel.from( tax_agglom_min..tax_agglom_max )
     ch_metadata
-        .combine( QIIME2_FILTERASV.out.qza.flatten() )
+        .combine( QIIME2_FILTERASV.out.qza )
         .combine( ch_tax )
         .combine( ch_taxlevel )
         .set{ ch_for_ancom_tax }

--- a/subworkflows/local/qiime2_diversity.nf
+++ b/subworkflows/local/qiime2_diversity.nf
@@ -37,10 +37,9 @@ workflow QIIME2_DIVERSITY {
         //Print warning if rarefaction depth is <10000
         QIIME2_DIVERSITY_CORE.out.depth.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn it.baseName.toString().replace("WARNING ","QIIME2_DIVERSITY_CORE: ") }
 
-        //alpha_diversity ( ch_metadata, DIVERSITY_CORE.out.qza, ch_metacolumn_all )
+        //alpha_diversity ( ch_metadata, DIVERSITY_CORE.out.qza )
         ch_metadata
             .combine( QIIME2_DIVERSITY_CORE.out.vector.flatten() )
-            .combine( ch_metacolumn_all )
             .set{ ch_to_diversity_alpha }
         QIIME2_DIVERSITY_ALPHA ( ch_to_diversity_alpha )
 


### PR DESCRIPTION
Closes https://github.com/nf-core/ampliseq/issues/447

While making sure that `--metadata_category` propagates to all relevant processes correctly (which was before not given), I changed `ch_metacolumn_all` & `ch_metacolumn_pairwise` to contain one value per channel entry instead of one comma separated channel entry. The latter than also means that parallelization is maximized. I touched here code from the very beginning of ampliseq and I hope it did improve overall.

Edit: because the tests fail due to container problems I also fixed https://github.com/nf-core/mag/pull/315 that followed https://github.com/nf-core/rnaseq/issues/764.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
