### PR TITLE
use phylogenetic placement output in qiime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed`
 
 - [#563](https://github.com/nf-core/ampliseq/pull/563) - Renamed DADA2 taxonomic classification files to include the chosen reference taxonomy abbreviation.
+- [#567](https://github.com/nf-core/ampliseq/pull/567) - Renamed `--dada_tax_agglom_min` and `--qiime_tax_agglom_min` to `--tax_agglom_min` and `--dada_tax_agglom_max` and `--qiime_tax_agglom_max` to `--tax_agglom_max`
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#564](https://github.com/nf-core/ampliseq/pull/564) - Added phylogenetic placement
+- [#564](https://github.com/nf-core/ampliseq/pull/564),[#565](https://github.com/nf-core/ampliseq/pull/565) - Added phylogenetic placement
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#564](https://github.com/nf-core/ampliseq/pull/564),[#565](https://github.com/nf-core/ampliseq/pull/565) - Added phylogenetic placement
+- [#564](https://github.com/nf-core/ampliseq/pull/564),[#567](https://github.com/nf-core/ampliseq/pull/567) - Added phylogenetic placement
 
 ### `Changed`
 

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -69,7 +69,9 @@
 
 ### Phylogenetic placement
 
-- nf-core/phyloplace (https://github.com/nf-core/phyloplace, https://nf-co.re/phyloplace) was originally written by Daniel Lundin.
+- [nf-core/phyloplace](https://nf-co.re/phyloplace)
+
+  > Daniel Lundin. (2023). nf-core/phyloplace: First release (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.7643948
 
 - [HMMER](https://pubmed.ncbi.nlm.nih.gov/22039361/)
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -573,11 +573,19 @@ process {
         ]
     }
 
-    withName: 'QIIME2_INASV|QIIME2_INSEQ|QIIME2_INTAX' {
+    withName: 'QIIME2_INASV|QIIME2_INSEQ|QIIME2_INTAX|QIIME2_INTREE' {
         publishDir = [
             path: { "${params.outdir}/qiime2/input" },
             mode: params.publish_dir_mode,
             pattern: "*.qza"
+        ]
+    }
+
+    withName: FORMAT_PPLACETAX {
+        publishDir = [
+            path: { "${params.outdir}/pplace" },
+            mode: params.publish_dir_mode,
+            pattern: "*.per_query_unique.tsv"
         ]
     }
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -38,8 +38,8 @@ params {
     metadata_category_barplot = "treatment1,badpairwise10"
 
     //restrict ANCOM analysis to higher taxonomic levels
-    dada_tax_agglom_max = 4
-    qiime_tax_agglom_max = 4
+    tax_agglom_max = 4
+    tax_agglom_max = 4
 
     sbdiexport = true
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -39,7 +39,6 @@ params {
 
     //restrict ANCOM analysis to higher taxonomic levels
     tax_agglom_max = 4
-    tax_agglom_max = 4
 
     sbdiexport = true
 

--- a/conf/test_pplace.config
+++ b/conf/test_pplace.config
@@ -28,19 +28,23 @@ params {
     qiime_ref_taxonomy = "greengenes85"
     filter_ssu = "bac"
 
-    //this is to remove low abundance ASVs to reduce runtime of downstream processes
+    // this is to remove low abundance ASVs to reduce runtime of downstream processes
     min_samples = 2
     min_frequency = 10
 
-    //pplace
+    // pplace
     pplace_tree = "https://github.com/nf-core/test-datasets/raw/phyloplace/testdata/cyanos_16s.newick"
     pplace_aln = "https://github.com/nf-core/test-datasets/raw/phyloplace/testdata/cyanos_16s.alnfna"
     pplace_model = "GTR+F+I+I+R3"
     pplace_taxonomy = "https://github.com/nf-core/test-datasets/raw/phyloplace/testdata/cyanos_16s.taxonomy.tsv"
     pplace_name = "test_pplace"
 
+    // Adjust taxonomic levels
+    dada_tax_agglom_max = 1
+    dada_tax_agglom_max = 3
 
-    //Skip some steps to reduce runtime
+    // Skip some steps to reduce runtime
     skip_alpha_rarefaction = true
     skip_fastqc = true
+    skip_ancom = true
 }

--- a/conf/test_pplace.config
+++ b/conf/test_pplace.config
@@ -40,7 +40,7 @@ params {
     pplace_name = "test_pplace"
 
     // Adjust taxonomic levels
-    dada_tax_agglom_max = 1
+    dada_tax_agglom_min = 1
     dada_tax_agglom_max = 3
 
     // Skip some steps to reduce runtime

--- a/conf/test_pplace.config
+++ b/conf/test_pplace.config
@@ -40,8 +40,8 @@ params {
     pplace_name = "test_pplace"
 
     // Adjust taxonomic levels
-    dada_tax_agglom_min = 1
-    dada_tax_agglom_max = 3
+    tax_agglom_min = 1
+    tax_agglom_max = 3
 
     // Skip some steps to reduce runtime
     skip_alpha_rarefaction = true

--- a/docs/output.md
+++ b/docs/output.md
@@ -242,6 +242,7 @@ Phylogenetic placement grafts sequences onto a phylogenetic reference tree and o
 - `pplace/`
   - `*.graft.*.epa_result.newick`: Full phylogeny with query sequences grafted on to the reference phylogeny, in newick format.
   - `*.taxonomy.per_query.tsv`: Tab separated file with taxonomy information per query from classification by `gappa examine examinassign`
+  - `*.per_query_unique.tsv`: Tab separated file with taxonomy information as aboe, but one row per query, by filtering for lowest LWR (likelihood weight ratio)
   - `*.heattree.tree.svg`: Heattree in SVG format from calling `gappa examine heattree`, see [Gappa documentation](https://github.com/Pbdas/epa-ng/blob/master/README.md) for details.
   - `pplace/hmmer/`: Contains intermediatary files if HMMER is used
   - `pplace/mafft/`: Contains intermediatary files if MAFFT is used

--- a/docs/output.md
+++ b/docs/output.md
@@ -271,7 +271,7 @@ Intermediate data imported to QIIME2 is saved as QIIME2 fragments, that can be c
 
 #### Taxonomic classification
 
-Taxonomic classification with QIIME2 is typically similar to DADA2 classifications. However, both options are available. When taxonomic classification with DADA2 and QIIME2 is performed, DADA2 classification takes precedence over QIIME2 classifications for all downstream analysis.
+Taxonomic classification with QIIME2 is typically similar to DADA2 classifications. However, both options are available. When taxonomic classification with DADA2 and QIIME2 is performed, DADA2 classification takes precedence over QIIME2 classifications for all downstream analysis. Taxonomic classification by phylogenetic placement superseeds DADA2 and QIIME2 classification.
 
 <details markdown="1">
 <summary>Output files</summary>
@@ -285,7 +285,7 @@ Taxonomic classification with QIIME2 is typically similar to DADA2 classificatio
 
 #### Abundance tables
 
-The abundance tables are the final data for further downstream analysis and visualisations. The tables are based on the computed ASVs and taxonomic classification (DADA2 classification takes precedence over QIIME2 classifications), but after removal of unwanted taxa. Unwanted taxa are often off-targets generated in PCR with primers that are not perfectly specific for the target DNA (can be specified by `--exclude_taxa`), by default mitrochondria and chloroplast sequences are removed because these are frequent unwanted non-bacteria PCR products.
+The abundance tables are the final data for further downstream analysis and visualisations. The tables are based on the computed ASVs and taxonomic classification (in the following priotity: phylogenetic placement [EPA-NG, Gappa], DADA2, QIIME2), but after removal of unwanted taxa. Unwanted taxa are often off-targets generated in PCR with primers that are not perfectly specific for the target DNA (can be specified by `--exclude_taxa`), by default mitrochondria and chloroplast sequences are removed because these are frequent unwanted non-bacteria PCR products.
 
 All following analysis is based on these filtered tables.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -318,6 +318,7 @@ Absolute abundance tables produced by the previous steps contain count data, but
   - `rel-table-ASV.tsv`: Tab-separated relative abundance table for all ASVs.
   - `rel-table-ASV_with-DADA2-tax.tsv`: Tab-separated table for all ASVs with DADA2 taxonomic classification, sequence and relative abundance.
   - `rel-table-ASV_with-QIIME2-tax.tsv`: Tab-separated table for all ASVs with QIIME2 taxonomic classification, sequence and relative abundance.
+  - `rel-table-ASV_with-PPLACE-tax.tsv`: Tab-separated table for all ASVs with EPA-NG - Gappa taxonomic classification, sequence and relative abundance.
 
 </details>
 

--- a/lib/WorkflowAmpliseq.groovy
+++ b/lib/WorkflowAmpliseq.groovy
@@ -43,13 +43,8 @@ class WorkflowAmpliseq {
             System.exit(1)
         }
 
-        if (params.dada_tax_agglom_min > params.dada_tax_agglom_max) {
-            log.error "Incompatible parameters: `--dada_tax_agglom_min` may not be greater than `--dada_tax_agglom_max`."
-            System.exit(1)
-        }
-
-        if (params.qiime_tax_agglom_min > params.qiime_tax_agglom_max) {
-            log.error "Incompatible parameters: `--qiime_tax_agglom_min` may not be greater than `--qiime_tax_agglom_max`."
+        if (params.tax_agglom_min > params.tax_agglom_max) {
+            log.error "Incompatible parameters: `--tax_agglom_min` may not be greater than `--tax_agglom_max`."
             System.exit(1)
         }
 

--- a/modules/local/format_pplacetax.nf
+++ b/modules/local/format_pplacetax.nf
@@ -1,0 +1,99 @@
+process FORMAT_PPLACETAX {
+    tag "${tax.baseName}"
+    label 'process_high'
+
+    conda "bioconda::bioconductor-dada2=1.22.0 conda-forge::r-digest=0.6.30"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bioconductor-dada2:1.22.0--r41h399db7b_0' :
+        'quay.io/biocontainers/bioconductor-dada2:1.22.0--r41h399db7b_0' }"
+
+    input:
+    tuple val(meta), path(tax)
+
+    output:
+    path("*.per_query_unique.tsv"), emit: unique
+    path("*.taxonomy.tsv")        , emit: tsv
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    """
+    #!/usr/bin/env Rscript
+
+    tax = read.table("$tax", header = TRUE, sep = "\t", stringsAsFactors = FALSE, comment.char = '', quote = '')
+
+    df <- data.frame(
+        name=character(),
+        LWR=character(),
+        fract=character(),
+        aLWR=character(),
+        afract=character(),
+        taxopath=character(),
+        stringsAsFactors=FALSE)
+
+    for (asvid in unique(tax\$name)) {
+        # subset per ASV ID
+        temp = subset(tax, tax\$name == asvid)
+        maxLWR = max(temp\$LWR)
+        temp = subset(temp, temp\$LWR == maxLWR)
+
+        if ( nrow(temp) == 1 ) {
+            # STEP 1: if there is just 1 maximum, choose this row
+            print( paste ( asvid,"was added in STEP 1" ) )
+            temp = temp[which.max(temp\$LWR),]
+            df <- rbind(df, temp)
+        } else {
+            # STEP2: be conservative, choose the taxonomy with less entries
+            # count number of entries in "taxopath", simplified: number of semicolons
+            temp\$taxlevels = nchar( temp\$taxopath ) - nchar(gsub(';', '', temp\$taxopath )) + 1
+            minTaxlevels = min(temp\$taxlevels)
+            temp = subset(temp, temp\$taxlevels == minTaxlevels)
+            temp\$taxlevels = NULL
+            if ( nrow(temp) == 1 ) {
+                df <- rbind(df, temp)
+                print( paste ( asvid,"was added in STEP 2" ) )
+            } else {
+                # STEP 3: if number of entries is same, remove last entry
+                # then, check if reduced entries are identical > if yes, choose any row, if no, repeat
+                # at that step the taxonomies have same length
+                print( paste ( asvid,"enters STEP 3" ) )
+                list_taxonpath <- str_split( temp\$taxopath, ";")
+                df_taxonpath <- as.data.frame(do.call(rbind, list_taxonpath))
+                for (i in ncol(df_taxonpath):0) {
+                    # choose first column and change taxon to reduced overlap
+                    print(paste("i:",i))
+                    print(df_taxonpath[,1:i])
+                    print(paste("len:",length(unique(df_taxonpath[,i]))))
+                    if ( length(unique(df_taxonpath[,i])) == 1 ) {
+                        if (i>1) {
+                            temp\$taxopath <- apply(df_taxonpath[1,1:i], 1, paste, collapse=";")[[1]]
+                        } else if (i==1) {
+                            temp\$taxopath <- df_taxonpath[1,1]
+                        }
+                        df <- rbind(df, temp[1,])
+                        print( paste ( asvid,"was added with",temp\$taxopath[[1]],"in STEP 3a" ) )
+                        break
+                    } else if (i==0) {
+                        # if all fails, i.e. there is no consensus on any taxonomic level, use NA
+                        temp\$taxopath <- "NA"
+                        df <- rbind(df, temp[1,])
+                        print( paste ( asvid,"was added with",temp\$taxopath[[1]],"in STEP 3b" ) )
+                    }
+                }
+            }
+        }
+    }
+
+    # output the cleaned, unified, unique taxonomic classification per ASV
+    write.table(df, file = "${meta.id}.taxonomy.per_query_unique.tsv", row.names = FALSE, col.names = TRUE, quote = FALSE, na = '', sep = "\\t")
+
+    # output ASV taxonomy table for QIIME2
+    df_clean <- subset(df, select = c("name","taxopath"))
+    colnames(df_clean) <- c("ASV_ID","taxonomy")
+    write.table(df_clean, file = "${meta.id}.taxonomy.tsv", row.names = FALSE, col.names = TRUE, quote = FALSE, na = '', sep = "\\t")
+
+    writeLines(c("\\"${task.process}\\":", paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")),paste0("    dada2: ", packageVersion("dada2")) ), "versions.yml")
+    """
+}

--- a/modules/local/format_pplacetax.nf
+++ b/modules/local/format_pplacetax.nf
@@ -63,9 +63,6 @@ process FORMAT_PPLACETAX {
                 df_taxonpath <- as.data.frame(do.call(rbind, list_taxonpath))
                 for (i in ncol(df_taxonpath):0) {
                     # choose first column and change taxon to reduced overlap
-                    print(paste("i:",i))
-                    print(df_taxonpath[,1:i])
-                    print(paste("len:",length(unique(df_taxonpath[,i]))))
                     if ( length(unique(df_taxonpath[,i])) == 1 ) {
                         if (i>1) {
                             temp\$taxopath <- apply(df_taxonpath[1,1:i], 1, paste, collapse=";")[[1]]

--- a/modules/local/qiime2_intree.nf
+++ b/modules/local/qiime2_intree.nf
@@ -1,0 +1,34 @@
+process QIIME2_INTREE {
+    tag "${meta.id}:${meta.model}"
+    label 'process_low'
+
+    container "quay.io/qiime2/core:2022.11"
+
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
+
+    input:
+    tuple val(meta), path(tree)
+
+    output:
+    path("tree.qza")   , emit: qza
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    """
+    qiime tools import \\
+        --type 'Phylogeny[Rooted]' \\
+        --input-path $tree \\
+        --output-path tree.qza
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        qiime2: \$( qiime --version | sed '1!d;s/.* //' )
+    END_VERSIONS
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -47,10 +47,8 @@ params {
     picrust           = false
     sbdiexport        = false
     addsh             = false
-    dada_tax_agglom_min = 2
-    dada_tax_agglom_max = 6
-    qiime_tax_agglom_min = 2
-    qiime_tax_agglom_max = 6
+    tax_agglom_min = 2
+    tax_agglom_max = 6
     ignore_failed_trimming = false
     ignore_empty_input_files = false
     qiime_adonis_formula = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -280,7 +280,7 @@
                 },
                 "pplace_taxonomy": {
                     "type": "string",
-                    "help_text": "Headerless, tab-separated, first column with tree leaves, second column with taxonomy ranks separated by semicolon `;`.",
+                    "help_text": "Headerless, tab-separated, first column with tree leaves, second column with taxonomy ranks separated by semicolon `;`. The results take precedence over DADA2 and QIIME2 classifications.",
                     "description": "Tab-separated file with taxonomy assignments of reference sequences."
                 },
                 "pplace_name": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -426,33 +426,19 @@
                     "description": "Minimum sample counts to retain a sample for ANCOM analysis. Any sample below that threshold will be removed.",
                     "fa_icon": "fas fa-greater-than-equal"
                 },
-                "dada_tax_agglom_min": {
+                "tax_agglom_min": {
                     "type": "integer",
                     "default": 2,
-                    "description": "Minimum taxonomy agglomeration level for DADA2 classification",
+                    "description": "Minimum taxonomy agglomeration level for taxonomic classifications",
                     "fa_icon": "fas fa-greater-than-equal",
                     "help_text": "Depends on the reference taxonomy database used."
                 },
-                "dada_tax_agglom_max": {
+                "tax_agglom_max": {
                     "type": "integer",
                     "default": 6,
-                    "description": "Maximum taxonomy agglomeration level for DADA2 classification",
+                    "description": "Maximum taxonomy agglomeration level for taxonomic classifications",
                     "fa_icon": "fas fa-greater-than-equal",
                     "help_text": "Depends on the reference taxonomy database used. Most default databases have genus level at 6."
-                },
-                "qiime_tax_agglom_min": {
-                    "type": "integer",
-                    "default": 2,
-                    "description": "Minimum taxonomy agglomeration level for QIIME2 classification",
-                    "fa_icon": "fas fa-greater-than-equal",
-                    "help_text": "Depends on the reference taxonomy database used."
-                },
-                "qiime_tax_agglom_max": {
-                    "type": "integer",
-                    "default": 6,
-                    "description": "Maximum taxonomy agglomeration level for QIIME2 classification",
-                    "fa_icon": "fas fa-greater-than-equal",
-                    "help_text": "Depends on the reference taxonomy database used. Default databases should have genus level at 6."
                 }
             }
         },

--- a/subworkflows/local/qiime2_export.nf
+++ b/subworkflows/local/qiime2_export.nf
@@ -7,6 +7,7 @@ include { QIIME2_EXPORT_RELASV                  } from '../../modules/local/qiim
 include { QIIME2_EXPORT_RELTAX                  } from '../../modules/local/qiime2_export_reltax'
 include { COMBINE_TABLE as COMBINE_TABLE_QIIME2 } from '../../modules/local/combine_table'
 include { COMBINE_TABLE as COMBINE_TABLE_DADA2  } from '../../modules/local/combine_table'
+include { COMBINE_TABLE as COMBINE_TABLE_PPLACE } from '../../modules/local/combine_table'
 
 workflow QIIME2_EXPORT {
     take:
@@ -15,6 +16,7 @@ workflow QIIME2_EXPORT {
     ch_tax
     ch_QIIME2_tax_tsv
     ch_DADA2_tax_tsv
+    ch_pplace_tax_tsv
     tax_agglom_min
     tax_agglom_max
 
@@ -33,6 +35,9 @@ workflow QIIME2_EXPORT {
 
     //combine_table.r (optional), similar to DADA2_table.tsv but with additionally taxonomy merged
     COMBINE_TABLE_DADA2 ( QIIME2_EXPORT_RELASV.out.tsv, QIIME2_EXPORT_ABSOLUTE.out.fasta, ch_DADA2_tax_tsv, 'rel-table-ASV_with-DADA2-tax.tsv' )
+
+    //combine_table.r (optional), similar to DADA2_table.tsv but with additionally taxonomy merged
+    COMBINE_TABLE_PPLACE ( QIIME2_EXPORT_RELASV.out.tsv, QIIME2_EXPORT_ABSOLUTE.out.fasta, ch_pplace_tax_tsv, 'rel-table-ASV_with-PPLACE-tax.tsv' )
 
     emit:
     abs_fasta      = QIIME2_EXPORT_ABSOLUTE.out.fasta

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -504,7 +504,7 @@ workflow AMPLISEQ {
         ch_versions = ch_versions.mix( FASTA_NEWICK_EPANG_GAPPA.out.versions )
 
         ch_pplace_tax = FORMAT_PPLACETAX ( FASTA_NEWICK_EPANG_GAPPA.out.taxonomy_per_query ).tsv
-    }
+    } else { ch_pplace_tax = Channel.empty() }
 
     //QIIME2
     if ( run_qiime2 ) {
@@ -586,7 +586,7 @@ workflow AMPLISEQ {
         }
         //Export various ASV tables
         if (!params.skip_abundance_tables) {
-            QIIME2_EXPORT ( ch_asv, ch_seq, ch_tax, QIIME2_TAXONOMY.out.tsv, ch_dada2_tax, tax_agglom_min, tax_agglom_max )
+            QIIME2_EXPORT ( ch_asv, ch_seq, ch_tax, QIIME2_TAXONOMY.out.tsv, ch_dada2_tax, ch_pplace_tax, tax_agglom_min, tax_agglom_max )
         }
 
         if (!params.skip_barplot) {

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -91,6 +91,10 @@ if ( !is_fasta_input && (!params.FW_primer || !params.RV_primer) && !params.skip
     System.exit(1)
 }
 
+// save params to values to be able to overwrite it
+tax_agglom_min = params.tax_agglom_min
+tax_agglom_max = params.tax_agglom_max
+
 //use custom taxlevels from --dada_assign_taxlevels or database specific taxlevels if specified in conf/ref_databases.config
 if ( params.dada_ref_taxonomy ) {
     taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" :
@@ -544,18 +548,12 @@ workflow AMPLISEQ {
         } else if ( params.pplace_tree && params.pplace_taxonomy) {
             log.info "Use EPA-NG / GAPPA taxonomy classification"
             ch_tax = QIIME2_INTAX ( ch_pplace_tax ).qza
-            tax_agglom_min = params.tax_agglom_min
-            tax_agglom_max = params.tax_agglom_max
         } else if ( params.dada_ref_taxonomy ) {
             log.info "Use DADA2 taxonomy classification"
             ch_tax = QIIME2_INTAX ( ch_dada2_tax ).qza
-            tax_agglom_min = params.tax_agglom_min
-            tax_agglom_max = params.tax_agglom_max
         } else if ( params.qiime_ref_taxonomy || params.classifier ) {
             log.info "Use QIIME2 taxonomy classification"
             ch_tax = QIIME2_TAXONOMY.out.qza
-            tax_agglom_min = params.tax_agglom_min
-            tax_agglom_max = params.tax_agglom_max
         } else {
             log.info "Use no taxonomy classification"
             ch_tax = Channel.empty()

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -149,6 +149,8 @@ include { FORMAT_TAXRESULTS as FORMAT_TAXRESULTS_ADDSP } from '../modules/local/
 include { QIIME2_INSEQ                  } from '../modules/local/qiime2_inseq'
 include { QIIME2_FILTERTAXA             } from '../modules/local/qiime2_filtertaxa'
 include { QIIME2_INASV                  } from '../modules/local/qiime2_inasv'
+include { QIIME2_INTREE                 } from '../modules/local/qiime2_intree'
+include { FORMAT_PPLACETAX              } from '../modules/local/format_pplacetax'
 include { FILTER_STATS                  } from '../modules/local/filter_stats'
 include { MERGE_STATS as MERGE_STATS_FILTERTAXA } from '../modules/local/merge_stats'
 include { QIIME2_BARPLOT                } from '../modules/local/qiime2_barplot'
@@ -500,12 +502,8 @@ workflow AMPLISEQ {
         }
         FASTA_NEWICK_EPANG_GAPPA ( ch_pp_data )
         ch_versions = ch_versions.mix( FASTA_NEWICK_EPANG_GAPPA.out.versions )
-        //TODO: if params.pplace_taxonomy is given, use taxonomy over DADA2 taxonomy for downstream analysis --> FASTA_NEWICK_EPANG_GAPPA.out.taxonomy_per_query --> test_pplace.taxonomy.per_query.tsv
-            //Use for each ASV the annotation with lowest LWR (likelihood-weight-ration) -> conversion script
-                //if tie -> use annotation with less entries (i.e. conservative choice)
-                    //if same number of entries -> remove last entry
-                        //if those truncated annotations arent identical, remove one more entry; repeat until identical
-        //TODO: use newick tree in downstream analysis --> FASTA_NEWICK_EPANG_GAPPA.out.grafted_phylogeny --> test_pplace.graft.test_pplace.epa_result.newick
+
+        ch_pplace_tax = FORMAT_PPLACETAX ( FASTA_NEWICK_EPANG_GAPPA.out.taxonomy_per_query ).tsv
     }
 
     //QIIME2
@@ -528,16 +526,26 @@ workflow AMPLISEQ {
     // SUBWORKFLOW / MODULES : Downstream analysis with QIIME2
     //
     if ( run_qiime2 ) {
-        //Import ASV abundance table and sequences into QIIME2
+        // Import ASV abundance table and sequences into QIIME2
         QIIME2_INASV ( ch_dada2_asv )
         QIIME2_INSEQ ( ch_fasta )
 
-        //Import taxonomic classification into QIIME2, if available
+        // Import phylogenetic tree into QIIME2
+        if ( params.pplace_tree ) {
+            ch_tree = QIIME2_INTREE ( FASTA_NEWICK_EPANG_GAPPA.out.grafted_phylogeny ).qza
+        } else { ch_tree = Channel.empty() }
+
+        // Import taxonomic classification into QIIME2, if available
         if ( params.skip_taxonomy ) {
             log.info "Skip taxonomy classification"
             ch_tax = Channel.empty()
             tax_agglom_min = 1
             tax_agglom_max = 2
+        } else if ( params.pplace_tree && params.pplace_taxonomy) {
+            log.info "Use EPA-NG / GAPPA taxonomy classification"
+            ch_tax = QIIME2_INTAX ( ch_pplace_tax ).qza
+            tax_agglom_min = params.dada_tax_agglom_min
+            tax_agglom_max = params.dada_tax_agglom_max
         } else if ( params.dada_ref_taxonomy ) {
             log.info "Use DADA2 taxonomy classification"
             ch_tax = QIIME2_INTAX ( ch_dada2_tax ).qza
@@ -555,7 +563,7 @@ workflow AMPLISEQ {
             tax_agglom_max = 2
         }
 
-        //Filtering ASVs by taxonomy & prevalence & counts
+        // Filtering ASVs by taxonomy & prevalence & counts
         if (params.exclude_taxa != "none" || params.min_frequency != 1 || params.min_samples != 1) {
             QIIME2_FILTERTAXA (
                 QIIME2_INASV.out.qza,
@@ -614,6 +622,7 @@ workflow AMPLISEQ {
                 ch_metadata,
                 ch_asv,
                 ch_seq,
+                ch_tree,
                 ch_tsv,
                 ch_metacolumn_pairwise,
                 ch_metacolumn_all,

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -544,18 +544,18 @@ workflow AMPLISEQ {
         } else if ( params.pplace_tree && params.pplace_taxonomy) {
             log.info "Use EPA-NG / GAPPA taxonomy classification"
             ch_tax = QIIME2_INTAX ( ch_pplace_tax ).qza
-            tax_agglom_min = params.dada_tax_agglom_min
-            tax_agglom_max = params.dada_tax_agglom_max
+            tax_agglom_min = params.tax_agglom_min
+            tax_agglom_max = params.tax_agglom_max
         } else if ( params.dada_ref_taxonomy ) {
             log.info "Use DADA2 taxonomy classification"
             ch_tax = QIIME2_INTAX ( ch_dada2_tax ).qza
-            tax_agglom_min = params.dada_tax_agglom_min
-            tax_agglom_max = params.dada_tax_agglom_max
+            tax_agglom_min = params.tax_agglom_min
+            tax_agglom_max = params.tax_agglom_max
         } else if ( params.qiime_ref_taxonomy || params.classifier ) {
             log.info "Use QIIME2 taxonomy classification"
             ch_tax = QIIME2_TAXONOMY.out.qza
-            tax_agglom_min = params.qiime_tax_agglom_min
-            tax_agglom_max = params.qiime_tax_agglom_max
+            tax_agglom_min = params.tax_agglom_min
+            tax_agglom_max = params.tax_agglom_max
         } else {
             log.info "Use no taxonomy classification"
             ch_tax = Channel.empty()


### PR DESCRIPTION
Closes https://github.com/nf-core/ampliseq/issues/561

Taxonomic tree and taxonomic annotation from phylogenetic placement are now picked up and used in downstream (QIIME2) analysis. 

The additional code in `FORMAT_PPLACETAX` uses only the taxonomic annotation from Gappa that
```
- has the lowest LWR, 
- if multiple, 
     - if identical it will choose the first one, 
     - if not identical, it will choose the one with less taxonomic entries, 
               - if same number of taxonomic entries, it will remove entries until they are identical, 
               - if all removed it will add a `NA`. 
```
I searched, tested and dismissed several pre-made code/commands/functions for this, such as from R's stringi or stringr packages, so I made the custom code.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
