### PR TITLE
Let QIIME2 accept special symbols in taxonomy strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#551](https://github.com/nf-core/ampliseq/pull/551) - Handle empty barrnap results files
-- [#552](https://github.com/nf-core/ampliseq/pull/552) - Accept taxonomy strings that contain `#`,`'`
+- [#553](https://github.com/nf-core/ampliseq/pull/553) - Handle empty barrnap results files
+- [#554](https://github.com/nf-core/ampliseq/pull/554) - Accept taxonomy strings that contain `#`,`'`
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#551](https://github.com/nf-core/ampliseq/pull/551) - Handle empty barrnap results files
+- [#552](https://github.com/nf-core/ampliseq/pull/552) - Accept taxonomy strings that contain `#`,`'`
 
 ### `Dependencies`
 

--- a/bin/parse_dada2_taxonomy.r
+++ b/bin/parse_dada2_taxonomy.r
@@ -11,7 +11,7 @@ tax_file <- args[1]
 OUT="tax.tsv"
 
 # read required files
-tax = read.table(tax_file, header = TRUE, sep = "\t", stringsAsFactors = FALSE)
+tax = read.table(tax_file, header = TRUE, sep = "\t", stringsAsFactors = FALSE, comment.char = '', quote = '')
 
 # Join columns 2:ncol(.) - 1, the taxonomy ranks (sequence is the last)
 r <- colnames(tax)[!colnames(tax) %in% c('ASV_ID', 'sequence')]


### PR DESCRIPTION
Addresses a problem that occurs in 2.5.0 that choosing [silva_132.18s.99_rep_set.dada2.fa.gz](https://zenodo.org/record/1447330) with `--dada_ref_tax_custom`, 
i.e. with `nextflow run nf-core/ampliseq -r 2.5.0 -profile singularity --input samplesheet.tsv --dada_assign_taxlevels "Eukaryota,Opisthokonta,Holozoa,Metazoa,Tetrapoda,Mammalia,Homo,Genus" --dada_ref_tax_custom "https://zenodo.org/record/1447330/files/silva_132.18s.99_rep_set.dada2.fa.gz" --skip_dada_addspecies --outdir results`
the taxonomic strings contain `#` and `'` and will fail to be transferred to QIIME2. This PR fixes the issue.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
