### PR TITLE
Prevent rare error with sample sheet edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#605](https://github.com/nf-core/ampliseq/pull/605) - Make `--sbdiexport` compatible with PR2 version 5.0.0
 - [#614](https://github.com/nf-core/ampliseq/pull/614),[#620](https://github.com/nf-core/ampliseq/pull/620) - Template update for nf-core/tools version 2.9
 - [#617](https://github.com/nf-core/ampliseq/pull/617) - Fix database compatibility check for `--sbdiexport`
+- [#628](https://github.com/nf-core/ampliseq/pull/628) - Fix edge case for sample sheet input when using specific combinations of sampleID and forwardReads or reverseReads that will forward one file too much to cutadapt
 
 ### `Dependencies`
 

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -228,6 +228,8 @@ workflow AMPLISEQ {
                 meta.single_end = single_end.toBoolean()
                 def reads = single_end ? readfw : [readfw,readrv]
                 if ( !meta.single_end && !readrv ) { error("Entry `reverseReads` is missing in $params.input for $meta.id, either correct the samplesheet or use `--single_end`, `--pacbio`, or `--iontorrent`") } // make sure that reverse reads are present when single_end isnt specified
+                if ( !meta.single_end && ( readfw.getSimpleName() == meta.id || readrv.getSimpleName() == meta.id ) ) { error("Entry `sampleID` cannot be identical to simple name of `forwardReads` or `reverseReads`, please change `sampleID` in $params.input for sample $meta.id") } // sample name and any file name without extensions arent identical, because rename_raw_data_files.nf would forward 3 files (2 renamed +1 input) instead of 2 in that case
+                if ( meta.single_end && ( readfw.getSimpleName() == meta.id+"_1" || readfw.getSimpleName() == meta.id+"_2" ) ) { error("Entry `sampleID`+ `_1` or `_2` cannot be identical to simple name of `forwardReads`, please change `sampleID` in $params.input for sample $meta.id") } // sample name and file name without extensions arent identical, because rename_raw_data_files.nf would forward 2 files (1 renamed +1 input) instead of 1 in that case
                 return [meta, reads] }
     } else if ( params.input_fasta ) {
         ch_input_fasta = Channel.fromPath(params.input_fasta, checkIfExists: true)


### PR DESCRIPTION
Closes https://github.com/nf-core/ampliseq/issues/627

This PR attempts the fix by adding two sanity checks after reading the sample sheet that will raise a clear error with the request to change sampleIDs. I did think about fixing it in the [problematic code line of the renaming module](https://github.com/nf-core/ampliseq/blob/3b252d263d101879c7077eae94a7a3d714b051aa/modules/local/rename_raw_data_files.nf#L14) that picks up additionally to renamed files also an original input file, but I didn't come up with a feasible solution (all my solutions would require a re-factoring of multiple other modules to correct the sample ID).

Using the sample sheet `samplesheet.tsv` with content
```
sampleID	forwardReads	reverseReads
S127_02	S127_01.fastq.gz	S127_02.fastq.gz
S115	S115_1.fastq.gz	S115_2.fastq.gz
```
with 
**(1)** `nextflow run nf-core/ampliseq -r 2.6.1 -profile test,singularity --metadata false --input samplesheet.tsv --outdir results` will fail with
```
ERROR ~ Error executing process > 'NFCORE_AMPLISEQ:AMPLISEQ:CUTADAPT_WORKFLOW:CUTADAPT_BASIC (S127_02)'

Caused by:
  Process `NFCORE_AMPLISEQ:AMPLISEQ:CUTADAPT_WORKFLOW:CUTADAPT_BASIC (S127_02)` terminated with an error exit status (2)

Command executed:

  cutadapt \
      --cores 2 \
      --minimum-length 1 -O 3 -e 0.1 -g GTGYCAGCMGCCGCGGTAA -G GGACTACNVGGGTWTCTAAT --discard-untrimmed \
      -o S127_02.trimmed_1.trim.fastq.gz -p S127_02.trimmed_2.trim.fastq.gz \
      S127_02.fastq.gz S127_02_1.fastq.gz S127_02_2.fastq.gz \
      > S127_02.trimmed.cutadapt.log
  cat <<-END_VERSIONS > versions.yml
  "NFCORE_AMPLISEQ:AMPLISEQ:CUTADAPT_WORKFLOW:CUTADAPT_BASIC":
      cutadapt: $(cutadapt --version)
  END_VERSIONS

Command exit status:
  2

Command output:
  (empty)

Command error:
  Run "cutadapt --help" to see command-line options.
  See https://cutadapt.readthedocs.io/ for full documentation.
  
  cutadapt: error: You provided 3 input file names, but either one or two are expected. The file names were:
   - 'S127_02.fastq.gz'
   - 'S127_02_1.fastq.gz'
   - 'S127_02_2.fastq.gz'
  Hint: If your path contains spaces, you need to enclose it in quotes
```
or
**(2)** `nextflow run nf-core/ampliseq -r 2.6.1 -profile test,singularity --metadata false --input samplesheet.tsv --outdir results --single_end`
will fail with:
```
ERROR ~ Error executing process > 'NFCORE_AMPLISEQ:AMPLISEQ:CUTADAPT_WORKFLOW:CUTADAPT_BASIC (S115)'

Caused by:
  Process `NFCORE_AMPLISEQ:AMPLISEQ:CUTADAPT_WORKFLOW:CUTADAPT_BASIC (S115)` terminated with an error exit status (2)

Command executed:

  cutadapt \
      --cores 2 \
      --minimum-length 1 -O 3 -e 0.1 -g GTGYCAGCMGCCGCGGTAA --discard-untrimmed \
      -o S115.trimmed.trim.fastq.gz \
      S115.fastq.gz S115_1.fastq.gz \
      > S115.trimmed.cutadapt.log
  cat <<-END_VERSIONS > versions.yml
  "NFCORE_AMPLISEQ:AMPLISEQ:CUTADAPT_WORKFLOW:CUTADAPT_BASIC":
      cutadapt: $(cutadapt --version)
  END_VERSIONS

Command exit status:
  2

Command output:
  (empty)

Command error:
  Run "cutadapt --help" to see command-line options.
  See https://cutadapt.readthedocs.io/ for full documentation.
  
  cutadapt: error: It appears you want to trim paired-end data because you provided two input files, but then you also need to provide two output files (with -o and -p) or use the --interleaved option.
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
