### PR TITLE
fix typo in quick start command

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,7 +40,7 @@ nextflow run nf-core/ampliseq \
     --input "samplesheet.tsv" \
     --FW_primer GTGYCAGCMGCCGCGGTAA \
     --RV_primer GGACTACNVGGGTWTCTAAT \
-    --metadata "data/Metadata.tsv"
+    --metadata "data/Metadata.tsv" \
     --outdir "./results"
 ```
 


### PR DESCRIPTION
Fix small typo in quick start command which will make the command fail...

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
