### PR TITLE
Update software & nf-core modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
+- [#468](https://github.com/nf-core/ampliseq/pull/468) - Updated software
+
+| Tool     | Previous version | New version |
+| -------- | ---------------- | ----------- |
+| QIIME2   | 2021.8           | 2022.2      |
+| PICRUSt2 | 2.4.2            | 2.5.0       |
+| MultiQC  | 1.12             | 1.13a       |
+
 ### `Removed`
 
 ## nf-core/ampliseq version 2.3.2 - 2022-05-27

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -175,17 +175,17 @@ params {
     }
     //QIIME2 taxonomic reference databases
     qiime_ref_databases {
-        //SILVA for QIIME2 v2021.2, see https://docs.qiime2.org/2021.2/data-resources/#silva-16s-18s-rrna
+        //SILVA for QIIME2 v2022.2, see https://docs.qiime2.org/2022.2/data-resources/#silva-16s-18s-rrna
         'silva=138' {
             title = "QIIME2 pre-formatted SILVA dereplicated at 99% similarity - Version 138"
-            file = [ "https://data.qiime2.org/2021.8/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2021.8/common/silva-138-99-tax.qza" ]
+            file = [ "https://data.qiime2.org/2022.2/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2022.2/common/silva-138-99-tax.qza" ]
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = "taxref_reformat_qiime_silva138.sh"
         }
         'silva' {
             title = "QIIME2 pre-formatted SILVA dereplicated at 99% similarity - Version 138"
-            file = [ "https://data.qiime2.org/2021.8/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2021.8/common/silva-138-99-tax.qza" ]
+            file = [ "https://data.qiime2.org/2022.2/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2022.2/common/silva-138-99-tax.qza" ]
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = "taxref_reformat_qiime_silva138.sh"
@@ -217,7 +217,7 @@ params {
         }
         'greengenes85' {
             title = "Greengenes 16S - Version 13_8 - clustered at 85% similarity - for testing purposes only"
-            file = [ "https://data.qiime2.org/2021.8/tutorials/training-feature-classifiers/85_otus.fasta", "https://data.qiime2.org/2021.8/tutorials/training-feature-classifiers/85_otu_taxonomy.txt" ]
+            file = [ "https://data.qiime2.org/2022.2/tutorials/training-feature-classifiers/85_otus.fasta", "https://data.qiime2.org/2022.2/tutorials/training-feature-classifiers/85_otu_taxonomy.txt" ]
             citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
             fmtscript = "taxref_reformat_qiime_greengenes85.sh"
         }

--- a/modules.json
+++ b/modules.json
@@ -4,16 +4,16 @@
     "repos": {
         "nf-core/modules": {
             "custom/dumpsoftwareversions": {
-                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                "git_sha": "e5b44499efcf6f7fb24874886bac60591c5d94dd"
             },
             "cutadapt": {
                 "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "fastqc": {
-                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                "git_sha": "49b18b1639f4f7104187058866a8fab33332bdfe"
             },
             "multiqc": {
-                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                "git_sha": "5138acca0985ca01c38a1c4fba917d83772b1106"
             },
             "vsearch/usearchglobal": {
                 "git_sha": "5f0d75bb3745ddcb6306982e1afba71efa76c81e"

--- a/modules/local/picrust.nf
+++ b/modules/local/picrust.nf
@@ -2,10 +2,10 @@ process PICRUST {
     tag "${seq},${abund}"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::picrust2=2.4.2" : null)
+    conda (params.enable_conda ? "bioconda::picrust2=2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/picrust2:2.4.2--pyhdfd78af_0' :
-        'quay.io/biocontainers/picrust2:2.4.2--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/picrust2:2.5.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/picrust2:2.5.0--pyhdfd78af_0' }"
 
     input:
     path(seq)

--- a/modules/local/qiime2_alphararefaction.nf
+++ b/modules/local/qiime2_alphararefaction.nf
@@ -17,6 +17,7 @@ process QIIME2_ALPHARAREFACTION {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     maxdepth=\$(count_table_minmax_reads.py $stats maximum 2>&1)
 

--- a/modules/local/qiime2_alphararefaction.nf
+++ b/modules/local/qiime2_alphararefaction.nf
@@ -2,7 +2,7 @@ process QIIME2_ALPHARAREFACTION {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(metadata)

--- a/modules/local/qiime2_ancom_asv.nf
+++ b/modules/local/qiime2_ancom_asv.nf
@@ -18,6 +18,7 @@ process QIIME2_ANCOM_ASV {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime composition add-pseudocount \
         --i-table ${table} \

--- a/modules/local/qiime2_ancom_asv.nf
+++ b/modules/local/qiime2_ancom_asv.nf
@@ -6,7 +6,7 @@ process QIIME2_ANCOM_ASV {
     label 'error_ignore'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     tuple path(metadata), path(table)

--- a/modules/local/qiime2_ancom_tax.nf
+++ b/modules/local/qiime2_ancom_tax.nf
@@ -16,6 +16,7 @@ process QIIME2_ANCOM_TAX {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
     mkdir ancom
 
     # Sum data at the specified level

--- a/modules/local/qiime2_ancom_tax.nf
+++ b/modules/local/qiime2_ancom_tax.nf
@@ -4,7 +4,7 @@ process QIIME2_ANCOM_TAX {
     label 'single_cpu'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     tuple path(metadata), path(table), path(taxonomy) ,val(taxlevel)

--- a/modules/local/qiime2_barplot.nf
+++ b/modules/local/qiime2_barplot.nf
@@ -16,6 +16,7 @@ process QIIME2_BARPLOT {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime taxa barplot  \
         --i-table ${table}  \

--- a/modules/local/qiime2_barplot.nf
+++ b/modules/local/qiime2_barplot.nf
@@ -2,7 +2,7 @@ process QIIME2_BARPLOT {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(metadata)

--- a/modules/local/qiime2_classify.nf
+++ b/modules/local/qiime2_classify.nf
@@ -3,7 +3,7 @@ process QIIME2_CLASSIFY {
     label 'process_high'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(trained_classifier)

--- a/modules/local/qiime2_classify.nf
+++ b/modules/local/qiime2_classify.nf
@@ -17,6 +17,7 @@ process QIIME2_CLASSIFY {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime feature-classifier classify-sklearn  \
         --i-classifier ${trained_classifier}  \

--- a/modules/local/qiime2_diversity_adonis.nf
+++ b/modules/local/qiime2_diversity_adonis.nf
@@ -3,7 +3,7 @@ process QIIME2_DIVERSITY_ADONIS {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     tuple path(metadata), path(core)

--- a/modules/local/qiime2_diversity_adonis.nf
+++ b/modules/local/qiime2_diversity_adonis.nf
@@ -17,6 +17,7 @@ process QIIME2_DIVERSITY_ADONIS {
     def formula = params.qiime_adonis_formula
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime diversity adonis \\
         --p-n-jobs $task.cpus \\

--- a/modules/local/qiime2_diversity_alpha.nf
+++ b/modules/local/qiime2_diversity_alpha.nf
@@ -15,6 +15,7 @@ process QIIME2_DIVERSITY_ALPHA {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime diversity alpha-group-significance \
         --i-alpha-diversity ${core} \

--- a/modules/local/qiime2_diversity_alpha.nf
+++ b/modules/local/qiime2_diversity_alpha.nf
@@ -3,7 +3,7 @@ process QIIME2_DIVERSITY_ALPHA {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     tuple path(metadata), path(core)

--- a/modules/local/qiime2_diversity_beta.nf
+++ b/modules/local/qiime2_diversity_beta.nf
@@ -15,6 +15,7 @@ process QIIME2_DIVERSITY_BETA {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime diversity beta-group-significance \
         --i-distance-matrix ${core} \

--- a/modules/local/qiime2_diversity_beta.nf
+++ b/modules/local/qiime2_diversity_beta.nf
@@ -3,7 +3,7 @@ process QIIME2_DIVERSITY_BETA {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     tuple path(metadata), path(core), val(category)

--- a/modules/local/qiime2_diversity_betaord.nf
+++ b/modules/local/qiime2_diversity_betaord.nf
@@ -3,7 +3,7 @@ process QIIME2_DIVERSITY_BETAORD {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     tuple path(metadata), path(core)

--- a/modules/local/qiime2_diversity_betaord.nf
+++ b/modules/local/qiime2_diversity_betaord.nf
@@ -15,6 +15,7 @@ process QIIME2_DIVERSITY_BETAORD {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
     mkdir beta_diversity
 
     qiime emperor plot \

--- a/modules/local/qiime2_diversity_core.nf
+++ b/modules/local/qiime2_diversity_core.nf
@@ -20,6 +20,7 @@ process QIIME2_DIVERSITY_CORE {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     mindepth=\$(count_table_minmax_reads.py $stats minimum 2>&1)
     if [ \"\$mindepth\" -gt \"10000\" ]; then echo \$mindepth >\"Use the sampling depth of \$mindepth for rarefaction.txt\" ; fi

--- a/modules/local/qiime2_diversity_core.nf
+++ b/modules/local/qiime2_diversity_core.nf
@@ -2,7 +2,7 @@ process QIIME2_DIVERSITY_CORE {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(metadata)

--- a/modules/local/qiime2_export_absolute.nf
+++ b/modules/local/qiime2_export_absolute.nf
@@ -2,7 +2,7 @@ process QIIME2_EXPORT_ABSOLUTE {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(table)

--- a/modules/local/qiime2_export_absolute.nf
+++ b/modules/local/qiime2_export_absolute.nf
@@ -23,6 +23,7 @@ process QIIME2_EXPORT_ABSOLUTE {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     #produce raw count table in biom format "table/feature-table.biom"
     qiime tools export --input-path ${table}  \

--- a/modules/local/qiime2_export_relasv.nf
+++ b/modules/local/qiime2_export_relasv.nf
@@ -14,6 +14,7 @@ process QIIME2_EXPORT_RELASV {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     #convert to relative abundances
     qiime feature-table relative-frequency \

--- a/modules/local/qiime2_export_relasv.nf
+++ b/modules/local/qiime2_export_relasv.nf
@@ -2,7 +2,7 @@ process QIIME2_EXPORT_RELASV {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(table)

--- a/modules/local/qiime2_export_reltax.nf
+++ b/modules/local/qiime2_export_reltax.nf
@@ -17,6 +17,7 @@ process QIIME2_EXPORT_RELTAX {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     ##on several taxa level
     array=(\$(seq ${tax_agglom_min} 1 ${tax_agglom_max}))

--- a/modules/local/qiime2_export_reltax.nf
+++ b/modules/local/qiime2_export_reltax.nf
@@ -2,7 +2,7 @@ process QIIME2_EXPORT_RELTAX {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(table)

--- a/modules/local/qiime2_extract.nf
+++ b/modules/local/qiime2_extract.nf
@@ -4,7 +4,7 @@ process QIIME2_EXTRACT {
     label 'single_cpu'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     tuple val(meta), path(database)

--- a/modules/local/qiime2_extract.nf
+++ b/modules/local/qiime2_extract.nf
@@ -16,6 +16,7 @@ process QIIME2_EXTRACT {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     ### Import
     qiime tools import --type \'FeatureData[Sequence]\' \

--- a/modules/local/qiime2_filterasv.nf
+++ b/modules/local/qiime2_filterasv.nf
@@ -3,7 +3,7 @@ process QIIME2_FILTERASV {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     tuple path(metadata), path(table), val(category)

--- a/modules/local/qiime2_filterasv.nf
+++ b/modules/local/qiime2_filterasv.nf
@@ -15,6 +15,7 @@ process QIIME2_FILTERASV {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime feature-table filter-samples \
         --i-table ${table} \

--- a/modules/local/qiime2_filtertaxa.nf
+++ b/modules/local/qiime2_filtertaxa.nf
@@ -3,7 +3,7 @@ process QIIME2_FILTERTAXA {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(table)

--- a/modules/local/qiime2_filtertaxa.nf
+++ b/modules/local/qiime2_filtertaxa.nf
@@ -22,6 +22,7 @@ process QIIME2_FILTERTAXA {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     if ! [ \"${exclude_taxa}\" = \"none\" ]; then
         #filter sequences

--- a/modules/local/qiime2_inasv.nf
+++ b/modules/local/qiime2_inasv.nf
@@ -3,7 +3,7 @@ process QIIME2_INASV {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(asv)

--- a/modules/local/qiime2_inseq.nf
+++ b/modules/local/qiime2_inseq.nf
@@ -3,7 +3,7 @@ process QIIME2_INSEQ {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(seq)

--- a/modules/local/qiime2_intax.nf
+++ b/modules/local/qiime2_intax.nf
@@ -3,7 +3,7 @@ process QIIME2_INTAX {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(tax) //ASV_tax_species.tsv

--- a/modules/local/qiime2_train.nf
+++ b/modules/local/qiime2_train.nf
@@ -4,7 +4,7 @@ process QIIME2_TRAIN {
     label 'single_cpu'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     tuple val(meta), path(qza)

--- a/modules/local/qiime2_train.nf
+++ b/modules/local/qiime2_train.nf
@@ -16,6 +16,7 @@ process QIIME2_TRAIN {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     #Train classifier
     qiime feature-classifier fit-classifier-naive-bayes \

--- a/modules/local/qiime2_tree.nf
+++ b/modules/local/qiime2_tree.nf
@@ -15,6 +15,7 @@ process QIIME2_TREE {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+    export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime alignment mafft \
         --i-sequences ${repseq} \

--- a/modules/local/qiime2_tree.nf
+++ b/modules/local/qiime2_tree.nf
@@ -2,7 +2,7 @@ process QIIME2_TREE {
     label 'process_medium'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.2"
 
     input:
     path(repseq)

--- a/modules/nf-core/modules/custom/dumpsoftwareversions/main.nf
+++ b/modules/nf-core/modules/custom/dumpsoftwareversions/main.nf
@@ -2,10 +2,10 @@ process CUSTOM_DUMPSOFTWAREVERSIONS {
     label 'process_low'
 
     // Requires `pyyaml` which does not have a dedicated container but is in the MultiQC container
-    conda (params.enable_conda ? "bioconda::multiqc=1.11" : null)
+    conda (params.enable_conda ? 'bioconda::multiqc=1.13a' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.11--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.11--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.13a--pyhdfd78af_1' :
+        'quay.io/biocontainers/multiqc:1.13a--pyhdfd78af_1' }"
 
     input:
     path versions

--- a/modules/nf-core/modules/fastqc/main.nf
+++ b/modules/nf-core/modules/fastqc/main.nf
@@ -44,4 +44,16 @@ process FASTQC {
         END_VERSIONS
         """
     }
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.html
+    touch ${prefix}.zip
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        fastqc: \$( fastqc --version | sed -e "s/FastQC v//g" )
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/modules/multiqc/main.nf
+++ b/modules/nf-core/modules/multiqc/main.nf
@@ -1,13 +1,14 @@
 process MULTIQC {
     label 'process_medium'
 
-    conda (params.enable_conda ? 'bioconda::multiqc=1.12' : null)
+    conda (params.enable_conda ? 'bioconda::multiqc=1.13a' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.12--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.12--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.13a--pyhdfd78af_1' :
+        'quay.io/biocontainers/multiqc:1.13a--pyhdfd78af_1' }"
 
     input:
-    path multiqc_files
+    path  multiqc_files, stageAs: "?/*"
+    tuple path(multiqc_config), path(multiqc_logo)
 
     output:
     path "*multiqc_report.html", emit: report
@@ -20,8 +21,25 @@ process MULTIQC {
 
     script:
     def args = task.ext.args ?: ''
+    def config = multiqc_config ? "--config $multiqc_config" : ''
     """
-    multiqc -f $args .
+    multiqc \\
+        --force \\
+        $config \\
+        $args \\
+        .
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        multiqc: \$( multiqc --version | sed -e "s/multiqc, version //g" )
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch multiqc_data
+    touch multiqc_plots
+    touch multiqc_report.html
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/modules/multiqc/meta.yml
+++ b/modules/nf-core/modules/multiqc/meta.yml
@@ -17,6 +17,14 @@ input:
       type: file
       description: |
         List of reports / files recognised by MultiQC, for example the html and zip output of FastQC
+  - multiqc_config:
+      type: file
+      description: Config yml for MultiQC
+      pattern: "*.{yml,yaml}"
+  - multiqc_logo:
+      type: file
+      description: Logo file for MultiQC
+      pattern: "*.{png}"
 output:
   - report:
       type: file

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -23,7 +23,10 @@ if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input sample
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-ch_multiqc_config        = file("$projectDir/assets/multiqc_config.yml", checkIfExists: true)
+ch_multiqc_config        = [
+                            file("$projectDir/assets/multiqc_config.yml", checkIfExists: true),
+                            file("$projectDir/assets/nf-core-ampliseq_logo_light.png", checkIfExists: true)
+                            ]
 ch_multiqc_custom_config = params.multiqc_config ? Channel.fromPath(params.multiqc_config) : Channel.empty()
 
 /*
@@ -672,8 +675,11 @@ workflow AMPLISEQ {
             ch_multiqc_files = ch_multiqc_files.mix(CUTADAPT_WORKFLOW.out.logs.collect{it[1]}.ifEmpty([]))
         }
 
+        ch_multiqc_configs = Channel.from(ch_multiqc_config).mix(ch_multiqc_custom_config).ifEmpty([])
+
         MULTIQC (
-            ch_multiqc_files.collect()
+            ch_multiqc_files.collect(),
+            ch_multiqc_configs.collect()
         )
         multiqc_report = MULTIQC.out.report.toList()
         ch_versions    = ch_versions.mix(MULTIQC.out.versions)


### PR DESCRIPTION
This updates QIIME2 to the most recent container, Picrust2, and nf-core modules.

Hm, tests worked locally, but in CI they fail with:
```
Error executing process > 'NFCORE_AMPLISEQ:AMPLISEQ:QIIME2_PREPTAX:QIIME2_EXTRACT (GTGYCAGCMGCCGCGGTAA-GGACTACNVGGGTWTCTAAT)'

Caused by:
  Process `NFCORE_AMPLISEQ:AMPLISEQ:QIIME2_PREPTAX:QIIME2_EXTRACT (GTGYCAGCMGCCGCGGTAA-GGACTACNVGGGTWTCTAAT)` terminated with an error exit status (1)

Command executed:

  export XDG_CONFIG_HOME="${PWD}/HOME"
  export MPLCONFIGDIR="${PWD}/HOME"
  
  ### Import
  qiime tools import --type 'FeatureData[Sequence]'         --input-path greengenes85.fna         --output-path ref-seq.qza
  qiime tools import --type 'FeatureData[Taxonomy]'         --input-format HeaderlessTSVTaxonomyFormat         --input-path greengenes85.tax         --output-path ref-taxonomy.qza
  #Extract sequences based on primers
  qiime feature-classifier extract-reads         --i-sequences ref-seq.qza         --p-f-primer GTGYCAGCMGCCGCGGTAA         --p-r-primer GGACTACNVGGGTWTCTAAT         --o-reads GTGYCAGCMGCCGCGGTAA-GGACTACNVGGGTWTCTAAT-ref-seq.qza         --quiet
  
  cat <<-END_VERSIONS > versions.yml
  "NFCORE_AMPLISEQ:AMPLISEQ:QIIME2_PREPTAX:QIIME2_EXTRACT":
      qiime2: $( qiime --version | sed -e "s/q2cli version //g" | tr -d '`' | sed -e "s/Run qiime info for more version details.//g" )
  END_VERSIONS

Command exit status:
  1

Command output:
  (empty)

Command error:
  f3455a9d1521: Pull complete
  e48cafe6838b: Pull complete
  d567a5191575: Pull complete
  5516372d4765: Pull complete
  1caf0a6f49c2: Pull complete
  cf7ed69f5061: Pull complete
  Digest: sha256:5b0fb4b78b6df236c1d77d97e1f7c800187675c609584cde9c6bb7acefac76ea
  Status: Downloaded newer image for quay.io/qiime2/core:2022.2
  Traceback (most recent call last):
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/q2cli/builtin/tools.py", line 157, in import_data
      artifact = qiime2.sdk.Artifact.import_data(type, input_path,
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/qiime2/sdk/result.py", line 249, in import_data
      pm = qiime2.sdk.PluginManager()
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/qiime2/sdk/plugin_manager.py", line 67, in __new__
      self._init(add_plugins=add_plugins)
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/qiime2/sdk/plugin_manager.py", line 105, in _init
      plugin = entry_point.load()
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2465, in load
      return self.resolve()
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2471, in resolve
      module = __import__(self.module_name, fromlist=['__name__'], level=0)
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/q2_diversity/__init__.py", line 11, in <module>
      from ._beta import (beta, beta_phylogenetic, bioenv,
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/q2_diversity/_beta/__init__.py", line 13, in <module>
      from ._beta_rarefaction import beta_rarefaction
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/q2_diversity/_beta/_beta_rarefaction.py", line 23, in <module>
      from .._ordination import pcoa
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/q2_diversity/_ordination.py", line 13, in <module>
      import umap as up
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/umap/__init__.py", line 2, in <module>
      from .umap_ import UMAP
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/umap/umap_.py", line 41, in <module>
      from umap.layouts import (
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/umap/layouts.py", line 40, in <module>
      def rdist(x, y):
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/numba/core/decorators.py", line 214, in wrapper
      disp.enable_caching()
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/numba/core/dispatcher.py", line 812, in enable_caching
      self._cache = FunctionCache(self.py_func)
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/numba/core/caching.py", line 610, in __init__
      self._impl = self._impl_class(py_func)
    File "/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/numba/core/caching.py", line 347, in __init__
      raise RuntimeError("cannot cache function %r: no locator available "
  RuntimeError: cannot cache function 'rdist': no locator available for file '/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/umap/layouts.py'
  
  An unexpected error has occurred:
  
    cannot cache function 'rdist': no locator available for file '/opt/conda/envs/qiime2-2022.2/lib/python3.8/site-packages/umap/layouts.py'
  
  See above for debug info.

Work dir:
  /home/runner/work/ampliseq/ampliseq/work/74/fd0dafb5befdb8043c18a09d1ebdef

Tip: you can replicate the issue by changing to the process work dir and entering the command `bash .command.run`


Execution cancelled -- Finishing pending tasks before exit
Cannot invoke method getAt() on null object

 -- Check script './workflows/ampliseq.nf' at line: 272 or see '.nextflow.log' file for more details
WARN: Got an interrupted exception while taking agent result | java.lang.InterruptedException
-[nf-core/ampliseq] Pipeline completed with errors-
WARN: Killing running tasks (1)
Error: Process completed with exit code 1.
```
Only Info I found was https://forum.qiime2.org/t/docker-throwing-error-in-latest-version-of-qiime/23653/5 which identifies docker's `-u` make the process fail while when omitting `-u` it succeeds.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
