### PR TITLE
Fix empty barrnap output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#551](https://github.com/nf-core/ampliseq/pull/551) - Handle empty barrnap results files
+
 ### `Dependencies`
 
 ### `Removed`

--- a/bin/sbdiexportreannotate.R
+++ b/bin/sbdiexportreannotate.R
@@ -25,6 +25,11 @@ taxonomy <- read.delim(taxfile, sep = '\t', stringsAsFactors = FALSE)
 # Read the predictions table if provided, otherwise create one
 if ( ! is.na(predfile) ) {
     predictions <- read.delim(predfile, sep = '\t', stringsAsFactors = FALSE)
+    if ( nrow(predictions) < 1 ) {
+        colnames <- names(predictions)
+        predictions <- data.frame(ASV_ID = taxonomy$ASV_ID)
+        predictions[,colnames[colnames != "ASV_ID"]] <- NA
+    }
 } else {
     predictions <- data.frame(ASV_ID = taxonomy$ASV_ID)
 }

--- a/bin/summarize_barrnap.py
+++ b/bin/summarize_barrnap.py
@@ -32,8 +32,8 @@ for file in sys.argv[1:]:
 
 # Write results
 fh = open("summary.tsv", mode="w")
-orglist = list(orgs)
-header = list(orgs)
+orglist = sorted(orgs)
+header = sorted(orgs)
 header.insert(0, "ASV_ID")
 header.append("eval_method")
 fh.write("\t".join(header) + "\n")

--- a/modules/local/barrnapsummary.nf
+++ b/modules/local/barrnapsummary.nf
@@ -11,6 +11,7 @@ process BARRNAPSUMMARY {
 
     output:
     path "summary.tsv" , emit: summary
+    path "*warning.txt" , emit: warning
 
     when:
     task.ext.when == null || task.ext.when
@@ -20,6 +21,12 @@ process BARRNAPSUMMARY {
 
     """
     summarize_barrnap.py $predictions
+
+    if [[ \$(wc -l < summary.tsv ) -le 1 ]]; then
+        touch WARNING_no_rRNA_found_warning.txt
+    else
+        touch no_warning.txt
+    fi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -617,7 +617,7 @@ workflow AMPLISEQ {
     if ( params.sbdiexport ) {
         SBDIEXPORT ( ch_dada2_asv, ch_dada2_tax, ch_metadata )
         ch_versions = ch_versions.mix(SBDIEXPORT.out.versions.first())
-        SBDIEXPORTREANNOTATE ( ch_dada2_tax, ch_barrnapsummary )
+        SBDIEXPORTREANNOTATE ( ch_dada2_tax, ch_barrnapsummary.ifEmpty([]) )
     }
 
     CUSTOM_DUMPSOFTWAREVERSIONS (

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -316,9 +316,10 @@ workflow AMPLISEQ {
         BARRNAP ( ch_unfiltered_fasta )
         BARRNAPSUMMARY ( BARRNAP.out.gff.collect() )
         BARRNAPSUMMARY.out.warning.subscribe {
-            if ( it.baseName.toString().startsWith("WARNING") )
+            if ( it.baseName.toString().startsWith("WARNING") ) {
                 log.error "Barrnap could not identify any rRNA in the ASV sequences! This will result in all sequences being removed with SSU filtering."
                 System.exit(1)
+            }
         }
         ch_barrnapsummary = BARRNAPSUMMARY.out.summary
         ch_versions = ch_versions.mix(BARRNAP.out.versions.ifEmpty(null))

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -331,7 +331,7 @@ workflow AMPLISEQ {
     } else if (!params.skip_barrnap && !params.filter_ssu) {
         BARRNAP ( ch_unfiltered_fasta )
         BARRNAPSUMMARY ( BARRNAP.out.gff.collect() )
-        BARRNAPSUMMARY.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn "Barrnap could not identify any rRNA in the ASV sequences, which seem to be non-ribosomal. We recommended to use the --skip_barrnap option for these sequences." }
+        BARRNAPSUMMARY.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn "Barrnap could not identify any rRNA in the ASV sequences. We recommended to use the --skip_barrnap option for these sequences." }
         ch_barrnapsummary = BARRNAPSUMMARY.out.summary
         ch_versions = ch_versions.mix(BARRNAP.out.versions.ifEmpty(null))
         ch_dada2_fasta = ch_unfiltered_fasta

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -315,6 +315,7 @@ workflow AMPLISEQ {
     if (!params.skip_barrnap && params.filter_ssu) {
         BARRNAP ( ch_unfiltered_fasta )
         BARRNAPSUMMARY ( BARRNAP.out.gff.collect() )
+        BARRNAPSUMMARY.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn "Barrnap could not identify any rRNA in the ASV sequences, which seem to be non-ribosomal. We recommended to use the --skip_barrnap option for these sequences." }
         ch_barrnapsummary = BARRNAPSUMMARY.out.summary
         ch_versions = ch_versions.mix(BARRNAP.out.versions.ifEmpty(null))
         FILTER_SSU ( DADA2_MERGE.out.fasta, DADA2_MERGE.out.asv, BARRNAPSUMMARY.out.summary )
@@ -325,6 +326,7 @@ workflow AMPLISEQ {
     } else if (!params.skip_barrnap && !params.filter_ssu) {
         BARRNAP ( ch_unfiltered_fasta )
         BARRNAPSUMMARY ( BARRNAP.out.gff.collect() )
+        BARRNAPSUMMARY.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn "Barrnap could not identify any rRNA in the ASV sequences, which seem to be non-ribosomal. We recommended to use the --skip_barrnap option for these sequences." }
         ch_barrnapsummary = BARRNAPSUMMARY.out.summary
         ch_versions = ch_versions.mix(BARRNAP.out.versions.ifEmpty(null))
         ch_dada2_fasta = ch_unfiltered_fasta

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -315,7 +315,11 @@ workflow AMPLISEQ {
     if (!params.skip_barrnap && params.filter_ssu) {
         BARRNAP ( ch_unfiltered_fasta )
         BARRNAPSUMMARY ( BARRNAP.out.gff.collect() )
-        BARRNAPSUMMARY.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn "Barrnap could not identify any rRNA in the ASV sequences, which seem to be non-ribosomal. We recommended to use the --skip_barrnap option for these sequences." }
+        BARRNAPSUMMARY.out.warning.subscribe {
+            if ( it.baseName.toString().startsWith("WARNING") )
+                log.error "Barrnap could not identify any rRNA in the ASV sequences! This will result in all sequences being removed with SSU filtering."
+                System.exit(1)
+        }
         ch_barrnapsummary = BARRNAPSUMMARY.out.summary
         ch_versions = ch_versions.mix(BARRNAP.out.versions.ifEmpty(null))
         FILTER_SSU ( DADA2_MERGE.out.fasta, DADA2_MERGE.out.asv, BARRNAPSUMMARY.out.summary )


### PR DESCRIPTION
Fix so empty output from barrnap can be handled by sbdi_export, added warnings and error messages id barrnap fails to find rRNA sequences. This adresses #552 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
