### PR TITLE
correct website indent in main.nf

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -4,7 +4,7 @@
     nf-core/ampliseq
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Github : https://github.com/nf-core/ampliseq
-Website: https://nf-co.re/ampliseq
+    Website: https://nf-co.re/ampliseq
     Slack  : https://nfcore.slack.com/channels/ampliseq
 ----------------------------------------------------------------------------------------
 */


### PR DESCRIPTION
Uniform indent in main.nf, which was misaligned in template update 2.5.0/2.5.1

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
