### PR TITLE
update to qiime2 2022.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
-| Tool     | Previous version | New version |
-| -------- | ---------------- | ----------- |
-| QIIME2   | 2021.8           | 2022.8      |
+| Tool   | Previous version | New version |
+| ------ | ---------------- | ----------- |
+| QIIME2 | 2021.8           | 2022.8      |
 
 ### `Removed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
+| Tool     | Previous version | New version |
+| -------- | ---------------- | ----------- |
+| QIIME2   | 2021.8           | 2022.8      |
+
 ### `Removed`
 
 ## nf-core/ampliseq version 2.4.0 - 2022-09-07

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -192,14 +192,14 @@ params {
         //SILVA for QIIME2 v2021.2, see https://docs.qiime2.org/2021.2/data-resources/#silva-16s-18s-rrna
         'silva=138' {
             title = "QIIME2 pre-formatted SILVA dereplicated at 99% similarity - Version 138"
-            file = [ "https://data.qiime2.org/2021.8/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2021.8/common/silva-138-99-tax.qza" ]
+            file = [ "https://data.qiime2.org/2022.8/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2022.8/common/silva-138-99-tax.qza" ]
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = "taxref_reformat_qiime_silva138.sh"
         }
         'silva' {
             title = "QIIME2 pre-formatted SILVA dereplicated at 99% similarity - Version 138"
-            file = [ "https://data.qiime2.org/2021.8/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2021.8/common/silva-138-99-tax.qza" ]
+            file = [ "https://data.qiime2.org/2022.8/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2022.8/common/silva-138-99-tax.qza" ]
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = "taxref_reformat_qiime_silva138.sh"
@@ -231,7 +231,7 @@ params {
         }
         'greengenes85' {
             title = "Greengenes 16S - Version 13_8 - clustered at 85% similarity - for testing purposes only"
-            file = [ "https://data.qiime2.org/2021.8/tutorials/training-feature-classifiers/85_otus.fasta", "https://data.qiime2.org/2021.8/tutorials/training-feature-classifiers/85_otu_taxonomy.txt" ]
+            file = [ "https://data.qiime2.org/2022.8/tutorials/training-feature-classifiers/85_otus.fasta", "https://data.qiime2.org/2022.8/tutorials/training-feature-classifiers/85_otu_taxonomy.txt" ]
             citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
             fmtscript = "taxref_reformat_qiime_greengenes85.sh"
         }

--- a/modules/local/qiime2_alphararefaction.nf
+++ b/modules/local/qiime2_alphararefaction.nf
@@ -2,7 +2,7 @@ process QIIME2_ALPHARAREFACTION {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(metadata)

--- a/modules/local/qiime2_ancom_asv.nf
+++ b/modules/local/qiime2_ancom_asv.nf
@@ -6,7 +6,7 @@ process QIIME2_ANCOM_ASV {
     label 'error_ignore'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     tuple path(metadata), path(table)

--- a/modules/local/qiime2_ancom_tax.nf
+++ b/modules/local/qiime2_ancom_tax.nf
@@ -4,7 +4,7 @@ process QIIME2_ANCOM_TAX {
     label 'single_cpu'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     tuple path(metadata), path(table), path(taxonomy) ,val(taxlevel)

--- a/modules/local/qiime2_barplot.nf
+++ b/modules/local/qiime2_barplot.nf
@@ -2,7 +2,7 @@ process QIIME2_BARPLOT {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(metadata)

--- a/modules/local/qiime2_classify.nf
+++ b/modules/local/qiime2_classify.nf
@@ -3,7 +3,7 @@ process QIIME2_CLASSIFY {
     label 'process_high'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(trained_classifier)

--- a/modules/local/qiime2_diversity_adonis.nf
+++ b/modules/local/qiime2_diversity_adonis.nf
@@ -3,7 +3,7 @@ process QIIME2_DIVERSITY_ADONIS {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     tuple path(metadata), path(core)

--- a/modules/local/qiime2_diversity_alpha.nf
+++ b/modules/local/qiime2_diversity_alpha.nf
@@ -3,7 +3,7 @@ process QIIME2_DIVERSITY_ALPHA {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     tuple path(metadata), path(core)

--- a/modules/local/qiime2_diversity_beta.nf
+++ b/modules/local/qiime2_diversity_beta.nf
@@ -3,7 +3,7 @@ process QIIME2_DIVERSITY_BETA {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     tuple path(metadata), path(core), val(category)

--- a/modules/local/qiime2_diversity_betaord.nf
+++ b/modules/local/qiime2_diversity_betaord.nf
@@ -3,7 +3,7 @@ process QIIME2_DIVERSITY_BETAORD {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     tuple path(metadata), path(core)

--- a/modules/local/qiime2_diversity_core.nf
+++ b/modules/local/qiime2_diversity_core.nf
@@ -2,7 +2,7 @@ process QIIME2_DIVERSITY_CORE {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(metadata)

--- a/modules/local/qiime2_export_absolute.nf
+++ b/modules/local/qiime2_export_absolute.nf
@@ -2,7 +2,7 @@ process QIIME2_EXPORT_ABSOLUTE {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(table)

--- a/modules/local/qiime2_export_relasv.nf
+++ b/modules/local/qiime2_export_relasv.nf
@@ -2,7 +2,7 @@ process QIIME2_EXPORT_RELASV {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(table)

--- a/modules/local/qiime2_export_reltax.nf
+++ b/modules/local/qiime2_export_reltax.nf
@@ -2,7 +2,7 @@ process QIIME2_EXPORT_RELTAX {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(table)

--- a/modules/local/qiime2_extract.nf
+++ b/modules/local/qiime2_extract.nf
@@ -4,7 +4,7 @@ process QIIME2_EXTRACT {
     label 'single_cpu'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     tuple val(meta), path(database)

--- a/modules/local/qiime2_filterasv.nf
+++ b/modules/local/qiime2_filterasv.nf
@@ -3,7 +3,7 @@ process QIIME2_FILTERASV {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     tuple path(metadata), path(table), val(category)

--- a/modules/local/qiime2_filtertaxa.nf
+++ b/modules/local/qiime2_filtertaxa.nf
@@ -3,7 +3,7 @@ process QIIME2_FILTERTAXA {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(table)

--- a/modules/local/qiime2_inasv.nf
+++ b/modules/local/qiime2_inasv.nf
@@ -3,7 +3,7 @@ process QIIME2_INASV {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(asv)

--- a/modules/local/qiime2_inseq.nf
+++ b/modules/local/qiime2_inseq.nf
@@ -3,7 +3,7 @@ process QIIME2_INSEQ {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(seq)

--- a/modules/local/qiime2_intax.nf
+++ b/modules/local/qiime2_intax.nf
@@ -3,7 +3,7 @@ process QIIME2_INTAX {
     label 'process_low'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(tax) //ASV_tax_species.tsv

--- a/modules/local/qiime2_train.nf
+++ b/modules/local/qiime2_train.nf
@@ -4,7 +4,7 @@ process QIIME2_TRAIN {
     label 'single_cpu'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     tuple val(meta), path(qza)

--- a/modules/local/qiime2_tree.nf
+++ b/modules/local/qiime2_tree.nf
@@ -2,7 +2,7 @@ process QIIME2_TREE {
     label 'process_medium'
 
     conda (params.enable_conda ? { exit 1 "QIIME2 has no conda package" } : null)
-    container "quay.io/qiime2/core:2021.8"
+    container "quay.io/qiime2/core:2022.8"
 
     input:
     path(repseq)


### PR DESCRIPTION
Attempt to update to qiime2 2022.8, after docker failed with 2022.2 in https://github.com/nf-core/ampliseq/pull/468

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
