### PR TITLE
Update QIIME2 from 2022.8 to 2022.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
+- [#528](https://github.com/nf-core/ampliseq/pull/528) - Updated QIIME2
+
+| Tool   | Previous version | New version |
+| ------ | ---------------- | ----------- |
+| QIIME2 | 2022.8           | 2022.11     |
+
 ### `Removed`
 
 - [#513](https://github.com/nf-core/ampliseq/pull/513) - Removed parameter `--enable_conda`.

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -192,14 +192,14 @@ params {
         //SILVA for QIIME2 v2021.2, see https://docs.qiime2.org/2021.2/data-resources/#silva-16s-18s-rrna
         'silva=138' {
             title = "QIIME2 pre-formatted SILVA dereplicated at 99% similarity - Version 138"
-            file = [ "https://data.qiime2.org/2022.8/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2022.8/common/silva-138-99-tax.qza" ]
+            file = [ "https://data.qiime2.org/2022.11/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2022.11/common/silva-138-99-tax.qza" ]
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = "taxref_reformat_qiime_silva138.sh"
         }
         'silva' {
             title = "QIIME2 pre-formatted SILVA dereplicated at 99% similarity - Version 138"
-            file = [ "https://data.qiime2.org/2022.8/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2022.8/common/silva-138-99-tax.qza" ]
+            file = [ "https://data.qiime2.org/2022.11/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2022.11/common/silva-138-99-tax.qza" ]
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = "taxref_reformat_qiime_silva138.sh"
@@ -231,7 +231,7 @@ params {
         }
         'greengenes85' {
             title = "Greengenes 16S - Version 13_8 - clustered at 85% similarity - for testing purposes only"
-            file = [ "https://data.qiime2.org/2022.8/tutorials/training-feature-classifiers/85_otus.fasta", "https://data.qiime2.org/2022.8/tutorials/training-feature-classifiers/85_otu_taxonomy.txt" ]
+            file = [ "https://data.qiime2.org/2022.11/tutorials/training-feature-classifiers/85_otus.fasta", "https://data.qiime2.org/2022.11/tutorials/training-feature-classifiers/85_otu_taxonomy.txt" ]
             citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
             fmtscript = "taxref_reformat_qiime_greengenes85.sh"
         }

--- a/modules/local/qiime2_alphararefaction.nf
+++ b/modules/local/qiime2_alphararefaction.nf
@@ -1,7 +1,7 @@
 process QIIME2_ALPHARAREFACTION {
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_ancom_asv.nf
+++ b/modules/local/qiime2_ancom_asv.nf
@@ -5,7 +5,7 @@ process QIIME2_ANCOM_ASV {
     label 'process_long'
     label 'error_ignore'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_ancom_tax.nf
+++ b/modules/local/qiime2_ancom_tax.nf
@@ -3,7 +3,7 @@ process QIIME2_ANCOM_TAX {
     label 'process_medium'
     label 'single_cpu'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_barplot.nf
+++ b/modules/local/qiime2_barplot.nf
@@ -1,7 +1,7 @@
 process QIIME2_BARPLOT {
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_classify.nf
+++ b/modules/local/qiime2_classify.nf
@@ -2,7 +2,7 @@ process QIIME2_CLASSIFY {
     tag "${repseq},${trained_classifier}"
     label 'process_high'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_diversity_adonis.nf
+++ b/modules/local/qiime2_diversity_adonis.nf
@@ -2,7 +2,7 @@ process QIIME2_DIVERSITY_ADONIS {
     tag "${core.baseName} - ${formula}"
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_diversity_alpha.nf
+++ b/modules/local/qiime2_diversity_alpha.nf
@@ -2,7 +2,7 @@ process QIIME2_DIVERSITY_ALPHA {
     tag "${core.baseName}"
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_diversity_beta.nf
+++ b/modules/local/qiime2_diversity_beta.nf
@@ -2,7 +2,7 @@ process QIIME2_DIVERSITY_BETA {
     tag "${core.baseName} - ${category}"
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_diversity_betaord.nf
+++ b/modules/local/qiime2_diversity_betaord.nf
@@ -2,7 +2,7 @@ process QIIME2_DIVERSITY_BETAORD {
     tag "${core.baseName}"
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_diversity_core.nf
+++ b/modules/local/qiime2_diversity_core.nf
@@ -1,7 +1,7 @@
 process QIIME2_DIVERSITY_CORE {
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_export_absolute.nf
+++ b/modules/local/qiime2_export_absolute.nf
@@ -1,7 +1,7 @@
 process QIIME2_EXPORT_ABSOLUTE {
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_export_relasv.nf
+++ b/modules/local/qiime2_export_relasv.nf
@@ -1,7 +1,7 @@
 process QIIME2_EXPORT_RELASV {
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_export_reltax.nf
+++ b/modules/local/qiime2_export_reltax.nf
@@ -1,7 +1,7 @@
 process QIIME2_EXPORT_RELTAX {
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_extract.nf
+++ b/modules/local/qiime2_extract.nf
@@ -3,7 +3,7 @@ process QIIME2_EXTRACT {
     label 'process_low'
     label 'single_cpu'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_featuretable_group.nf
+++ b/modules/local/qiime2_featuretable_group.nf
@@ -2,7 +2,7 @@ process QIIME2_FEATURETABLE_GROUP {
     tag "${category}"
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_filterasv.nf
+++ b/modules/local/qiime2_filterasv.nf
@@ -2,7 +2,7 @@ process QIIME2_FILTERASV {
     tag "${category}"
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_filtertaxa.nf
+++ b/modules/local/qiime2_filtertaxa.nf
@@ -2,7 +2,7 @@ process QIIME2_FILTERTAXA {
     tag "taxa:${exclude_taxa};min-freq:${min_frequency};min-samples:${min_samples}"
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_inasv.nf
+++ b/modules/local/qiime2_inasv.nf
@@ -2,7 +2,7 @@ process QIIME2_INASV {
     tag "${asv}"
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_inseq.nf
+++ b/modules/local/qiime2_inseq.nf
@@ -2,7 +2,7 @@ process QIIME2_INSEQ {
     tag "${seq}"
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_intax.nf
+++ b/modules/local/qiime2_intax.nf
@@ -2,7 +2,7 @@ process QIIME2_INTAX {
     tag "${tax}"
     label 'process_low'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_train.nf
+++ b/modules/local/qiime2_train.nf
@@ -3,7 +3,7 @@ process QIIME2_TRAIN {
     label 'process_high'
     label 'single_cpu'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/local/qiime2_tree.nf
+++ b/modules/local/qiime2_tree.nf
@@ -1,7 +1,7 @@
 process QIIME2_TREE {
     label 'process_medium'
 
-    container "quay.io/qiime2/core:2022.8"
+    container "quay.io/qiime2/core:2022.11"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {


### PR DESCRIPTION
This might fix https://github.com/nf-core/ampliseq/issues/516 _edit: unfortunately it doesnt!_
The size of the new container is 1/3 of the old container, already this is a stark argument.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
