### PR TITLE
Fix warnings introduced in nextflow 22.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#495](https://github.com/nf-core/ampliseq/pull/495) - Template update for nf-core/tools version 2.6
 - [#501](https://github.com/nf-core/ampliseq/pull/501) - Check for empty fields in samplesheet column "run" and raise an appropriate error.
 - [#503](https://github.com/nf-core/ampliseq/pull/503) - Changed environment for formatting databases.
+- [#504](https://github.com/nf-core/ampliseq/pull/504) - Fixed warnings with nextflow 22.10 (and later) about processes that are defined more than once.
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -279,7 +279,7 @@ process {
         ]
     }
 
-    withName: 'MERGE_STATS|MERGE_STATS_FILTERSSU|MERGE_STATS_FILTERTAXA' {
+    withName: 'MERGE_STATS_STD|MERGE_STATS_FILTERSSU|MERGE_STATS_FILTERTAXA' {
         publishDir = [
             path: { "${params.outdir}" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -117,7 +117,7 @@ process {
         ]
     }
 
-    withName: DADA2_QUALITY {
+    withName: DADA2_QUALITY1 {
         ext.args = ", n = 5e+04, aggregate = TRUE"
         publishDir = [
             [

--- a/subworkflows/local/cutadapt_workflow.nf
+++ b/subworkflows/local/cutadapt_workflow.nf
@@ -5,7 +5,7 @@
 include { CUTADAPT as CUTADAPT_BASIC                        } from '../../modules/nf-core/cutadapt/main'
 include { CUTADAPT as CUTADAPT_READTHROUGH                  } from '../../modules/nf-core/cutadapt/main'
 include { CUTADAPT as CUTADAPT_DOUBLEPRIMER                 } from '../../modules/nf-core/cutadapt/main'
-include { CUTADAPT_SUMMARY                                  } from '../../modules/local/cutadapt_summary'
+include { CUTADAPT_SUMMARY as CUTADAPT_SUMMARY_STD          } from '../../modules/local/cutadapt_summary'
 include { CUTADAPT_SUMMARY as CUTADAPT_SUMMARY_DOUBLEPRIMER } from '../../modules/local/cutadapt_summary'
 include { CUTADAPT_SUMMARY_MERGE                            } from '../../modules/local/cutadapt_summary_merge'
 
@@ -24,7 +24,7 @@ workflow CUTADAPT_WORKFLOW {
                 [ meta, log ] }
         .groupTuple(by: 0 )
         .set { ch_cutadapt_logs }
-    CUTADAPT_SUMMARY ( "cutadapt_standard", ch_cutadapt_logs )
+    CUTADAPT_SUMMARY_STD ( "cutadapt_standard", ch_cutadapt_logs )
 
     if (illumina_pe_its) {
         CUTADAPT_READTHROUGH ( ch_trimmed_reads ).reads.set { ch_trimmed_reads }
@@ -41,10 +41,10 @@ workflow CUTADAPT_WORKFLOW {
             .groupTuple(by: 0 )
             .set { ch_cutadapt_doubleprimer_logs }
         CUTADAPT_SUMMARY_DOUBLEPRIMER ( "cutadapt_doubleprimer", ch_cutadapt_doubleprimer_logs )
-        ch_summaries = CUTADAPT_SUMMARY.out.tsv.combine( CUTADAPT_SUMMARY_DOUBLEPRIMER.out.tsv )
+        ch_summaries = CUTADAPT_SUMMARY_STD.out.tsv.combine( CUTADAPT_SUMMARY_DOUBLEPRIMER.out.tsv )
         CUTADAPT_SUMMARY_MERGE ( "merge", ch_summaries )
     } else {
-        CUTADAPT_SUMMARY_MERGE ( "copy", CUTADAPT_SUMMARY.out.tsv )
+        CUTADAPT_SUMMARY_MERGE ( "copy", CUTADAPT_SUMMARY_STD.out.tsv )
     }
 
     //Filter empty files

--- a/subworkflows/local/dada2_preprocessing.nf
+++ b/subworkflows/local/dada2_preprocessing.nf
@@ -2,7 +2,7 @@
  * Preprocessing with DADA2
  */
 
-include { DADA2_QUALITY                   } from '../../modules/local/dada2_quality'
+include { DADA2_QUALITY as DADA2_QUALITY1 } from '../../modules/local/dada2_quality'
 include { TRUNCLEN                        } from '../../modules/local/trunclen'
 include { DADA2_FILTNTRIM                 } from '../../modules/local/dada2_filtntrim'
 include { DADA2_QUALITY as DADA2_QUALITY2 } from '../../modules/local/dada2_quality'
@@ -42,14 +42,14 @@ workflow DADA2_PREPROCESSING {
     }
 
     if ( !params.skip_dada_quality ) {
-        DADA2_QUALITY ( ch_all_trimmed_reads.dump(tag: 'into_dada2_quality') )
-        ch_versions_dada2_preprocessing = ch_versions_dada2_preprocessing.mix(DADA2_QUALITY.out.versions)
-        DADA2_QUALITY.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn it.baseName.toString().replace("WARNING ","DADA2_QUALITY: ") }
+        DADA2_QUALITY1 ( ch_all_trimmed_reads.dump(tag: 'into_dada2_quality') )
+        ch_versions_dada2_preprocessing = ch_versions_dada2_preprocessing.mix(DADA2_QUALITY1.out.versions)
+        DADA2_QUALITY1.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn it.baseName.toString().replace("WARNING ","DADA2_QUALITY1: ") }
     }
 
     //find truncation values in case they are not supplied
     if ( find_truncation_values ) {
-        TRUNCLEN ( DADA2_QUALITY.out.tsv )
+        TRUNCLEN ( DADA2_QUALITY1.out.tsv )
         TRUNCLEN.out.trunc
             .toSortedList()
             .set { ch_trunc }

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -130,7 +130,7 @@ include { MERGE_STATS as MERGE_STATS_FILTERSSU } from '../modules/local/merge_st
 include { MERGE_STATS as MERGE_STATS_FILTERLENASV } from '../modules/local/merge_stats'
 include { FORMAT_TAXONOMY               } from '../modules/local/format_taxonomy'
 include { ITSX_CUTASV                   } from '../modules/local/itsx_cutasv'
-include { MERGE_STATS                   } from '../modules/local/merge_stats'
+include { MERGE_STATS as MERGE_STATS_STD} from '../modules/local/merge_stats'
 include { DADA2_TAXONOMY                } from '../modules/local/dada2_taxonomy'
 include { DADA2_ADDSPECIES              } from '../modules/local/dada2_addspecies'
 include { ASSIGNSH                      } from '../modules/local/assignsh'
@@ -292,8 +292,8 @@ workflow AMPLISEQ {
 
     //merge cutadapt_summary and dada_stats files
     if (!params.skip_cutadapt) {
-        MERGE_STATS (CUTADAPT_WORKFLOW.out.summary, DADA2_MERGE.out.dada2stats)
-        ch_stats = MERGE_STATS.out.tsv
+        MERGE_STATS_STD (CUTADAPT_WORKFLOW.out.summary, DADA2_MERGE.out.dada2stats)
+        ch_stats = MERGE_STATS_STD.out.tsv
     } else {
         ch_stats = DADA2_MERGE.out.dada2stats
     }

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -134,7 +134,7 @@ include { MERGE_STATS                   } from '../modules/local/merge_stats'
 include { DADA2_TAXONOMY                } from '../modules/local/dada2_taxonomy'
 include { DADA2_ADDSPECIES              } from '../modules/local/dada2_addspecies'
 include { ASSIGNSH                      } from '../modules/local/assignsh'
-include { FORMAT_TAXRESULTS             } from '../modules/local/format_taxresults'
+include { FORMAT_TAXRESULTS as FORMAT_TAXRESULTS_STD   } from '../modules/local/format_taxresults'
 include { FORMAT_TAXRESULTS as FORMAT_TAXRESULTS_ADDSP } from '../modules/local/format_taxresults'
 include { QIIME2_INSEQ                  } from '../modules/local/qiime2_inseq'
 include { QIIME2_FILTERTAXA             } from '../modules/local/qiime2_filtertaxa'
@@ -417,8 +417,8 @@ workflow AMPLISEQ {
             ch_cut_fasta = ITSX_CUTASV.out.fasta
             DADA2_TAXONOMY ( ch_cut_fasta, ch_assigntax, 'ASV_ITS_tax.tsv', taxlevels )
             ch_versions = ch_versions.mix(DADA2_TAXONOMY.out.versions)
-            FORMAT_TAXRESULTS ( DADA2_TAXONOMY.out.tsv, ch_fasta, 'ASV_tax.tsv' )
-            ch_versions = ch_versions.mix( FORMAT_TAXRESULTS.out.versions.ifEmpty(null) )
+            FORMAT_TAXRESULTS_STD ( DADA2_TAXONOMY.out.tsv, ch_fasta, 'ASV_tax.tsv' )
+            ch_versions = ch_versions.mix( FORMAT_TAXRESULTS_STD.out.versions.ifEmpty(null) )
             if (!params.skip_dada_addspecies) {
                 DADA2_ADDSPECIES ( DADA2_TAXONOMY.out.rds, ch_addspecies, 'ASV_ITS_tax_species.tsv', taxlevels )
                 FORMAT_TAXRESULTS_ADDSP ( DADA2_ADDSPECIES.out.tsv, ch_fasta, 'ASV_tax_species.tsv' )
@@ -449,11 +449,11 @@ workflow AMPLISEQ {
                         .set { ch_cut_fasta }
                     VSEARCH_USEARCHGLOBAL( ch_cut_fasta, ch_assigntax, vsearch_cutoff, 'blast6out', "" )
                     ch_versions = ch_versions.mix(VSEARCH_USEARCHGLOBAL.out.versions.ifEmpty(null))
-                    ASSIGNSH( FORMAT_TAXRESULTS.out.tsv, ch_shinfo.collect(), VSEARCH_USEARCHGLOBAL.out.txt, 'ASV_tax_SH.tsv')
+                    ASSIGNSH( FORMAT_TAXRESULTS_STD.out.tsv, ch_shinfo.collect(), VSEARCH_USEARCHGLOBAL.out.txt, 'ASV_tax_SH.tsv')
                     ch_versions = ch_versions.mix(ASSIGNSH.out.versions.ifEmpty(null))
                     ch_dada2_tax = ASSIGNSH.out.tsv
                 } else {
-                    ch_dada2_tax = FORMAT_TAXRESULTS.out.tsv
+                    ch_dada2_tax = FORMAT_TAXRESULTS_STD.out.tsv
                 }
             }
         }


### PR DESCRIPTION
Fix code to avoid warnings such as
`WARN: A process with name 'CUTADAPT_SUMMARY_DOUBLEPRIMER' is defined more than once in module script: github-ampliseq/ampliseq/./workflows/../subworkflows/local/cutadapt_workflow.nf -- Make sure to not define the same function as process`
that appear from nextflow version 22.10 onward.
Should not have any functional impact whatsoever.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
