### PR TITLE
Remove taxonomic adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed`
 
 - [#537](https://github.com/nf-core/ampliseq/pull/537) - Update output generated with option sbdi-export
-- [#541](https://github.com/nf-core/ampliseq/pull/541) - Remove adjustments of taxonomic levels for RDP & SILVA & GTDB & UNITE database for DADA2 taxonomic classification
+- [#541](https://github.com/nf-core/ampliseq/pull/541) - Remove adjustments of taxonomic levels for RDP & SILVA & GTDB & UNITE database for DADA2 taxonomic classification, reduced default of `--dada_tax_agglom_max` from 7 to 6
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed`
 
 - [#537](https://github.com/nf-core/ampliseq/pull/537) - Update output generated with option sbdi-export
+- [#541](https://github.com/nf-core/ampliseq/pull/541) - Remove adjustments of taxonomic levels for RDP & SILVA & GTDB & UNITE database for DADA2 taxonomic classification
 
 ### `Fixed`
 

--- a/bin/taxref_reformat_gtdb.sh
+++ b/bin/taxref_reformat_gtdb.sh
@@ -10,7 +10,7 @@ for f in *.tar.gz; do
 done
 
 # Write the assignTaxonomy() fasta file: assignTaxonomy.fna
-cat ar122*.fna bac120*.fna | sed '/^>/s/>[^ ]\+ \([^[]\+\) \[.*/>\1/' | sed '/^>/s/ \[.*//' | sed 's/[a-z]__//g' | sed '/^>/s/\(Archaea\)\|\(Bacteria\)/&;&/' > assignTaxonomy.fna
+cat ar122*.fna bac120*.fna | sed '/^>/s/>[^ ]\+ \([^[]\+\) \[.*/>\1/' | sed '/^>/s/ \[.*//' | sed 's/[a-z]__//g' > assignTaxonomy.fna
 
 # Write the addSpecies() fasta file: addSpecies.fna
 cat ar122*.fna bac120*.fna | sed '/^>/s/>\([^ ]\+\) .*;s__\([^[]\+\) \[.*/>\1 \2/' > addSpecies.fna

--- a/bin/taxref_reformat_standard.sh
+++ b/bin/taxref_reformat_standard.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
 # Uses preformatted databases from DADA2 (https://benjjneb.github.io/dada2/training.html)
-# The file for taxonomy assignment, identified by containing "train" in the name,
-# gets the first field duplicated:
-gunzip -c *train*gz | sed 's/>\([^;]*\)/>\1;\1/' > assignTaxonomy.fna
+# The file for taxonomy assignment, identified by containing "train" in the name
+gunzip -c *train*gz > assignTaxonomy.fna
 
 # and the file for add species, identified by containing "species" in the name, is renamed
 mv *species*gz addSpecies.fna.gz

--- a/bin/taxref_reformat_unite.sh
+++ b/bin/taxref_reformat_unite.sh
@@ -8,7 +8,7 @@ tar xzf *gz
 
 # Remove leading "k__" and the like, remove ranks classified as "unknown",
 # and replace space with underscore to create assignTaxonomy.fna
-cat */*[[:digit:]].fasta | sed '/^>/s/;k__.*//' | sed '/^>/s/[a-z]__unidentified//g' | sed '/^>/s/[a-z]__//g' | sed '/^>/s/ /_/g' | sed 's/>.*|/&Eukaryota;/' > assignTaxonomy.fna
+cat */*[[:digit:]].fasta | sed '/^>/s/;k__.*//' | sed '/^>/s/[a-z]__unidentified//g' | sed '/^>/s/[a-z]__//g' | sed '/^>/s/ /_/g' > assignTaxonomy.fna
 
 # Reformat to addSpecies format
 sed 's/>\([^|]\+\)|\([^|]\+|[^|]\+\)|.*/>\2 \1/' assignTaxonomy.fna | sed '/^>/s/_/ /g' > addSpecies.fna

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -6,7 +6,7 @@
  * Please also reflect all changes in 'nextflow_schema.json'
  * Each entry requires as a minimum: title, file, citation, fmtscript
  * Optional entries are: taxlevels, shfile
- * taxlevels default in "dada2_taxonomy.nf": "Kingdom,Phylum,Class,Order,Family,Genus,Species"
+ * taxlevels default in "dada2_taxonomy.nf" and "dada2_addspecies.nf": "Kingdom,Phylum,Class,Order,Family,Genus,Species"
  */
 
 params {

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -6,6 +6,7 @@
  * Please also reflect all changes in 'nextflow_schema.json'
  * Each entry requires as a minimum: title, file, citation, fmtscript
  * Optional entries are: taxlevels, shfile
+ * taxlevels default in "dada2_taxonomy.nf": "Kingdom,Phylum,Class,Order,Family,Genus,Species"
  */
 
 params {
@@ -16,7 +17,6 @@ params {
             citation = "Sundh J, Manoharan L, Iwaszkiewicz-Eggebrecht E, Miraldo A, Andersson A, Ronquist F. COI reference sequences from BOLD DB. doi: https://doi.org/10.17044/scilifelab.20514192.v2"
             fmtscript = "taxref_reformat_coidb.sh"
             dbversion = "COIDB 221216 (https://doi.org/10.17044/scilifelab.20514192.v2)"
-            taxlevels = "Kingdom,Phylum,Class,Order,Family,Genus,Species"
         }
         'coidb=221216' {
             title = "COIDB - CO1 Taxonomy Database - Release 221216"
@@ -24,7 +24,6 @@ params {
             citation = "Sundh J, Manoharan L, Iwaszkiewicz-Eggebrecht E, Miraldo A, Andersson A, Ronquist F. COI reference sequences from BOLD DB. doi: https://doi.org/10.17044/scilifelab.20514192.v2"
             fmtscript = "taxref_reformat_coidb.sh"
             dbversion = "COIDB 221216 (https://doi.org/10.17044/scilifelab.20514192.v2)"
-            taxlevels = "Kingdom,Phylum,Class,Order,Family,Genus,Species"
         }
         'midori2-co1' {
             title = "MIDORI2 - CO1 Taxonomy Database - Release GB250"
@@ -76,6 +75,7 @@ params {
             citation = "Guillou L, Bachar D, Audic S, Bass D, Berney C, Bittner L, Boutte C, Burgaud G, de Vargas C, Decelle J, Del Campo J, Dolan JR, Dunthorn M, Edvardsen B, Holzmann M, Kooistra WH, Lara E, Le Bescot N, Logares R, Mahé F, Massana R, Montresor M, Morard R, Not F, Pawlowski J, Probert I, Sauvadet AL, Siano R, Stoeck T, Vaulot D, Zimmermann P, Christen R. The Protist Ribosomal Reference database (PR2): a catalog of unicellular eukaryote small sub-unit rRNA sequences with curated taxonomy. Nucleic Acids Res. 2013 Jan;41(Database issue):D597-604. doi: 10.1093/nar/gks1160. Epub 2012 Nov 27. PMID: 23193267; PMCID: PMC3531120."
             fmtscript = "taxref_reformat_pr2.sh"
             dbversion = "PR2 v4.14.0 (https://github.com/pr2database/pr2database/releases/tag/v4.14.0)"
+            taxlevels = "Domain,Kingdom,Phylum,Class,Order,Family,Genus,Species"
         }
         'pr2=4.14.0' {
             title = "PR2 - Protist Reference Ribosomal Database - Version 4.14.0"
@@ -83,6 +83,7 @@ params {
             citation = "Guillou L, Bachar D, Audic S, Bass D, Berney C, Bittner L, Boutte C, Burgaud G, de Vargas C, Decelle J, Del Campo J, Dolan JR, Dunthorn M, Edvardsen B, Holzmann M, Kooistra WH, Lara E, Le Bescot N, Logares R, Mahé F, Massana R, Montresor M, Morard R, Not F, Pawlowski J, Probert I, Sauvadet AL, Siano R, Stoeck T, Vaulot D, Zimmermann P, Christen R. The Protist Ribosomal Reference database (PR2): a catalog of unicellular eukaryote small sub-unit rRNA sequences with curated taxonomy. Nucleic Acids Res. 2013 Jan;41(Database issue):D597-604. doi: 10.1093/nar/gks1160. Epub 2012 Nov 27. PMID: 23193267; PMCID: PMC3531120."
             fmtscript = "taxref_reformat_pr2.sh"
             dbversion = "PR2 v4.14.0 (https://github.com/pr2database/pr2database/releases/tag/v4.14.0)"
+            taxlevels = "Domain,Kingdom,Phylum,Class,Order,Family,Genus,Species"
         }
         'pr2=4.13.0' {
             title = "PR2 - Protist Reference Ribosomal Database - Version 4.13.0"
@@ -90,6 +91,7 @@ params {
             citation = "Guillou L, Bachar D, Audic S, Bass D, Berney C, Bittner L, Boutte C, Burgaud G, de Vargas C, Decelle J, Del Campo J, Dolan JR, Dunthorn M, Edvardsen B, Holzmann M, Kooistra WH, Lara E, Le Bescot N, Logares R, Mahé F, Massana R, Montresor M, Morard R, Not F, Pawlowski J, Probert I, Sauvadet AL, Siano R, Stoeck T, Vaulot D, Zimmermann P, Christen R. The Protist Ribosomal Reference database (PR2): a catalog of unicellular eukaryote small sub-unit rRNA sequences with curated taxonomy. Nucleic Acids Res. 2013 Jan;41(Database issue):D597-604. doi: 10.1093/nar/gks1160. Epub 2012 Nov 27. PMID: 23193267; PMCID: PMC3531120."
             fmtscript = "taxref_reformat_pr2.sh"
             dbversion = "PR2 v4.13.0 (https://github.com/pr2database/pr2database/releases/tag/v4.13.0)"
+            taxlevels = "Domain,Kingdom,Phylum,Class,Order,Family,Genus,Species"
         }
         'rdp' {
             title = "RDP - Ribosomal Database Project - RDP trainset 18/release 11.5"
@@ -111,6 +113,7 @@ params {
             citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v4"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
             dbversion = "SBDI-GTDB-R07-RS207-1 (https://scilifelab.figshare.com/articles/dataset/SBDI_Sativa_curated_16S_GTDB_database/14869077/4)"
+            taxlevels = "Domain,Kingdom,Phylum,Class,Order,Family,Genus,Species"
         }
         'sbdi-gtdb=R07-RS207-1' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R07-RS207-1"
@@ -118,6 +121,7 @@ params {
             citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v4"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
             dbversion = "SBDI-GTDB-R07-RS207-1 (https://scilifelab.figshare.com/articles/dataset/SBDI_Sativa_curated_16S_GTDB_database/14869077/4)"
+            taxlevels = "Domain,Kingdom,Phylum,Class,Order,Family,Genus,Species"
         }
         'sbdi-gtdb=R06-RS202-3' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R06-RS202-1"
@@ -125,6 +129,7 @@ params {
             citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v3"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
             dbversion = "SBDI-GTDB-R06-RS202-3 (https://scilifelab.figshare.com/articles/dataset/SBDI_Sativa_curated_16S_GTDB_database/14869077/3)"
+            taxlevels = "Domain,Kingdom,Phylum,Class,Order,Family,Genus,Species"
         }
         'sbdi-gtdb=R06-RS202-1' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R06-RS202-1"
@@ -132,6 +137,7 @@ params {
             citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v1"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
             dbversion = "SBDI-GTDB-R06-RS202-1 (https://scilifelab.figshare.com/articles/dataset/SBDI_Sativa_curated_16S_GTDB_database/14869077/1)"
+            taxlevels = "Domain,Kingdom,Phylum,Class,Order,Family,Genus,Species"
         }
         'silva' {
             title = "Silva 138.1 prokaryotic SSU"

--- a/conf/test_fasta.config
+++ b/conf/test_fasta.config
@@ -22,7 +22,7 @@ params {
     // Input data
     input = "https://raw.githubusercontent.com/nf-core/test-datasets/ampliseq/testdata/ASV_seqs.fasta"
     dada_ref_taxonomy = "rdp=18"
-    dada_assign_taxlevels = "K,D,P,C,O,F,Genus"
+    dada_assign_taxlevels = "K,P,C,O,F,Genus"
 
     skip_qiime = true
 }

--- a/modules/local/barrnapsummary.nf
+++ b/modules/local/barrnapsummary.nf
@@ -1,7 +1,7 @@
 process BARRNAPSUMMARY {
     label 'process_single'
 
-    conda (params.enable_conda ? "python=3.9" : null)
+    conda "conda-forge::python=3.9"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/python:3.9' :
         'quay.io/biocontainers/python:3.9' }"

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -26,7 +26,7 @@ process DADA2_ADDSPECIES {
     def args = task.ext.args ?: ''
     def taxlevels = taxlevels_input ?
         'c("' + taxlevels_input.split(",").join('","') + '")' :
-        'c("Domain", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
+        'c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
     def seed = task.ext.seed ?: '100'
     """
     #!/usr/bin/env Rscript

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -26,7 +26,7 @@ process DADA2_TAXONOMY {
     def args = task.ext.args ?: ''
     def taxlevels = taxlevels_input ?
         'c("' + taxlevels_input.split(",").join('","') + '")' :
-        'c("Domain", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
+        'c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")'
     def seed = task.ext.seed ?: '100'
     """
     #!/usr/bin/env Rscript

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ params {
     sbdiexport        = false
     addsh             = false
     dada_tax_agglom_min = 2
-    dada_tax_agglom_max = 7
+    dada_tax_agglom_max = 6
     qiime_tax_agglom_min = 2
     qiime_tax_agglom_max = 6
     ignore_failed_trimming = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -407,10 +407,10 @@
                 },
                 "dada_tax_agglom_max": {
                     "type": "integer",
-                    "default": 7,
+                    "default": 6,
                     "description": "Maximum taxonomy agglomeration level for DADA2 classification",
                     "fa_icon": "fas fa-greater-than-equal",
-                    "help_text": "Depends on the reference taxonomy database used. Default databases should have genus level at 7."
+                    "help_text": "Depends on the reference taxonomy database used. Most default databases have genus level at 6."
                 },
                 "qiime_tax_agglom_min": {
                     "type": "integer",


### PR DESCRIPTION
Removed any modification of the number of taxonomic levels in reference databases for DADA2 classification:
- SILVA and RDP had the duplication of the first field removed (bin/taxref_reformat_standard.sh)
- GTDB had an additional level of "Archaea" or "Bacteria" removed (bin/taxref_reformat_gtdb.sh)
- UNITE had "Eukaryota" removed (bin/taxref_reformat_unite.sh)
- the default was changed to the majority of databases ("Kingdom,Phylum,Class,Order,Family,Genus,Species")

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
