### PR TITLE
produce QC plot after preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#460](https://github.com/nf-core/ampliseq/pull/460) - Taxonomic ranks for DADA2 taxonomic classification can be now adjusted using `--dada_assign_taxlevels <comma separated string>`.
 - [#461](https://github.com/nf-core/ampliseq/pull/461) - A custom DADA2 reference taxonomy database can now be used with `--dada_ref_tax_custom` and `--dada_ref_tax_custom_sp`, typically accompanied by `--dada_assign_taxlevels`.
 - [#446](https://github.com/nf-core/ampliseq/pull/446),[#467](https://github.com/nf-core/ampliseq/pull/467) - Binned quality scores from Illumina NovaSeq data can be now corrected with `--illumina_novaseq`.
+- [#477](https://github.com/nf-core/ampliseq/pull/477) - QC plots of DADA2's plotQualityProfile are now also produced after preprocessing.
 
 ### `Changed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -159,6 +159,23 @@ process {
         ]
     }
 
+    withName: DADA2_QUALITY2 {
+        ext.args = ", n = 5e+04, aggregate = TRUE"
+        ext.prefix = { "${meta}_preprocessed" }
+        publishDir = [
+            [
+                path: { "${params.outdir}/dada2/QC" },
+                mode: params.publish_dir_mode,
+                pattern: "*{.pdf,plotQualityProfile.txt}"
+            ],
+            [
+                path: { "${params.outdir}/dada2/args" },
+                mode: params.publish_dir_mode,
+                pattern: "*.args.txt"
+            ]
+        ]
+    }
+
     withName: DADA2_ERR {
         ext.seed = "${params.seed}"
         ext.args = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -166,7 +166,7 @@ process {
             [
                 path: { "${params.outdir}/dada2/QC" },
                 mode: params.publish_dir_mode,
-                pattern: "*{.pdf,plotQualityProfile.txt}"
+                pattern: "*{.pdf}"
             ],
             [
                 path: { "${params.outdir}/dada2/args" },

--- a/docs/output.md
+++ b/docs/output.md
@@ -118,6 +118,7 @@ DADA2 reduces sequence errors and dereplicates sequences by quality filtering, d
   - `*.err.convergence.txt`: Convergence values for DADA2's dada command, should reduce over several magnitudes and approaching 0.
   - `*.err.pdf`: Estimated error rates for each possible transition. The black line shows the estimated error rates after convergence of the machine-learning algorithm. The red line shows the error rates expected under the nominal definition of the Q-score. The estimated error rates (black line) should be a good fit to the observed rates (points), and the error rates should drop with increased quality.
   - `*_qual_stats.pdf`: Overall read quality profiles: heat map of the frequency of each quality score at each base position. The mean quality score at each position is shown by the green line, and the quartiles of the quality score distribution by the orange lines. The red line shows the scaled proportion of reads that extend to at least that position.
+  - `*_preprocessed_qual_stats.pdf`: Same as above, but after preprocessing.
 
 </details>
 

--- a/modules/local/dada2_quality.nf
+++ b/modules/local/dada2_quality.nf
@@ -11,7 +11,7 @@ process DADA2_QUALITY {
     tuple val(meta), path(reads)
 
     output:
-    path "${meta}_qual_stats.pdf"            , emit: pdf
+    path "*_qual_stats.pdf"            , emit: pdf
     tuple val(meta), path("*_qual_stats.tsv"), emit: tsv
     path "versions.yml"                      , emit: versions
     path "*.args.txt"                        , emit: args
@@ -19,6 +19,7 @@ process DADA2_QUALITY {
 
     script:
     def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta}"
     """
     #!/usr/bin/env Rscript
 
@@ -38,7 +39,7 @@ process DADA2_QUALITY {
         readfiles <- readfiles[1:max_files]
     } else {
         max_files <- length(readfiles)
-        write.table(max_files, file = paste0(max_files," files were used for ${meta} plotQualityProfile.txt"), row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
+        write.table(max_files, file = paste0(max_files," files were used for ${prefix} plotQualityProfile.txt"), row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
     }
 
     plot <- plotQualityProfile(readfiles$args)
@@ -57,12 +58,12 @@ process DADA2_QUALITY {
     }
 
     #write output
-    write.table( t(df), file = paste0("${meta}_qual_stats",".tsv"), sep = "\t", row.names = TRUE, col.names = FALSE, quote = FALSE)
-    pdf(paste0("${meta}_qual_stats",".pdf"))
+    write.table( t(df), file = paste0("${prefix}_qual_stats",".tsv"), sep = "\t", row.names = TRUE, col.names = FALSE, quote = FALSE)
+    pdf(paste0("${prefix}_qual_stats",".pdf"))
     plot
     dev.off()
 
-    write.table(paste0('plotQualityProfile\t$args\nmax_files\t',max_files), file = "plotQualityProfile.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
+    write.table(paste0('plotQualityProfile\t$args\nmax_files\t',max_files), file = "${prefix}_plotQualityProfile.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
     writeLines(c("\\"${task.process}\\":", paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")),paste0("    dada2: ", packageVersion("dada2")),paste0("    ShortRead: ", packageVersion("ShortRead")) ), "versions.yml")
     """
 }

--- a/subworkflows/local/dada2_preprocessing.nf
+++ b/subworkflows/local/dada2_preprocessing.nf
@@ -1,0 +1,124 @@
+/*
+ * Preprocessing with DADA2
+ */
+
+include { DADA2_QUALITY                   } from '../../modules/local/dada2_quality'
+include { TRUNCLEN                        } from '../../modules/local/trunclen'
+include { DADA2_FILTNTRIM                 } from '../../modules/local/dada2_filtntrim'
+include { DADA2_QUALITY as DADA2_QUALITY2 } from '../../modules/local/dada2_quality'
+
+workflow DADA2_PREPROCESSING {
+    take:
+    ch_trimmed_reads
+    single_end
+    find_truncation_values
+    trunclenf
+    trunclenr
+
+    main:
+    ch_versions_dada2_preprocessing = Channel.empty()
+
+    //plot unprocessed, aggregated quality profile for forward and reverse reads separately
+    if (single_end) {
+        ch_trimmed_reads
+            .map { meta, reads -> [ reads ] }
+            .collect()
+            .map { reads -> [ "single_end", reads ] }
+            .set { ch_all_trimmed_reads }
+    } else {
+        ch_trimmed_reads
+            .map { meta, reads -> [ reads[0] ] }
+            .collect()
+            .map { reads -> [ "FW", reads ] }
+            .set { ch_all_trimmed_fw }
+        ch_trimmed_reads
+            .map { meta, reads -> [ reads[1] ] }
+            .collect()
+            .map { reads -> [ "RV", reads ] }
+            .set { ch_all_trimmed_rv }
+        ch_all_trimmed_fw
+            .mix ( ch_all_trimmed_rv )
+            .set { ch_all_trimmed_reads }
+    }
+
+    if ( !params.skip_dada_quality ) {
+        DADA2_QUALITY ( ch_all_trimmed_reads.dump(tag: 'into_dada2_quality') )
+        ch_versions_dada2_preprocessing = ch_versions_dada2_preprocessing.mix(DADA2_QUALITY.out.versions.first())
+        DADA2_QUALITY.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn it.baseName.toString().replace("WARNING ","DADA2_QUALITY: ") }
+    }
+
+    //find truncation values in case they are not supplied
+    if ( find_truncation_values ) {
+        TRUNCLEN ( DADA2_QUALITY.out.tsv )
+        TRUNCLEN.out.trunc
+            .toSortedList()
+            .set { ch_trunc }
+        ch_versions_dada2_preprocessing = ch_versions_dada2_preprocessing.mix(TRUNCLEN.out.versions.first())
+        //add one more warning or reminder that trunclenf and trunclenr were chosen automatically
+        ch_trunc.subscribe {
+            if ( "${it[0][1]}".toInteger() + "${it[1][1]}".toInteger() <= 10 ) { log.warn "`--trunclenf` was set to ${it[0][1]} and `--trunclenr` to ${it[1][1]}, this is too low! Please either change `--trunc_qmin` (and `--trunc_rmin`), or set `--trunclenf` and `--trunclenr`." }
+            else if ( "${it[0][1]}".toInteger() <= 10 ) { log.warn "`--trunclenf` was set to ${it[0][1]}, this is too low! Please either change `--trunc_qmin` (and `--trunc_rmin`), or set `--trunclenf` and `--trunclenr`." }
+            else if ( "${it[1][1]}".toInteger() <= 10 ) { log.warn "`--trunclenr` was set to ${it[1][1]}, this is too low! Please either change `--trunc_qmin` (and `--trunc_rmin`), or set `--trunclenf` and `--trunclenr`." }
+            else log.warn "Probably everything is fine, but this is a reminder that `--trunclenf` was set automatically to ${it[0][1]} and `--trunclenr` to ${it[1][1]}. If this doesnt seem reasonable, then please change `--trunc_qmin` (and `--trunc_rmin`), or set `--trunclenf` and `--trunclenr` directly."
+        }
+    } else {
+        Channel.from( [['FW', trunclenf], ['RV', trunclenr]] )
+            .toSortedList()
+            .set { ch_trunc }
+    }
+    ch_trimmed_reads.combine(ch_trunc).set { ch_trimmed_reads }
+
+    //filter reads
+    DADA2_FILTNTRIM ( ch_trimmed_reads.dump(tag: 'into_filtntrim')  )
+    ch_versions_dada2_preprocessing = ch_versions_dada2_preprocessing.mix(DADA2_FILTNTRIM.out.versions.first())
+
+    //plot post-processing, aggregated quality profile for forward and reverse reads separately
+    if (single_end) {
+        DADA2_FILTNTRIM.out.reads
+            .map { meta, reads -> [ reads ] }
+            .collect()
+            .map { reads -> [ "single_end", reads ] }
+            .set { ch_all_preprocessed_reads }
+    } else {
+        DADA2_FILTNTRIM.out.reads
+            .map { meta, reads -> [ reads[0] ] }
+            .collect()
+            .map { reads -> [ "FW", reads ] }
+            .set { ch_all_preprocessed_fw }
+        DADA2_FILTNTRIM.out.reads
+            .map { meta, reads -> [ reads[1] ] }
+            .collect()
+            .map { reads -> [ "RV", reads ] }
+            .set { ch_all_preprocessed_rv }
+        ch_all_preprocessed_fw
+            .mix ( ch_all_preprocessed_rv )
+            .set { ch_all_preprocessed_reads }
+    }
+    if ( !params.skip_dada_quality ) {
+        DADA2_QUALITY2 ( ch_all_preprocessed_reads.dump(tag: 'into_dada2_quality2') )
+        DADA2_QUALITY2.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn it.baseName.toString().replace("WARNING ","DADA2_QUALITY2: ") }
+    }
+
+    //group by sequencing run
+    DADA2_FILTNTRIM.out.reads
+        .map {
+            info, reads ->
+                def meta = [:]
+                meta.run = info.run
+                meta.single_end = info.single_end
+                [ meta, reads, info.id ] }
+        .groupTuple(by: 0 )
+        .map {
+            info, reads, ids ->
+                def meta = [:]
+                meta.run = info.run
+                meta.single_end = info.single_end
+                meta.id = ids.flatten().sort()
+                [ meta, reads.flatten().sort() ] }
+        .set { ch_filt_reads }
+
+    emit:
+    reads    = ch_filt_reads
+    logs      = DADA2_FILTNTRIM.out.log
+    versions = ch_versions_dada2_preprocessing
+}

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -115,9 +115,6 @@ if ( params.addsh ) {
 */
 
 include { RENAME_RAW_DATA_FILES         } from '../modules/local/rename_raw_data_files'
-include { DADA2_FILTNTRIM               } from '../modules/local/dada2_filtntrim'
-include { DADA2_QUALITY                 } from '../modules/local/dada2_quality'
-include { TRUNCLEN                      } from '../modules/local/trunclen'
 include { DADA2_ERR                     } from '../modules/local/dada2_err'
 include { NOVASEQ_ERR                   } from '../modules/local/novaseq_err'
 include { DADA2_DENOISING               } from '../modules/local/dada2_denoising'
@@ -155,6 +152,7 @@ include { SBDIEXPORTREANNOTATE          } from '../modules/local/sbdiexportreann
 //
 
 include { PARSE_INPUT                   } from '../subworkflows/local/parse_input'
+include { DADA2_PREPROCESSING           } from '../subworkflows/local/dada2_preprocessing'
 include { QIIME2_PREPTAX                } from '../subworkflows/local/qiime2_preptax'
 include { QIIME2_TAXONOMY               } from '../subworkflows/local/qiime2_taxonomy'
 include { CUTADAPT_WORKFLOW             } from '../subworkflows/local/cutadapt_workflow'
@@ -228,78 +226,20 @@ workflow AMPLISEQ {
     }
 
     //
-    // SUBWORKFLOW / MODULES : ASV generation with DADA2
+    // SUBWORKFLOW: Read preprocessing & QC plotting with DADA2
     //
-    //plot aggregated quality profile for forward and reverse reads separately
-    if (single_end) {
-        ch_trimmed_reads
-            .map { meta, reads -> [ reads ] }
-            .collect()
-            .map { reads -> [ "single_end", reads ] }
-            .set { ch_all_trimmed_reads }
-    } else {
-        ch_trimmed_reads
-            .map { meta, reads -> [ reads[0] ] }
-            .collect()
-            .map { reads -> [ "FW", reads ] }
-            .set { ch_all_trimmed_fw }
-        ch_trimmed_reads
-            .map { meta, reads -> [ reads[1] ] }
-            .collect()
-            .map { reads -> [ "RV", reads ] }
-            .set { ch_all_trimmed_rv }
-        ch_all_trimmed_fw
-            .mix ( ch_all_trimmed_rv )
-            .set { ch_all_trimmed_reads }
-    }
+    DADA2_PREPROCESSING ( 
+        ch_trimmed_reads,
+        single_end,
+        find_truncation_values,
+        trunclenf,
+        trunclenr
+    ).reads.set { ch_filt_reads }
+    ch_versions = ch_versions.mix(DADA2_PREPROCESSING.out.versions)
 
-    if ( !params.skip_dada_quality ) {
-        DADA2_QUALITY ( ch_all_trimmed_reads )
-        DADA2_QUALITY.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn it.baseName.toString().replace("WARNING ","DADA2_QUALITY: ") }
-    }
-
-    //find truncation values in case they are not supplied
-    if ( find_truncation_values ) {
-        TRUNCLEN ( DADA2_QUALITY.out.tsv )
-        TRUNCLEN.out.trunc
-            .toSortedList()
-            .set { ch_trunc }
-        ch_versions = ch_versions.mix(TRUNCLEN.out.versions.first())
-        //add one more warning or reminder that trunclenf and trunclenr were chosen automatically
-        ch_trunc.subscribe {
-            if ( "${it[0][1]}".toInteger() + "${it[1][1]}".toInteger() <= 10 ) { log.warn "`--trunclenf` was set to ${it[0][1]} and `--trunclenr` to ${it[1][1]}, this is too low! Please either change `--trunc_qmin` (and `--trunc_rmin`), or set `--trunclenf` and `--trunclenr`." }
-            else if ( "${it[0][1]}".toInteger() <= 10 ) { log.warn "`--trunclenf` was set to ${it[0][1]}, this is too low! Please either change `--trunc_qmin` (and `--trunc_rmin`), or set `--trunclenf` and `--trunclenr`." }
-            else if ( "${it[1][1]}".toInteger() <= 10 ) { log.warn "`--trunclenr` was set to ${it[1][1]}, this is too low! Please either change `--trunc_qmin` (and `--trunc_rmin`), or set `--trunclenf` and `--trunclenr`." }
-            else log.warn "Probably everything is fine, but this is a reminder that `--trunclenf` was set automatically to ${it[0][1]} and `--trunclenr` to ${it[1][1]}. If this doesnt seem reasonable, then please change `--trunc_qmin` (and `--trunc_rmin`), or set `--trunclenf` and `--trunclenr` directly."
-        }
-    } else {
-        Channel.from( [['FW', trunclenf], ['RV', trunclenr]] )
-            .toSortedList()
-            .set { ch_trunc }
-    }
-    ch_trimmed_reads.combine(ch_trunc).set { ch_trimmed_reads }
-
-    //filter reads
-    DADA2_FILTNTRIM ( ch_trimmed_reads.dump(tag: 'into_filtntrim')  )
-    //ch_versions = ch_versions.mix(DADA2_FILTNTRIM.out.versions.first())
-
-    //group by sequencing run
-    DADA2_FILTNTRIM.out.reads
-        .map {
-            info, reads ->
-                def meta = [:]
-                meta.run = info.run
-                meta.single_end = info.single_end
-                [ meta, reads, info.id ] }
-        .groupTuple(by: 0 )
-        .map {
-            info, reads, ids ->
-                def meta = [:]
-                meta.run = info.run
-                meta.single_end = info.single_end
-                meta.id = ids.flatten().sort()
-                [ meta, reads.flatten().sort() ] }
-        .set { ch_filt_reads }
+    //
+    // MODULES: ASV generation with DADA2
+    //
 
     //run error model
     if ( !params.illumina_novaseq ) {
@@ -321,7 +261,7 @@ workflow AMPLISEQ {
     DADA2_RMCHIMERA ( DADA2_DENOISING.out.seqtab )
 
     //group by sequencing run & group by meta
-    DADA2_FILTNTRIM.out.log
+    DADA2_PREPROCESSING.out.logs
         .map {
             info, reads ->
                 def meta = [:]


### PR DESCRIPTION
This adds a QC plot also after all read preprocessing steps. Until now, there was FASTQC on raw data, DADA2's plotQualityProfile after trimming (cutadapt), and now there is also DADA2's plotQualityProfile after quality and length filtering, i.e. directly before ASV computation.
I have also added those DADA2 preprocessing & QC plotting into a separate workflow.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
