### PR TITLE
assignTaxonomy Species assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#445](https://github.com/nf-core/ampliseq/pull/445) - The minimum number of total bases to use for error rate learning by default is 1e8 (DADA2, learnErrors, nbases). Previously, samples were read in the provided order until enough reads were obtained (DADA2, learnErrors, randomize=FALSE). Now, samples are picked at random from those provided (DADA2, learnError, randomize=TRUE) and a seed is set.
 - [#444](https://github.com/nf-core/ampliseq/pull/444) - Updated parameter documentation.
 - [#453](https://github.com/nf-core/ampliseq/pull/453) - Export a few more basic QIIME2 fragments (zipped files) that can be easily imported into the correct QIIME2 version for custom analysis.
+- [#464](https://github.com/nf-core/ampliseq/pull/464) - Reported taxonomic classifications on species level based on DADA2's assignTaxonomy (approximations) is now listed in column "Species" while exact matches based on DADA2's addSpecies are now reported in column "Species_exact".
 
 ### `Fixed`
 

--- a/bin/taxref_reformat_gtdb.sh
+++ b/bin/taxref_reformat_gtdb.sh
@@ -10,7 +10,7 @@ for f in *.tar.gz; do
 done
 
 # Write the assignTaxonomy() fasta file: assignTaxonomy.fna
-cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) \([^[]\+\) \[.*/>\2(\1\)/' | sed '/^>/s/;s__.*//' | sed 's/[a-z]__//g' | sed 's/ /_/g' | sed '/^>/s/\(Archaea\)\|\(Bacteria\)/&;&/' > assignTaxonomy.fna
+cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) \([^[]\+\) \[.*/>\2(\1\)/' | sed 's/[a-z]__//g' | sed 's/ /_/g' | sed '/^>/s/\(Archaea\)\|\(Bacteria\)/&;&/' > assignTaxonomy.fna
 
 # Write the addSpecies() fasta file: addSpecies.fna
 cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) .*;s__\([^[]\+\) \[.*/>\1 \2/' > addSpecies.fna

--- a/bin/taxref_reformat_gtdb.sh
+++ b/bin/taxref_reformat_gtdb.sh
@@ -10,7 +10,7 @@ for f in *.tar.gz; do
 done
 
 # Write the assignTaxonomy() fasta file: assignTaxonomy.fna
-cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) \([^[]\+\) \[.*/>\2(\1\)/' | sed 's/[a-z]__//g' | sed 's/ /_/g' | sed '/^>/s/\(Archaea\)\|\(Bacteria\)/&;&/' > assignTaxonomy.fna
+cat ar122*.fna bac120*.fna | sed '/^>/s/>[^ ]\+ \([^[]\+\) \[.*/>\1/' | sed '/^>/s/ \[.*//' | sed 's/[a-z]__//g' | sed '/^>/s/\(Archaea\)\|\(Bacteria\)/&;&/' > assignTaxonomy.fna
 
 # Write the addSpecies() fasta file: addSpecies.fna
 cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) .*;s__\([^[]\+\) \[.*/>\1 \2/' > addSpecies.fna

--- a/bin/taxref_reformat_midori2.sh
+++ b/bin/taxref_reformat_midori2.sh
@@ -2,12 +2,9 @@
 
 # Handles the MIDORI database.
 
-# There are preformatted DADA2 files for assignTaxonomy() and addSpecies() -- this is just ungzipped
-for f in MIDORI2_UNIQ_NUC_*_DADA2.fasta.gz; do
-    if [[ $f == *"MIDORI2_UNIQ_NUC_SP_"* ]]; then
-        #unzip, remove last ";", take last field separated by ";" and add fake SeqID
-        gunzip -c $f | sed 's/;*$//g' | sed 's/.*;/>SeqID /' > addSpecies.fna
-    elif [[ $f == *"MIDORI2_UNIQ_NUC_"* ]]; then
-        gunzip -c $f > assignTaxonomy.fna
-    fi
-done
+# There are preformatted DADA2 files for assignTaxonomy() and addSpecies()
+gunzip -c *.fasta.gz | sed 's/\(phylum_\)\|\(class_\)\|\(order_\)\|\(family_\)\|\(genus_\)//g' | sed 's/_[0-9]\+;/;/g' > assignTaxonomy.fna
+
+#unzip, remove last ";", take last field separated by ";" and add fake SeqID
+gunzip -c *.fasta.gz | sed 's/;*$//g' | sed 's/.*;/> /' | sed 's/> \(.*\)_\([0-9]\+$\)/>\2 \1/' > addSpecies.fna
+

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -12,7 +12,7 @@ params {
     dada_ref_databases {
         'midori2-co1=gb250' {
             title = "MIDORI2 - CO1 Taxonomy Database - Release GB250"
-            file = [ "http://reference-midori.info/download/Databases/GenBank250/DADA2/uniq/MIDORI2_UNIQ_NUC_GB250_CO1_DADA2.fasta.gz", "http://reference-midori.info/download/Databases/GenBank250/DADA2_sp/uniq/MIDORI2_UNIQ_NUC_SP_GB250_CO1_DADA2.fasta.gz" ]
+            file = [ "http://reference-midori.info/download/Databases/GenBank250/DADA2_sp/uniq/MIDORI2_UNIQ_NUC_SP_GB250_CO1_DADA2.fasta.gz" ]
             citation = "Machida RJ, Leray M, Ho SL, Knowlton N. Metazoan mitochondrial gene sequence reference datasets for taxonomic assignment of environmental samples. Sci Data. 2017 Mar 14;4:170027. doi: 10.1038/sdata.2017.27. PMID: 28291235; PMCID: PMC5349245."
             fmtscript = "taxref_reformat_midori2.sh"
             dbversion = 'midori2-co1=gb250'
@@ -20,7 +20,7 @@ params {
         }
         'midori2-co1' {
             title = "MIDORI2 - CO1 Taxonomy Database - Release GB250"
-            file = [ "http://reference-midori.info/download/Databases/GenBank250/DADA2/uniq/MIDORI2_UNIQ_NUC_GB250_CO1_DADA2.fasta.gz", "http://reference-midori.info/download/Databases/GenBank250/DADA2_sp/uniq/MIDORI2_UNIQ_NUC_SP_GB250_CO1_DADA2.fasta.gz" ]
+            file = [ "http://reference-midori.info/download/Databases/GenBank250/DADA2_sp/uniq/MIDORI2_UNIQ_NUC_SP_GB250_CO1_DADA2.fasta.gz" ]
             citation = "Machida RJ, Leray M, Ho SL, Knowlton N. Metazoan mitochondrial gene sequence reference datasets for taxonomic assignment of environmental samples. Sci Data. 2017 Mar 14;4:170027. doi: 10.1038/sdata.2017.27. PMID: 28291235; PMCID: PMC5349245."
             fmtscript = "taxref_reformat_midori2.sh"
             dbversion = 'midori2-co1=gb250'
@@ -105,14 +105,14 @@ params {
         }
         'silva' {
             title = "Silva 138.1 prokaryotic SSU"
-            file = [ "https://zenodo.org/record/4587955/files/silva_nr99_v138.1_train_set.fa.gz", "https://zenodo.org/record/4587955/files/silva_species_assignment_v138.1.fa.gz" ]
+            file = [ "https://zenodo.org/record/4587955/files/silva_nr99_v138.1_wSpecies_train_set.fa.gz", "https://zenodo.org/record/4587955/files/silva_species_assignment_v138.1.fa.gz" ]
             citation = "Quast C, Pruesse E, Yilmaz P, Gerken J, Schweer T, Yarza P, Peplies J, Glöckner FO. The SILVA ribosomal RNA gene database project: improved data processing and web-based tools. Nucleic Acids Res. 2013 Jan;41(Database issue):D590-6. doi: 10.1093/nar/gks1219. Epub 2012 Nov 28. PMID: 23193283; PMCID: PMC3531112."
             fmtscript = "taxref_reformat_standard.sh"
             dbversion = 'silva=138.1'
         }
         'silva=138' {
             title = "Silva 138.1 prokaryotic SSU"
-            file = [ "https://zenodo.org/record/4587955/files/silva_nr99_v138.1_train_set.fa.gz", "https://zenodo.org/record/4587955/files/silva_species_assignment_v138.1.fa.gz" ]
+            file = [ "https://zenodo.org/record/4587955/files/silva_nr99_v138.1_wSpecies_train_set.fa.gz", "https://zenodo.org/record/4587955/files/silva_species_assignment_v138.1.fa.gz" ]
             citation = "Quast C, Pruesse E, Yilmaz P, Gerken J, Schweer T, Yarza P, Peplies J, Glöckner FO. The SILVA ribosomal RNA gene database project: improved data processing and web-based tools. Nucleic Acids Res. 2013 Jan;41(Database issue):D590-6. doi: 10.1093/nar/gks1219. Epub 2012 Nov 28. PMID: 23193283; PMCID: PMC3531112."
             fmtscript = "taxref_reformat_standard.sh"
             dbversion = 'silva=138.1'

--- a/conf/test.config
+++ b/conf/test.config
@@ -24,7 +24,7 @@ params {
     RV_primer = "GGACTACNVGGGTWTCTAAT"
     input = "https://raw.githubusercontent.com/nf-core/test-datasets/ampliseq/samplesheets/Samplesheet.tsv"
     metadata = "https://raw.githubusercontent.com/nf-core/test-datasets/ampliseq/samplesheets/Metadata.tsv"
-    dada_ref_taxonomy = "rdp=18"
+    dada_ref_taxonomy = "gtdb"
     cut_dada_ref_taxonomy = true
     qiime_ref_taxonomy = "greengenes85"
     max_len_asv = 255

--- a/docs/output.md
+++ b/docs/output.md
@@ -177,7 +177,7 @@ Optionally, the ITS region can be extracted from each ASV sequence using ITSx, a
 
 ### Taxonomic classification with DADA2
 
-DADA2 taxonomically classifies the ASVs using a choice of supplied databases (specified with `--dada_ref_taxonomy`). The taxonomic classification will be done based on filtered ASV sequences (see above). 
+DADA2 taxonomically classifies the ASVs using a choice of supplied databases (specified with `--dada_ref_taxonomy`). The taxonomic classification will be done based on filtered ASV sequences (see above).
 
 Depending on the reference taxonomy database, sequences can be classified down to species. Species classification is either reported in columns "Species" using DADA2's assignTaxonomy function or "Species_exact" using DADA2's addSpecies function, the latter only assigns exact sequence matches. Generally, species assignment without exact matches are much less trustworthy than those with exact matches. With short amplicons, e.g. 16S rRNA gene V4 region, the non-exact species annotation is not recommended to be trusted. The longer the ASVs are, the more acceptable is the non-exact species classification, e.g. PacBio (nearly) full length 16S rRNA gene sequences are thought to be trustworthy.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -179,7 +179,7 @@ Optionally, the ITS region can be extracted from each ASV sequence using ITSx, a
 
 DADA2 taxonomically classifies the ASVs using a choice of supplied databases (specified with `--dada_ref_taxonomy`). The taxonomic classification will be done based on filtered ASV sequences (see above).
 
-Depending on the reference taxonomy database, sequences can be classified down to species. Species classification is either reported in columns "Species" using DADA2's assignTaxonomy function or "Species_exact" using DADA2's addSpecies function, the latter only assigns exact sequence matches. Generally, species assignment without exact matches are much less trustworthy than those with exact matches. With short amplicons, e.g. 16S rRNA gene V4 region, the non-exact species annotation is not recommended to be trusted. The longer the ASVs are, the more acceptable is the non-exact species classification, e.g. PacBio (nearly) full length 16S rRNA gene sequences are thought to be trustworthy.
+Depending on the reference taxonomy database, sequences can be classified down to species rank. Species classification is reported in columns "Species" using DADA2's assignTaxonomy function or "Species_exact" using DADA2's addSpecies function, the latter only assigns exact sequence matches. Generally, species assignment without exact matches are much less trustworthy than those with exact matches. With short amplicons, e.g. 16S rRNA gene V4 region, the non-exact species annotation is not recommended to be trusted. The longer the ASVs are, the more acceptable is the non-exact species classification, e.g. PacBio (nearly) full length 16S rRNA gene sequences are thought to be trustworthy.
 
 Files when _not_ using ITSx (default):
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -177,7 +177,9 @@ Optionally, the ITS region can be extracted from each ASV sequence using ITSx, a
 
 ### Taxonomic classification with DADA2
 
-DADA2 taxonomically classifies the ASVs using a choice of supplied databases (specified with `--dada_ref_taxonomy`). The taxonomic classification will be done based on filtered ASV sequences (see above).
+DADA2 taxonomically classifies the ASVs using a choice of supplied databases (specified with `--dada_ref_taxonomy`). The taxonomic classification will be done based on filtered ASV sequences (see above). 
+
+Depending on the reference taxonomy database, sequences can be classified down to species. Species classification is either reported in columns "Species" using DADA2's assignTaxonomy function or "Species_exact" using DADA2's addSpecies function, the latter only assigns exact sequence matches. Generally, species assignment without exact matches are much less trustworthy than those with exact matches. With short amplicons, e.g. 16S rRNA gene V4 region, the non-exact species annotation is not recommended to be trusted. The longer the ASVs are, the more acceptable is the non-exact species classification, e.g. PacBio (nearly) full length 16S rRNA gene sequences are thought to be trustworthy.
 
 Files when _not_ using ITSx (default):
 
@@ -186,7 +188,7 @@ Files when _not_ using ITSx (default):
 
 - `dada2/`
   - `ASV_tax.tsv`: Taxonomic classification for each ASV sequence.
-  - `ASV_tax_species.tsv`: Species classification for each ASV sequence.
+  - `ASV_tax_species.tsv`: Exact species classification for each ASV sequence.
   - `ref_taxonomy.txt`: Information about the used reference taxonomy, such as title, version, citation.
 
 </details>
@@ -198,9 +200,9 @@ Files when using ITSx:
 
 - `dada2/`
   - `ASV_ITS_tax.tsv`: Taxonomic classification with ITS region of each ASV sequence.
-  - `ASV_ITS_tax_species.tsv`: Species classification with ITS region of each ASV sequence.
+  - `ASV_ITS_tax_species.tsv`: Exact species classification with ITS region of each ASV sequence.
   - `ASV_tax.tsv`: Taxonomic classification of each ASV sequence, based on the ITS region.
-  - `ASV_tax_species.tsv`: Species classification of each ASV sequence, based on the ITS region.
+  - `ASV_tax_species.tsv`: Exact species classification of each ASV sequence, based on the ITS region.
   - `ref_taxonomy.txt`: Information about the used reference taxonomy, such as title, version, citation.
 
 </details>

--- a/lib/WorkflowAmpliseq.groovy
+++ b/lib/WorkflowAmpliseq.groovy
@@ -98,7 +98,7 @@ class WorkflowAmpliseq {
             System.exit(1)
         }
 
-        String[] sbdi_incompatible_databases = ["midori2-co1=gb250", "midori2-co1"]
+        String[] sbdi_incompatible_databases = ["midori2-co1=gb250","midori2-co1","rdp=18","rdp","sbdi-gtdb","sbdi-gtdb=R06-RS202-3","sbdi-gtdb=R06-RS202-1","silva=132","unite-fungi","unite-fungi=8.3","unite-fungi=8.2","unite-alleuk","unite-alleuk=8.3","unite-alleuk=8.2"]
         if ( params.sbdiexport && Arrays.stream(sbdi_incompatible_databases).anyMatch(entry -> params.dada_ref_taxonomy.toString().equals(entry)) ) {
             log.error "Incompatible parameters: `--sbdiexport` does not work with the chosen databse of `--dada_ref_taxonomy`, because the expected taxonomic levels do not match."
             System.exit(1)

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -37,8 +37,7 @@ process DADA2_ADDSPECIES {
     taxtable <- readRDS(\"$taxtable\")
 
     #remove Species annotation from assignTaxonomy
-    taxtable <- data.frame(taxtable)
-    taxa_nospecies <- taxtable[!grepl("Species",names(taxtable))]
+    taxa_nospecies <- taxtable[,!colnames(taxtable) %in% 'Species']
 
     tx <- addSpecies(taxa_nospecies, \"$database\", $args, verbose=TRUE)
 

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -53,6 +53,7 @@ process DADA2_ADDSPECIES {
 
     #add Species annotation from assignTaxonomy again, after "Genus" column
     if ( "Species" %in% colnames(taxtable) ) {
+        taxtable <- data.frame(taxtable)
         taxa_export <- data.frame(append(taxa, list(Species=taxtable\$Species), after=match("Genus", names(taxa))))
     } else {
         taxa_export <- taxa

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -53,7 +53,7 @@ process DADA2_ADDSPECIES {
     colnames(taxa)[which(names(taxa) == "Species")] <- "Species_exact"
 
     #add Species annotation from assignTaxonomy again, after "Genus" column
-    if ( "Species" %in% colnames(taxtable) ) { 
+    if ( "Species" %in% colnames(taxtable) ) {
         taxa_export <- data.frame(append(taxa, list(Species=taxtable\$Species), after=match("Genus", names(taxa))))
     } else {
         taxa_export <- taxa

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -37,8 +37,6 @@ process DADA2_TAXONOMY {
 
     # (1) Make a data frame, add ASV_ID from seq
     tx <- data.frame(ASV_ID = names(seq), taxa, sequence = row.names(taxa\$tax), row.names = names(seq))
-    # remove any column with ".Species", because Species taxonomy will be annotated later
-    tx <- tx[!grepl(".Species",names(tx))]
 
     # (2) Set confidence to the bootstrap for the most specific taxon
     # extract columns with taxonomic values
@@ -61,8 +59,8 @@ process DADA2_TAXONOMY {
     tx\$confidence <- valid_boot
 
     # (3) Reorder columns before writing to file
-    nospecies <- taxlevels[taxlevels != "Species"]
-    expected_order <- c("ASV_ID",paste0("tax.",nospecies),"confidence","sequence")
+    expected_order <- c("ASV_ID",paste0("tax.",taxlevels),"confidence","sequence")
+    expected_order <- intersect(expected_order,colnames(tx))
     taxa_export <- subset(tx, select = expected_order)
     colnames(taxa_export) <- sub("tax.", "", colnames(taxa_export))
     rownames(taxa_export) <- names(seq)

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -243,7 +243,7 @@
                 },
                 "dada_assign_taxlevels": {
                     "type": "string",
-                    "help_text": "Typically useful when providing a custom DADA2 reference taxonomy database with `--dada_ref_tax_custom`. If DADA2's addSpecies is used (default), the last element of the comma separated string must be 'Genus', otherwise no Species rank will be assigned. The element 'Species' is removed in DADA2's assignTaxonomy to leave room for DADA2's addSpecies.",
+                    "help_text": "Typically useful when providing a custom DADA2 reference taxonomy database with `--dada_ref_tax_custom`. If DADA2's addSpecies is used (default), the last element(s) of the comma separated string must be 'Genus' or 'Genus,Species'.",
                     "description": "Comma separated list of taxonomic levels used in DADA2's assignTaxonomy function"
                 },
                 "cut_dada_ref_taxonomy": {

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -90,6 +90,14 @@ if ( params.dada_ref_taxonomy ) {
         params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] ?: ""
 } else { taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" : "" }
 
+//make sure that taxlevels adheres to requirements when mixed with addSpecies
+if ( params.dada_ref_taxonomy && !params.skip_dada_addspecies && !params.skip_taxonomy && taxlevels ) {
+    if ( !taxlevels.endsWith(",Genus,Species") && !taxlevels.endsWith(",Genus") ) {
+        log.error "Incompatible settings: To use exact species annotations, taxonomic levels must end with `,Genus,Species` or `,Genus,Species` but are currently `${taxlevels}`. Taxonomic levels can be set with `--dada_assign_taxlevels`. Skip exact species annotations with `--skip_dada_addspecies`.\n"
+        System.exit(1)
+    }
+}
+
 //only run QIIME2 when taxonomy is actually calculated and all required data is available
 if ( !params.enable_conda && !params.skip_taxonomy && !params.skip_qiime ) {
     run_qiime2 = true


### PR DESCRIPTION
This PR allows Species assignment with DADA2's assignTaxonomy (results/dada2/ASV_tax.tsv) and exact match addSpecies as column "Species_exact" in (results/dada2/ASV_tax_species.tsv) for GTDB databases. This addresses https://github.com/nf-core/ampliseq/issues/351 & https://github.com/nf-core/ampliseq/issues/387.

The output changed in a way that Species assignment with assignTaxonomy will be performed and retained in case it is available from the taxonomy database. addSpecies will be run as well but not overwrite Species but instead adds a new column named Species_exact.

To run addSpecies, taxlevels (originating from --dada_assign_taxlevels or taxlevels from conf/ref_databases.config) must end with "Genus" or "Genus,Species".

Species assignment with assignTaxonomy works for databases:
- gtdb
- Silva: Using [silva_nr99_v138.1_wSpecies_train_set.fa.gz](https://zenodo.org/record/4587955/files/silva_nr99_v138.1_wSpecies_train_set.fa.gz) instead of [silva_nr99_v138.1_train_set.fa.gz](https://zenodo.org/record/4587955/files/silva_nr99_v138.1_train_set.fa.gz), only works for 138, not for 132!
- pr2

#### Can be tested for now with 
```
nextflow pull d4straub/ampliseq -r assigntaxonomy-for-species 
nextflow run d4straub/ampliseq -r assigntaxonomy-for-species -profile test,singularity --outdir result_test
```

#### Not perfectly solved:
- Unite: current file without removing species info would be fine, just the reformating script needs changes
- sbdiexport works only for databases that allow Species assignment with assignTaxonomy, because the usual databases do not report "Species" but "Species_exact" now.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
