### PR TITLE
Make header in overall_summary consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#553](https://github.com/nf-core/ampliseq/pull/553) - Handle empty barrnap results files
 - [#554](https://github.com/nf-core/ampliseq/pull/554) - Accept taxonomy strings that contain `#`,`'`
+- [#569](https://github.com/nf-core/ampliseq/pull/569) - Make header of overall_summary.tsv consistent between input data types
 
 ### `Dependencies`
 

--- a/modules/local/dada2_stats.nf
+++ b/modules/local/dada2_stats.nf
@@ -85,7 +85,7 @@ process DADA2_STATS {
         } else {
             track <- cbind(filter_and_trim, sapply(dadaFs, getN), rowSums(seqtab.nochim))
         }
-        colnames(track) <- c("input", "filtered", "denoised", "nonchim")
+        colnames(track) <- c("DADA2_input", "filtered", "denoised", "nonchim")
         track <- cbind(sample = sub(pattern = "(.*?)\\\\..*\$", replacement = "\\\\1", rownames(track)), track)
         write.table( track, file = "${meta.run}.stats.tsv", sep = "\\t", row.names = FALSE, quote = FALSE, na = '')
 


### PR DESCRIPTION
The input/DADA2_input column is named differently when using single end data compared to paired end, I suggest to use "DADA2_input" in both cases. I cannot find any conflicts in the ampliseq code.

<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
