### PR TITLE
Fix missing when statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#486](https://github.com/nf-core/ampliseq/pull/486) - Fixed typo in error message stating `--skip_classifer` instead of `--classifier`.
 - [#487](https://github.com/nf-core/ampliseq/pull/487),[#488](https://github.com/nf-core/ampliseq/pull/488) - Update stale links in usage documentation.
+- [#489](https://github.com/nf-core/ampliseq/pull/489) - Reduce linting warnings for nf-core tools version 2.5.1.
 
 ### `Dependencies`
 

--- a/modules/local/assignsh.nf
+++ b/modules/local/assignsh.nf
@@ -17,6 +17,9 @@ process ASSIGNSH {
     path outtable        , emit: tsv
     path "versions.yml"  , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     """

--- a/modules/local/barrnap.nf
+++ b/modules/local/barrnap.nf
@@ -15,6 +15,9 @@ process BARRNAP {
     path( "rrna.*.gff" )    , emit: gff
     path "versions.yml"     , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def kingdom = task.ext.kingdom ?: "bac,arc,mito,euk"

--- a/modules/local/combine_table.nf
+++ b/modules/local/combine_table.nf
@@ -16,6 +16,9 @@ process COMBINE_TABLE {
     path("${outfile}")  , emit: tsv
     path "versions.yml" , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     combine_table.r ${table} ${seq} ${tax}

--- a/modules/local/cutadapt_summary.nf
+++ b/modules/local/cutadapt_summary.nf
@@ -15,6 +15,9 @@ process CUTADAPT_SUMMARY {
     path("*_summary.tsv") , emit: tsv
     path "versions.yml"   , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def mode  = meta.single_end ? "single_end" : "paired_end"
     """

--- a/modules/local/cutadapt_summary_merge.nf
+++ b/modules/local/cutadapt_summary_merge.nf
@@ -15,6 +15,9 @@ process CUTADAPT_SUMMARY_MERGE {
     path("cutadapt_summary.tsv")      , emit: tsv
     path "versions.yml", optional:true, emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     if (action == "merge") {
         """

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -19,6 +19,9 @@ process DADA2_ADDSPECIES {
     path "versions.yml" , emit: versions
     path "*.args.txt"   , emit: args
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def taxlevels = taxlevels_input ?

--- a/modules/local/dada2_denoising.nf
+++ b/modules/local/dada2_denoising.nf
@@ -19,6 +19,9 @@ process DADA2_DENOISING {
     path "versions.yml"                   , emit: versions
     path "*.args.txt"                     , emit: args
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''

--- a/modules/local/dada2_err.nf
+++ b/modules/local/dada2_err.nf
@@ -18,6 +18,9 @@ process DADA2_ERR {
     path "versions.yml"               , emit: versions
     path "*.args.txt"                 , emit: args
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def seed = task.ext.seed ?: '100'

--- a/modules/local/dada2_filtntrim.nf
+++ b/modules/local/dada2_filtntrim.nf
@@ -16,6 +16,9 @@ process DADA2_FILTNTRIM {
     path "versions.yml"                        , emit: versions
     path "*.args.txt"                          , emit: args
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args        = task.ext.args ?: ''
     def in_and_out  = meta.single_end ? "\"${reads}\", \"${meta.id}.filt.fastq.gz\"" : "\"${reads[0]}\", \"${meta.id}_1.filt.fastq.gz\", \"${reads[1]}\", \"${meta.id}_2.filt.fastq.gz\""

--- a/modules/local/dada2_merge.nf
+++ b/modules/local/dada2_merge.nf
@@ -18,6 +18,9 @@ process DADA2_MERGE {
     path( "DADA2_table.rds" ), emit: rds
     path "versions.yml"      , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     #!/usr/bin/env Rscript

--- a/modules/local/dada2_quality.nf
+++ b/modules/local/dada2_quality.nf
@@ -17,6 +17,9 @@ process DADA2_QUALITY {
     path "*.args.txt"                        , emit: args
     path "*plotQualityProfile.txt"           , emit: warning
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta}"

--- a/modules/local/dada2_rmchimera.nf
+++ b/modules/local/dada2_rmchimera.nf
@@ -15,6 +15,9 @@ process DADA2_RMCHIMERA {
     path "versions.yml"                    , emit: versions
     path "*.args.txt"                      , emit: args
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def no_samples    = meta.id.size()

--- a/modules/local/dada2_stats.nf
+++ b/modules/local/dada2_stats.nf
@@ -14,6 +14,9 @@ process DADA2_STATS {
     tuple val(meta), path("*.stats.tsv"), emit: stats
     path "versions.yml"                 , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     if (!meta.single_end) {
         """

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -19,6 +19,9 @@ process DADA2_TAXONOMY {
     path "versions.yml"  , emit: versions
     path "*.args.txt"    , emit: args
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def taxlevels = taxlevels_input ?

--- a/modules/local/filter_len_asv.nf
+++ b/modules/local/filter_len_asv.nf
@@ -19,6 +19,9 @@ process FILTER_LEN_ASV {
     path( "ASV_len_filt.tsv" )   , emit: len_filt
     path "versions.yml"          , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def min_len_asv = params.min_len_asv ?: '1'
     def max_len_asv = params.max_len_asv ?: '1000000'

--- a/modules/local/filter_ssu.nf
+++ b/modules/local/filter_ssu.nf
@@ -18,6 +18,9 @@ process FILTER_SSU {
     path( "ASV_seqs.ssu.fasta" ) , emit: fasta
     path "versions.yml"          , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def kingdom = params.filter_ssu ?: "bac,arc,mito,euk"
     """

--- a/modules/local/filter_stats.nf
+++ b/modules/local/filter_stats.nf
@@ -14,6 +14,9 @@ process FILTER_STATS {
     path("count_table_filter_stats.tsv"), emit: tsv
     path "versions.yml"                 , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     filter_stats.py $unfiltered $filtered

--- a/modules/local/format_taxonomy.nf
+++ b/modules/local/format_taxonomy.nf
@@ -14,6 +14,9 @@ process FORMAT_TAXONOMY {
     path( "*addSpecies.fna*")     , emit: addspecies
     path( "ref_taxonomy.txt")     , emit: ref_tax_info
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     ${params.dada_ref_databases[params.dada_ref_taxonomy]["fmtscript"]}

--- a/modules/local/format_taxonomy.nf
+++ b/modules/local/format_taxonomy.nf
@@ -13,6 +13,7 @@ process FORMAT_TAXONOMY {
     path( "*assignTaxonomy.fna*" ), emit: assigntax
     path( "*addSpecies.fna*")     , emit: addspecies
     path( "ref_taxonomy.txt")     , emit: ref_tax_info
+    path "versions.yml"           , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -26,5 +27,10 @@ process FORMAT_TAXONOMY {
     echo -e "Title: ${params.dada_ref_databases[params.dada_ref_taxonomy]["title"]}\n" >>ref_taxonomy.txt
     echo -e "Citation: ${params.dada_ref_databases[params.dada_ref_taxonomy]["citation"]}\n" >>ref_taxonomy.txt
     echo "All entries: ${params.dada_ref_databases[params.dada_ref_taxonomy]}" >>ref_taxonomy.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bash: \$(bash --version | sed -n 1p | sed 's/GNU bash, version //g')
+    END_VERSIONS
     """
 }

--- a/modules/local/format_taxonomy_qiime.nf
+++ b/modules/local/format_taxonomy_qiime.nf
@@ -11,9 +11,10 @@ process FORMAT_TAXONOMY_QIIME {
     path(database)
 
     output:
-    path( "*.tax" ), emit: tax
-    path( "*.fna" ), emit: fasta
+    path( "*.tax" )          , emit: tax
+    path( "*.fna" )          , emit: fasta
     path( "ref_taxonomy.txt"), emit: ref_tax_info
+    path "versions.yml"      , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,5 +28,10 @@ process FORMAT_TAXONOMY_QIIME {
     echo -e "Title: ${params.qiime_ref_databases[params.qiime_ref_taxonomy]["title"]}\n" >>ref_taxonomy.txt
     echo -e "Citation: ${params.qiime_ref_databases[params.qiime_ref_taxonomy]["citation"]}\n" >>ref_taxonomy.txt
     echo "All entries: ${params.qiime_ref_databases[params.qiime_ref_taxonomy]}" >>ref_taxonomy.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bash: \$(bash --version | sed -n 1p | sed 's/GNU bash, version //g')
+    END_VERSIONS
     """
 }

--- a/modules/local/format_taxonomy_qiime.nf
+++ b/modules/local/format_taxonomy_qiime.nf
@@ -15,6 +15,9 @@ process FORMAT_TAXONOMY_QIIME {
     path( "*.fna" ), emit: fasta
     path( "ref_taxonomy.txt"), emit: ref_tax_info
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     ${params.qiime_ref_databases[params.qiime_ref_taxonomy]["fmtscript"]}

--- a/modules/local/format_taxresults.nf
+++ b/modules/local/format_taxresults.nf
@@ -15,6 +15,9 @@ process FORMAT_TAXRESULTS {
     path(outfile)      , emit: tsv
     path "versions.yml", emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     add_full_sequence_to_taxfile.py $taxtable $fastafile $outfile

--- a/modules/local/itsx_cutasv.nf
+++ b/modules/local/itsx_cutasv.nf
@@ -17,6 +17,9 @@ process ITSX_CUTASV {
     path "versions.yml"  , emit: versions
     path "*.args.txt"    , emit: args
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     """

--- a/modules/local/merge_stats.nf
+++ b/modules/local/merge_stats.nf
@@ -14,6 +14,9 @@ process MERGE_STATS {
     path("overall_summary.tsv") , emit: tsv
     path "versions.yml"         , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     #!/usr/bin/env Rscript

--- a/modules/local/metadata_all.nf
+++ b/modules/local/metadata_all.nf
@@ -11,7 +11,8 @@ process METADATA_ALL {
     path(metadata)
 
     output:
-    stdout
+    stdout               emit: category
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/metadata_all.nf
+++ b/modules/local/metadata_all.nf
@@ -13,6 +13,9 @@ process METADATA_ALL {
     output:
     stdout
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     metadata_all.r ${metadata}

--- a/modules/local/metadata_pairwise.nf
+++ b/modules/local/metadata_pairwise.nf
@@ -13,6 +13,9 @@ process METADATA_PAIRWISE {
     output:
     stdout
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     metadata_pairwise.r ${metadata}

--- a/modules/local/metadata_pairwise.nf
+++ b/modules/local/metadata_pairwise.nf
@@ -11,7 +11,8 @@ process METADATA_PAIRWISE {
     path(metadata)
 
     output:
-    stdout
+    stdout               emit: category
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/novaseq_err.nf
+++ b/modules/local/novaseq_err.nf
@@ -13,7 +13,7 @@ process NOVASEQ_ERR {
     tuple val(meta), path("*.md.err.rds"), emit: errormodel
     tuple val(meta), path("*.md.err.pdf"), emit: pdf
     tuple val(meta), path("*.md.err.convergence.txt"), emit: convergence
-    //path "versions.yml"                  , emit: versions
+    path "versions.yml"                  , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,10 +22,20 @@ process NOVASEQ_ERR {
     if (!meta.single_end) {
         """
         novaseq_err_pe.r ${errormodel[0]} ${errormodel[1]} ${meta.run}
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            R: \$(R --version | sed -n 1p | sed 's/R version //g' | sed 's/\\s.*\$//')
+        END_VERSIONS
         """
     } else {
         """
         novaseq_err_se.r ${errormodel} ${meta.run}
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            R: \$(R --version | sed -n 1p | sed 's/R version //g' | sed 's/\\s.*\$//')
+        END_VERSIONS
         """
     }
 }

--- a/modules/local/novaseq_err.nf
+++ b/modules/local/novaseq_err.nf
@@ -15,6 +15,9 @@ process NOVASEQ_ERR {
     tuple val(meta), path("*.md.err.convergence.txt"), emit: convergence
     //path "versions.yml"                  , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     if (!meta.single_end) {
         """

--- a/modules/local/picrust.nf
+++ b/modules/local/picrust.nf
@@ -18,7 +18,7 @@ process PICRUST {
     path("*_descrip.tsv"), emit: pathways
     path "versions.yml"  , emit: versions
     path "*.args.txt"    , emit: args
-    path "${message}.txt"
+    path "${message}.txt", emit: message
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/picrust.nf
+++ b/modules/local/picrust.nf
@@ -20,6 +20,9 @@ process PICRUST {
     path "*.args.txt"    , emit: args
     path "${message}.txt"
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     """

--- a/modules/local/qiime2_alphararefaction.nf
+++ b/modules/local/qiime2_alphararefaction.nf
@@ -14,6 +14,9 @@ process QIIME2_ALPHARAREFACTION {
     path("alpha-rarefaction/*"), emit: rarefaction
     path "versions.yml"        , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_ancom_asv.nf
+++ b/modules/local/qiime2_ancom_asv.nf
@@ -15,6 +15,9 @@ process QIIME2_ANCOM_ASV {
     path("ancom/*")     , emit: ancom
     path "versions.yml" , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_ancom_tax.nf
+++ b/modules/local/qiime2_ancom_tax.nf
@@ -13,6 +13,9 @@ process QIIME2_ANCOM_TAX {
     path "ancom/*"      , emit: ancom
     path "versions.yml" , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_barplot.nf
+++ b/modules/local/qiime2_barplot.nf
@@ -13,6 +13,9 @@ process QIIME2_BARPLOT {
     path("barplot/*")   , emit: folder
     path "versions.yml" , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_classify.nf
+++ b/modules/local/qiime2_classify.nf
@@ -14,6 +14,9 @@ process QIIME2_CLASSIFY {
     path("taxonomy.tsv"), emit: tsv
     path "versions.yml" , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_diversity_adonis.nf
+++ b/modules/local/qiime2_diversity_adonis.nf
@@ -12,6 +12,9 @@ process QIIME2_DIVERSITY_ADONIS {
     path("adonis/*")     , emit: html
     path "versions.yml"  , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def formula = params.qiime_adonis_formula

--- a/modules/local/qiime2_diversity_alpha.nf
+++ b/modules/local/qiime2_diversity_alpha.nf
@@ -12,6 +12,9 @@ process QIIME2_DIVERSITY_ALPHA {
     path("alpha_diversity/*"), emit: alpha
     path "versions.yml"      , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_diversity_beta.nf
+++ b/modules/local/qiime2_diversity_beta.nf
@@ -12,6 +12,9 @@ process QIIME2_DIVERSITY_BETA {
     path("beta_diversity/*"), emit: beta
     path "versions.yml"     , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_diversity_betaord.nf
+++ b/modules/local/qiime2_diversity_betaord.nf
@@ -12,6 +12,9 @@ process QIIME2_DIVERSITY_BETAORD {
     path("beta_diversity/*"), emit: beta
     path "versions.yml"     , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_diversity_core.nf
+++ b/modules/local/qiime2_diversity_core.nf
@@ -17,6 +17,9 @@ process QIIME2_DIVERSITY_CORE {
     path "versions.yml"                         , emit: versions
     path("*rarefaction.txt")                    , emit: depth
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_export_absolute.nf
+++ b/modules/local/qiime2_export_absolute.nf
@@ -20,6 +20,9 @@ process QIIME2_EXPORT_ABSOLUTE {
     path("abs-abund-table-*.tsv")    , emit: abundtable
     path "versions.yml"              , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_export_relasv.nf
+++ b/modules/local/qiime2_export_relasv.nf
@@ -11,6 +11,9 @@ process QIIME2_EXPORT_RELASV {
     path("rel-table-ASV.tsv"), emit: tsv
     path "versions.yml"      , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_export_reltax.nf
+++ b/modules/local/qiime2_export_reltax.nf
@@ -14,6 +14,9 @@ process QIIME2_EXPORT_RELTAX {
     path("*.tsv")        , emit: tsv
     path "versions.yml"  , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_extract.nf
+++ b/modules/local/qiime2_extract.nf
@@ -13,6 +13,9 @@ process QIIME2_EXTRACT {
     tuple val(meta), path("*.qza"), emit: qza
     path "versions.yml"          , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_filterasv.nf
+++ b/modules/local/qiime2_filterasv.nf
@@ -12,6 +12,9 @@ process QIIME2_FILTERASV {
     path("*.qza")       , emit: qza
     path "versions.yml" , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_filtertaxa.nf
+++ b/modules/local/qiime2_filtertaxa.nf
@@ -19,6 +19,9 @@ process QIIME2_FILTERTAXA {
     path("filtered-sequences.qza"), emit: seq
     path "versions.yml"       , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_inasv.nf
+++ b/modules/local/qiime2_inasv.nf
@@ -12,6 +12,9 @@ process QIIME2_INASV {
     path("table.qza")    , emit: qza
     path "versions.yml"  , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     echo -n "#OTU Table" | cat - "$asv" > biom-table.txt

--- a/modules/local/qiime2_inseq.nf
+++ b/modules/local/qiime2_inseq.nf
@@ -12,6 +12,9 @@ process QIIME2_INSEQ {
     path("rep-seqs.qza"), emit: qza
     path "versions.yml", emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     qiime tools import \

--- a/modules/local/qiime2_intax.nf
+++ b/modules/local/qiime2_intax.nf
@@ -12,6 +12,9 @@ process QIIME2_INTAX {
     path("taxonomy.qza") , emit: qza
     path "versions.yml"  , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     parse_dada2_taxonomy.r $tax

--- a/modules/local/qiime2_train.nf
+++ b/modules/local/qiime2_train.nf
@@ -13,6 +13,9 @@ process QIIME2_TRAIN {
     path("*-classifier.qza"), emit: qza
     path "versions.yml"    , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_tree.nf
+++ b/modules/local/qiime2_tree.nf
@@ -12,6 +12,9 @@ process QIIME2_TREE {
     path("tree.nwk")       , emit: nwk
     path "versions.yml"    , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/rename_raw_data_files.nf
+++ b/modules/local/rename_raw_data_files.nf
@@ -14,6 +14,9 @@ process RENAME_RAW_DATA_FILES {
     tuple val(meta), path("${meta.id}{_1,_2,}.fastq.gz", includeInputs: true), emit: fastq
     path "versions.yml"                                                      , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     // Add soft-links to original FastQs for consistent naming in pipeline
     def args        = task.ext.args ?: 'ln -s'

--- a/modules/local/sbdiexport.nf
+++ b/modules/local/sbdiexport.nf
@@ -16,6 +16,9 @@ process SBDIEXPORT {
     path "*.tsv"       , emit: sbditables
     path "versions.yml", emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     """

--- a/modules/local/sbdiexportreannotate.nf
+++ b/modules/local/sbdiexportreannotate.nf
@@ -14,6 +14,9 @@ process SBDIEXPORTREANNOTATE {
     path "*.tsv"       , emit: sbdiannottables
     path "versions.yml", emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     """
     sbdiexportreannotate.R ${params.dada_ref_databases[params.dada_ref_taxonomy]["dbversion"]} $taxonomytable

--- a/modules/local/trunclen.nf
+++ b/modules/local/trunclen.nf
@@ -14,6 +14,9 @@ process TRUNCLEN {
     tuple val(meta), stdout, emit: trunc
     path "versions.yml"    , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     """

--- a/subworkflows/local/qiime2_preptax.nf
+++ b/subworkflows/local/qiime2_preptax.nf
@@ -8,12 +8,12 @@ include { QIIME2_TRAIN          } from '../../modules/local/qiime2_train'
 
 workflow QIIME2_PREPTAX {
     take:
-    ch_dada_ref_taxonomy //channel, list of files
+    ch_qiime_ref_taxonomy //channel, list of files
     FW_primer //val
     RV_primer //val
 
     main:
-    FORMAT_TAXONOMY_QIIME ( ch_dada_ref_taxonomy )
+    FORMAT_TAXONOMY_QIIME ( ch_qiime_ref_taxonomy )
 
     ch_ref_database = FORMAT_TAXONOMY_QIIME.out.fasta.combine(FORMAT_TAXONOMY_QIIME.out.tax)
     ch_ref_database

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -539,16 +539,16 @@ workflow AMPLISEQ {
         //Select metadata categories for diversity analysis & ancom
         if (params.metadata_category) {
             ch_metacolumn_all = Channel.from(params.metadata_category.tokenize(','))
-            METADATA_PAIRWISE ( ch_metadata ).set { ch_metacolumn_pairwise }
+            METADATA_PAIRWISE ( ch_metadata ).category.set { ch_metacolumn_pairwise }
             ch_metacolumn_pairwise = ch_metacolumn_pairwise.splitCsv().flatten()
             ch_metacolumn_pairwise = ch_metacolumn_all.join(ch_metacolumn_pairwise)
         } else if (!params.skip_ancom || !params.skip_diversity_indices) {
-            METADATA_ALL ( ch_metadata ).set { ch_metacolumn_all }
+            METADATA_ALL ( ch_metadata ).category.set { ch_metacolumn_all }
             //return empty channel if no appropriate column was found
             ch_metacolumn_all.branch { passed: it != "" }.set { result }
             ch_metacolumn_all = result.passed
             ch_metacolumn_all = ch_metacolumn_all.splitCsv().flatten()
-            METADATA_PAIRWISE ( ch_metadata ).set { ch_metacolumn_pairwise }
+            METADATA_PAIRWISE ( ch_metadata ).category.set { ch_metacolumn_pairwise }
             ch_metacolumn_pairwise = ch_metacolumn_pairwise.splitCsv().flatten()
         } else {
             ch_metacolumn_all = Channel.empty()


### PR DESCRIPTION
linting with nf-core tools version 2.5.1 produce a lot of warning, I reduce those here by a large margin:
- added when sections to all modules
- add emit statements
- output versions in all modules

I havent fixed (yet?):

│ assignsh │ modules/local/assignsh.nf│ 'meta' map not emitted in output channel(s)│
│ cutadapt_summary │ modules/local/cutadapt_summary.nf │ 'meta' map not emitted in output channel(s) │
│ qiime2_train │ modules/local/qiime2_train.nf │ 'meta' map not emitted in output channel(s) │
│ sbdiexport │ modules/local/sbdiexport.nf │ Conda version not specified correctly │
│ sbdiexportreannotate │ modules/local/sbdiexportreannotate.nf │ Conda version not specified correctly 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
