### PR TITLE
update nf-core modules and local picrust module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
+- [#479](https://github.com/nf-core/ampliseq/pull/479) - Updated software
+
+| Tool     | Previous version | New version |
+| -------- | ---------------- | ----------- |
+| PICRUSt2 | 2.4.2            | 2.5.0       |
+| MultiQC  | 1.12             | 1.13a       |
+
 ### `Removed`
 
 ## nf-core/ampliseq version 2.3.2 - 2022-05-27

--- a/modules.json
+++ b/modules.json
@@ -7,7 +7,7 @@
             "modules": {
                 "custom/dumpsoftwareversions": {
                     "branch": "master",
-                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                    "git_sha": "e5b44499efcf6f7fb24874886bac60591c5d94dd"
                 },
                 "cutadapt": {
                     "branch": "master",
@@ -15,11 +15,11 @@
                 },
                 "fastqc": {
                     "branch": "master",
-                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                    "git_sha": "49b18b1639f4f7104187058866a8fab33332bdfe"
                 },
                 "multiqc": {
                     "branch": "master",
-                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                    "git_sha": "5138acca0985ca01c38a1c4fba917d83772b1106"
                 },
                 "vsearch/usearchglobal": {
                     "branch": "master",

--- a/modules/local/picrust.nf
+++ b/modules/local/picrust.nf
@@ -2,10 +2,10 @@ process PICRUST {
     tag "${seq},${abund}"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::picrust2=2.4.2" : null)
+    conda (params.enable_conda ? "bioconda::picrust2=2.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/picrust2:2.4.2--pyhdfd78af_0' :
-        'quay.io/biocontainers/picrust2:2.4.2--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/picrust2:2.5.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/picrust2:2.5.0--pyhdfd78af_0' }"
 
     input:
     path(seq)

--- a/modules/nf-core/modules/custom/dumpsoftwareversions/main.nf
+++ b/modules/nf-core/modules/custom/dumpsoftwareversions/main.nf
@@ -2,10 +2,10 @@ process CUSTOM_DUMPSOFTWAREVERSIONS {
     label 'process_low'
 
     // Requires `pyyaml` which does not have a dedicated container but is in the MultiQC container
-    conda (params.enable_conda ? "bioconda::multiqc=1.11" : null)
+    conda (params.enable_conda ? 'bioconda::multiqc=1.13a' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.11--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.11--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.13a--pyhdfd78af_1' :
+        'quay.io/biocontainers/multiqc:1.13a--pyhdfd78af_1' }"
 
     input:
     path versions

--- a/modules/nf-core/modules/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
+++ b/modules/nf-core/modules/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
+import yaml
 import platform
 from textwrap import dedent
-
-import yaml
 
 
 def _make_versions_html(versions):
@@ -59,12 +58,11 @@ versions_by_module = {}
 for process, process_versions in versions_by_process.items():
     module = process.split(":")[-1]
     try:
-        if versions_by_module[module] != process_versions:
-            raise AssertionError(
-                "We assume that software versions are the same between all modules. "
-                "If you see this error-message it means you discovered an edge-case "
-                "and should open an issue in nf-core/tools. "
-            )
+        assert versions_by_module[module] == process_versions, (
+            "We assume that software versions are the same between all modules. "
+            "If you see this error-message it means you discovered an edge-case "
+            "and should open an issue in nf-core/tools. "
+        )
     except KeyError:
         versions_by_module[module] = process_versions
 

--- a/modules/nf-core/modules/fastqc/main.nf
+++ b/modules/nf-core/modules/fastqc/main.nf
@@ -44,4 +44,16 @@ process FASTQC {
         END_VERSIONS
         """
     }
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.html
+    touch ${prefix}.zip
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        fastqc: \$( fastqc --version | sed -e "s/FastQC v//g" )
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/modules/multiqc/main.nf
+++ b/modules/nf-core/modules/multiqc/main.nf
@@ -1,13 +1,14 @@
 process MULTIQC {
     label 'process_medium'
 
-    conda (params.enable_conda ? 'bioconda::multiqc=1.12' : null)
+    conda (params.enable_conda ? 'bioconda::multiqc=1.13a' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.12--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.12--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.13a--pyhdfd78af_1' :
+        'quay.io/biocontainers/multiqc:1.13a--pyhdfd78af_1' }"
 
     input:
-    path multiqc_files
+    path  multiqc_files, stageAs: "?/*"
+    tuple path(multiqc_config), path(multiqc_logo)
 
     output:
     path "*multiqc_report.html", emit: report
@@ -20,8 +21,25 @@ process MULTIQC {
 
     script:
     def args = task.ext.args ?: ''
+    def config = multiqc_config ? "--config $multiqc_config" : ''
     """
-    multiqc -f $args .
+    multiqc \\
+        --force \\
+        $config \\
+        $args \\
+        .
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        multiqc: \$( multiqc --version | sed -e "s/multiqc, version //g" )
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch multiqc_data
+    touch multiqc_plots
+    touch multiqc_report.html
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/modules/multiqc/meta.yml
+++ b/modules/nf-core/modules/multiqc/meta.yml
@@ -17,6 +17,14 @@ input:
       type: file
       description: |
         List of reports / files recognised by MultiQC, for example the html and zip output of FastQC
+  - multiqc_config:
+      type: file
+      description: Config yml for MultiQC
+      pattern: "*.{yml,yaml}"
+  - multiqc_logo:
+      type: file
+      description: Logo file for MultiQC
+      pattern: "*.{png}"
 output:
   - report:
       type: file

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -23,7 +23,10 @@ if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input sample
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-ch_multiqc_config        = file("$projectDir/assets/multiqc_config.yml", checkIfExists: true)
+ch_multiqc_config        = [
+                           file("$projectDir/assets/multiqc_config.yml", checkIfExists: true),
+                           file("$projectDir/assets/nf-core-ampliseq_logo_light.png", checkIfExists: true)
+                           ]
 ch_multiqc_custom_config = params.multiqc_config ? Channel.fromPath(params.multiqc_config) : Channel.empty()
 
 /*
@@ -623,8 +626,11 @@ workflow AMPLISEQ {
             ch_multiqc_files = ch_multiqc_files.mix(CUTADAPT_WORKFLOW.out.logs.collect{it[1]}.ifEmpty([]))
         }
 
+        ch_multiqc_configs = Channel.from(ch_multiqc_config).mix(ch_multiqc_custom_config).ifEmpty([])
+
         MULTIQC (
-            ch_multiqc_files.collect()
+            ch_multiqc_files.collect(),
+            ch_multiqc_configs.collect()
         )
         multiqc_report = MULTIQC.out.report.toList()
         ch_versions    = ch_versions.mix(MULTIQC.out.versions)


### PR DESCRIPTION
Update software version as in https://github.com/nf-core/ampliseq/pull/468 but not QIIME2 (newer containers fail to run with docker).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
