### PR TITLE
Custom dada tax ref db input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,8 @@ jobs:
     strategy:
       matrix:
         # Run remaining test profiles with minimum nextflow version
-        profile: [test_multi, test_pacbio_its, test_doubleprimers, test_iontorrent, test_single, test_fasta, test_reftaxcustom]
+        profile:
+          [test_multi, test_pacbio_its, test_doubleprimers, test_iontorrent, test_single, test_fasta, test_reftaxcustom]
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         # Run remaining test profiles with minimum nextflow version
-        profile: [test_multi, test_pacbio_its, test_doubleprimers, test_iontorrent, test_single, test_fasta]
+        profile: [test_multi, test_pacbio_its, test_doubleprimers, test_iontorrent, test_single, test_fasta, test_reftaxcustom]
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#456](https://github.com/nf-core/ampliseq/pull/456) - An optional ASV length filter can be activated using `--min_len_asv <int>` and/or `--max_len_asv <int>`.
 - [#458](https://github.com/nf-core/ampliseq/pull/458) - Samplesheet, ASV fasta file, and/or metadata sheet is now exported into `<results>/input/`
 - [#460](https://github.com/nf-core/ampliseq/pull/460) - Taxonomic ranks for DADA2 taxonomic classification can be now adjusted using `--dada_assign_taxlevels <comma separated string>`.
+- [#461](https://github.com/nf-core/ampliseq/pull/461) - A custom DADA2 reference taxonomy database can now be used with `--dada_ref_tax_custom` and `--dada_ref_tax_custom_sp`, typically accompanied by `--dada_assign_taxlevels`.
 
 ### `Changed`
 

--- a/conf/test_reftaxcustom.config
+++ b/conf/test_reftaxcustom.config
@@ -1,0 +1,34 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run nf-core/ampliseq -profile test_reftaxcustom,<docker/singularity> --outdir <OUTDIR>
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name = 'Test custom DADA2 reference taxonomy database profile'
+    config_profile_description = 'Minimal test dataset to check --dada_ref_tax_custom'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = '6.GB'
+    max_time   = '6.h'
+
+    // Input data
+    FW_primer = "GTGYCAGCMGCCGCGGTAA"
+    RV_primer = "GGACTACNVGGGTWTCTAAT"
+    input = "https://raw.githubusercontent.com/nf-core/test-datasets/ampliseq/samplesheets/Samplesheet.tsv"
+
+    // Custom reference taxonomy
+    dada_ref_tax_custom = "https://zenodo.org/record/4310151/files/rdp_train_set_18.fa.gz"
+    dada_ref_tax_custom_sp = "https://zenodo.org/record/4310151/files/rdp_species_assignment_18.fa.gz"
+    dada_assign_taxlevels = "Kingdom,Phylum,Class,Order,Family,Genus"
+    
+    // Skip downstream analysis with QIIME2
+    skip_qiime = true
+}

--- a/conf/test_reftaxcustom.config
+++ b/conf/test_reftaxcustom.config
@@ -28,7 +28,7 @@ params {
     dada_ref_tax_custom = "https://zenodo.org/record/4310151/files/rdp_train_set_18.fa.gz"
     dada_ref_tax_custom_sp = "https://zenodo.org/record/4310151/files/rdp_species_assignment_18.fa.gz"
     dada_assign_taxlevels = "Kingdom,Phylum,Class,Order,Family,Genus"
-    
+
     // Skip downstream analysis with QIIME2
     skip_qiime = true
 }

--- a/lib/WorkflowAmpliseq.groovy
+++ b/lib/WorkflowAmpliseq.groovy
@@ -53,6 +53,16 @@ class WorkflowAmpliseq {
             System.exit(1)
         }
 
+        if (!params.dada_ref_tax_custom && params.dada_ref_tax_custom_sp) {
+            log.error "Incompatible parameters: `--dada_ref_tax_custom_sp` requires `--dada_ref_tax_custom`."
+            System.exit(1)
+        }
+
+        if (params.dada_ref_tax_custom && !params.dada_ref_tax_custom_sp && !params.skip_dada_addspecies) {
+            log.error "Incompatible parameters: Either `--skip_dada_addspecies` or `--dada_ref_tax_custom_sp` is additionally required to `--dada_ref_tax_custom`."
+            System.exit(1)
+        }
+
         if (params.dada_assign_taxlevels && params.sbdiexport) {
             log.error "Incompatible parameters: `--sbdiexport` expects specific taxonomics ranks (default) and therefore excludes modifying those using `--dada_assign_taxlevels`."
             System.exit(1)

--- a/nextflow.config
+++ b/nextflow.config
@@ -76,6 +76,8 @@ params {
     // Database options
     dada_ref_taxonomy     = "silva=138"
     dada_assign_taxlevels = null
+    dada_ref_tax_custom   = null
+    dada_ref_tax_custom_sp = null
     cut_dada_ref_taxonomy = false
     qiime_ref_taxonomy    = null
 
@@ -188,6 +190,7 @@ profiles {
     test_iontorrent    { includeConfig 'conf/test_iontorrent.config'    }
     test_fasta         { includeConfig 'conf/test_fasta.config'         }
     test_full          { includeConfig 'conf/test_full.config'          }
+    test_reftaxcustom  { includeConfig 'conf/test_reftaxcustom.config'  }
 }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -229,10 +229,20 @@
                         "unite-alleuk"
                     ]
                 },
+                "dada_ref_tax_custom": {
+                    "type": "string",
+                    "help_text": "Is preferred over `--dada_ref_taxonomy`. Either `--skip_dada_addspecies` (no species annotation) or `--dada_ref_tax_custom_sp` (species annotation) is additionally required. Consider also setting `--dada_assign_taxlevels`.\n\nMust be compatible to DADA2's assignTaxonomy function: 'Can be compressed. This reference fasta file should be formatted so that the id lines correspond to the taxonomy (or classification) of the associated sequence, and each taxonomic level is separated by a semicolon.' See also https://rdrr.io/bioc/dada2/man/assignTaxonomy.html",
+                    "description": "Path to a custom DADA2 reference taxonomy database"
+                },
+                "dada_ref_tax_custom_sp": {
+                    "type": "string",
+                    "help_text": "Requires `--dada_ref_tax_custom`. Must be compatible to DADA2's addSpecies function: 'Can be compressed. This reference fasta file should be formatted so that the id lines correspond to the genus-species binomial of the associated sequence.' See also https://rdrr.io/bioc/dada2/man/addSpecies.html",
+                    "description": "Path to a custom DADA2 reference taxonomy database for species assignment"
+                },
                 "dada_assign_taxlevels": {
                     "type": "string",
-                    "help_text": "If providing a custom DADA2 reference taxonomy database: comma separated list of taxonomic levels.",
-                    "description": "Important: if DADA2's addSpecies is used (default), the last element of the comma separated string must be 'Genus', otherwise no Species rank will be assigned."
+                    "help_text": "Typically useful when providing a custom DADA2 reference taxonomy database with `--dada_ref_tax_custom`. If DADA2's addSpecies is used (default), the last element of the comma separated string must be 'Genus', otherwise no Species rank will be assigned. The element 'Species' is removed in DADA2's assignTaxonomy to leave room for DADA2's addSpecies.",
+                    "description": "Comma separated list of taxonomic levels used in DADA2's assignTaxonomy function"
                 },
                 "cut_dada_ref_taxonomy": {
                     "type": "boolean",


### PR DESCRIPTION
Added two parameters that allow to supply DADA2's assignTaxonomy and addSpecies directly with files, i.e. custom databases.
Adresses https://github.com/nf-core/ampliseq/issues/427

edit: possibly some more documentation might be good? 
- Maybe in `docs/usage.md` a new section for taxonomy databases and custom databases? Not sure if ever someone looks into those though.
- README.md: `and, currently, taxonomic assignment of 16S, ITS and 18S amplicons.` could be changed to `and taxonomic assignment of 16S, ITS and 18S amplicons, or using custom databases.`?

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
