### PR TITLE
Make dada2 taxlevels flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#456](https://github.com/nf-core/ampliseq/pull/456) - An optional ASV length filter can be activated using `--min_len_asv <int>` and/or `--max_len_asv <int>`.
 - [#458](https://github.com/nf-core/ampliseq/pull/458) - Samplesheet, ASV fasta file, and/or metadata sheet is now exported into `<results>/input/`
+- [#460](https://github.com/nf-core/ampliseq/pull/460) - Taxonomic ranks for DADA2 taxonomic classification can be now adjusted using `--dada_assign_taxlevels <comma separated string>`.
 
 ### `Changed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -286,6 +286,7 @@ process {
 
     withName: DADA2_TAXONOMY {
         ext.seed = "${params.seed}"
+        ext.taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" : ""
         ext.args = [
             'minBoot = 50',
             params.pacbio ? "tryRC = TRUE" :
@@ -307,6 +308,7 @@ process {
 
     withName: DADA2_ADDSPECIES {
         ext.seed = "${params.seed}"
+        ext.taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" : ""
         ext.args = [
             'allowMultiple = FALSE, n = 1e5',
             params.pacbio ? "tryRC = TRUE" :

--- a/conf/test_fasta.config
+++ b/conf/test_fasta.config
@@ -22,6 +22,7 @@ params {
     // Input data
     input = "https://raw.githubusercontent.com/nf-core/test-datasets/ampliseq/testdata/ASV_seqs.fasta"
     dada_ref_taxonomy = "rdp=18"
+    dada_assign_taxlevels = "K,D,P,C,O,F,Genus"
 
     skip_qiime = true
 }

--- a/lib/WorkflowAmpliseq.groovy
+++ b/lib/WorkflowAmpliseq.groovy
@@ -53,6 +53,11 @@ class WorkflowAmpliseq {
             System.exit(1)
         }
 
+        if (params.dada_assign_taxlevels && params.sbdiexport) {
+            log.error "Incompatible parameters: `--sbdiexport` expects specific taxonomics ranks (default) and therefore excludes modifying those using `--dada_assign_taxlevels`."
+            System.exit(1)
+        }
+
         if (params.skip_dada_addspecies && params.sbdiexport) {
             log.error "Incompatible parameters: `--sbdiexport` expects species annotation and therefore excludes `--skip_dada_addspecies`."
             System.exit(1)

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -20,11 +20,18 @@ process DADA2_ADDSPECIES {
 
     script:
     def args = task.ext.args ?: ''
+    def taxlevels = task.ext.taxlevels ? 
+        'c("' + task.ext.taxlevels.split(",").join('","') + '")' : 
+        'c("Domain", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
     def seed = task.ext.seed ?: '100'
     """
     #!/usr/bin/env Rscript
     suppressPackageStartupMessages(library(dada2))
     set.seed($seed) # Initialize random number generator for reproducibility
+
+    #add "Species" if not already in taxlevels
+    taxlevels <- $taxlevels
+    if ( !"Species" %in% taxlevels ) { taxlevels <- c(taxlevels,"Species") }
 
     taxtable <- readRDS(\"$taxtable\")
 
@@ -32,24 +39,14 @@ process DADA2_ADDSPECIES {
 
     # Create a table with specified column order
     tmp <- data.frame(row.names(tx)) # To separate ASV_ID from sequence
-    taxa <- data.frame(
-        ASV_ID = tx[,"ASV_ID"],
-        Domain = tx[,"Domain"],
-        Kingdom = tx[,"Kingdom"],
-        Phylum = tx[,"Phylum"],
-        Class = tx[,"Class"],
-        Order = tx[,"Order"],
-        Family = tx[,"Family"],
-        Genus = tx[,"Genus"],
-        Species = tx[,"Species"],
-        confidence = tx[,"confidence"],
-        sequence = tmp[,],
-        row.names=row.names(tmp)
-    )
+    expected_order <- c("ASV_ID",taxlevels,"confidence")
+    taxa <- as.data.frame( subset(tx, select = expected_order) )
+    taxa\$sequence <- tmp[,1]
+    row.names(taxa) <- row.names(tmp)
 
     write.table(taxa, file = \"$outfile\", sep = "\\t", row.names = FALSE, col.names = TRUE, quote = FALSE, na = '')
 
-    write.table('addSpecies\t$args\nseed\t$seed', file = "addSpecies.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
+    write.table('addSpecies\t$args\ntaxlevels\t$taxlevels\nseed\t$seed', file = "addSpecies.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
     writeLines(c("\\"${task.process}\\":", paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")),paste0("    dada2: ", packageVersion("dada2")) ), "versions.yml")
     """
 }

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -20,8 +20,8 @@ process DADA2_ADDSPECIES {
 
     script:
     def args = task.ext.args ?: ''
-    def taxlevels = task.ext.taxlevels ? 
-        'c("' + task.ext.taxlevels.split(",").join('","') + '")' : 
+    def taxlevels = task.ext.taxlevels ?
+        'c("' + task.ext.taxlevels.split(",").join('","') + '")' :
         'c("Domain", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
     def seed = task.ext.seed ?: '100'
     """

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -20,8 +20,8 @@ process DADA2_TAXONOMY {
 
     script:
     def args = task.ext.args ?: ''
-    def taxlevels = task.ext.taxlevels ? 
-        'c("' + task.ext.taxlevels.split(",").join('","') + '")' : 
+    def taxlevels = task.ext.taxlevels ?
+        'c("' + task.ext.taxlevels.split(",").join('","') + '")' :
         'c("Domain", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
     def seed = task.ext.seed ?: '100'
     """
@@ -38,7 +38,7 @@ process DADA2_TAXONOMY {
     tx <- data.frame(ASV_ID = names(seq), taxa, sequence = row.names(taxa\$tax), row.names = names(seq))
     # remove any column with ".Species", because Species taxonomy will be annotated later
     tx <- tx[!grepl(".Species",names(tx))]
-    
+
     # (2) Set confidence to the bootstrap for the most specific taxon
     # extract columns with taxonomic values
     tax <- tx[ , grepl( "tax." , names( tx ) ) ]
@@ -58,7 +58,7 @@ process DADA2_TAXONOMY {
     valid_boot[is.na(valid_boot)] <- 0
     # add bootstrap values to column confidence
     tx\$confidence <- valid_boot
-    
+
     # (3) Reorder columns before writing to file
     nospecies <- taxlevels[taxlevels != "Species"]
     expected_order <- c("ASV_ID",paste0("tax.",nospecies),"confidence","sequence")

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -20,45 +20,51 @@ process DADA2_TAXONOMY {
 
     script:
     def args = task.ext.args ?: ''
+    def taxlevels = task.ext.taxlevels ? 
+        'c("' + task.ext.taxlevels.split(",").join('","') + '")' : 
+        'c("Domain", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
     def seed = task.ext.seed ?: '100'
     """
     #!/usr/bin/env Rscript
     suppressPackageStartupMessages(library(dada2))
     set.seed($seed) # Initialize random number generator for reproducibility
 
-    seq <- getSequences(\"$fasta\", collapse = TRUE, silence = FALSE)
-    taxa <- assignTaxonomy(seq, \"$database\", taxLevels = c("Domain", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"), $args, multithread = $task.cpus, verbose=TRUE, outputBootstraps = TRUE)
+    taxlevels <- $taxlevels
 
-    # Make a data frame, add ASV_ID from seq, set confidence to the bootstrap for the most specific taxon and reorder columns before writing to file
+    seq <- getSequences(\"$fasta\", collapse = TRUE, silence = FALSE)
+    taxa <- assignTaxonomy(seq, \"$database\", taxLevels = taxlevels, $args, multithread = $task.cpus, verbose=TRUE, outputBootstraps = TRUE)
+
+    # (1) Make a data frame, add ASV_ID from seq
     tx <- data.frame(ASV_ID = names(seq), taxa, sequence = row.names(taxa\$tax), row.names = names(seq))
-    tx\$confidence <- with(tx,
-        ifelse(!is.na(tax.Genus), boot.Genus,
-            ifelse(!is.na(tax.Family), boot.Family,
-                ifelse(!is.na(tax.Order), boot.Order,
-                    ifelse(!is.na(tax.Class), boot.Class,
-                        ifelse(!is.na(tax.Phylum), boot.Phylum,
-                            ifelse(!is.na(tax.Kingdom), boot.Kingdom,
-                                ifelse(!is.na(tax.Domain), boot.Domain, 0)
-                            )
-                        )
-                    )
-                )
-            )
-        )
-    )/100
-    taxa_export <- data.frame(
-        ASV_ID = tx\$ASV_ID,
-        Domain = tx\$tax.Domain,
-        Kingdom = tx\$tax.Kingdom,
-        Phylum = tx\$tax.Phylum,
-        Class = tx\$tax.Class,
-        Order = tx\$tax.Order,
-        Family = tx\$tax.Family,
-        Genus = tx\$tax.Genus,
-        confidence = tx\$confidence,
-        sequence = tx\$sequence,
-        row.names = names(seq)
-    )
+    # remove any column with ".Species", because Species taxonomy will be annotated later
+    tx <- tx[!grepl(".Species",names(tx))]
+    
+    # (2) Set confidence to the bootstrap for the most specific taxon
+    # extract columns with taxonomic values
+    tax <- tx[ , grepl( "tax." , names( tx ) ) ]
+    # find first occurrence of NA
+    res <- max.col(is.na(tax), ties = "first")
+    # correct if no NA is present in column to NA
+    if(any(res == 1)) is.na(res) <- (res == 1) & !is.na(tax[[1]])
+    # find index of last entry before NA, which is the bootstrap value
+    res <- res-1
+    # if NA choose last entry
+    res[is.na(res)] <- ncol(tax)
+    # extract bootstrap values
+    boot <- tx[ , grepl( "boot." , names( tx ) ) ]
+    boot\$last_tax <- res
+    valid_boot <- apply(boot,1,function(x) x[x[length(x)]][1]/100 )
+    # replace missing bootstrap values (NA) with 0
+    valid_boot[is.na(valid_boot)] <- 0
+    # add bootstrap values to column confidence
+    tx\$confidence <- valid_boot
+    
+    # (3) Reorder columns before writing to file
+    nospecies <- taxlevels[taxlevels != "Species"]
+    expected_order <- c("ASV_ID",paste0("tax.",nospecies),"confidence","sequence")
+    taxa_export <- subset(tx, select = expected_order)
+    colnames(taxa_export) <- sub("tax.", "", colnames(taxa_export))
+    rownames(taxa_export) <- names(seq)
 
     write.table(taxa_export, file = \"$outfile\", sep = "\\t", row.names = FALSE, col.names = TRUE, quote = FALSE, na = '')
 
@@ -66,7 +72,7 @@ process DADA2_TAXONOMY {
     taxa_export <- cbind( ASV_ID = tx\$ASV_ID, taxa\$tax, confidence = tx\$confidence)
     saveRDS(taxa_export, "ASV_tax.rds")
 
-    write.table('assignTaxonomy\t$args\nseed\t$seed', file = "assignTaxonomy.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
+    write.table('assignTaxonomy\t$args\ntaxlevels\t$taxlevels\nseed\t$seed', file = "assignTaxonomy.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
     writeLines(c("\\"${task.process}\\":", paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")),paste0("    dada2: ", packageVersion("dada2")) ), "versions.yml")
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -75,6 +75,7 @@ params {
 
     // Database options
     dada_ref_taxonomy     = "silva=138"
+    dada_assign_taxlevels = null
     cut_dada_ref_taxonomy = false
     qiime_ref_taxonomy    = null
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -229,6 +229,11 @@
                         "unite-alleuk"
                     ]
                 },
+                "dada_assign_taxlevels": {
+                    "type": "string",
+                    "help_text": "If providing a custom DADA2 reference taxonomy database: comma separated list of taxonomic levels.",
+                    "description": "Important: if DADA2's addSpecies is used (default), the last element of the comma separated string must be 'Genus', otherwise no Species rank will be assigned."
+                },
                 "cut_dada_ref_taxonomy": {
                     "type": "boolean",
                     "help_text": "Expected amplified sequences are extracted from the DADA2 reference taxonomy using the primer sequences, that might improve classification. This is not applied to species classification (assignSpecies) but only for lower taxonomic levels (assignTaxonomy).",


### PR DESCRIPTION
I attempted to make taxonomic levels for DADA2's assignTaxonomy and addSpecies flexible, i.e. not hardcoded, but adjustable with the parameter `--dada_assign_taxlevels <comma separated string>`.

Currently I see two restrictions:
- DADA2's addSpecies expects a "Genus" level, so that has to be include at least.
- sbdiexport expects the exact previously used taxonomic ranks, so I made that default and raise an error when attempting to use `--sbdiexport` and `--dada_assign_taxlevels`.

This is supposed to aid https://github.com/nf-core/ampliseq/pull/459 and allow later custom db additions as requested in https://github.com/nf-core/ampliseq/issues/427.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
