### PR TITLE
 Fix --dada_ref_tax_custom without --dada_ref_tax_custom_sp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#628](https://github.com/nf-core/ampliseq/pull/628) - Fix edge case for sample sheet input when using specific combinations of sampleID and forwardReads or reverseReads that will forward one file too much to cutadapt
 - [#630](https://github.com/nf-core/ampliseq/pull/630) - ASV rRNA (barrnap), length, and codon filter now work with ASV fasta file input
 - [#633](https://github.com/nf-core/ampliseq/pull/633) - UNIFRAC in QIIME2_DIVERSITY_CORE is now prevented from using a GPU to avoid errors
-- [#642](https://github.com/nf-core/ampliseq/pull/642) - Fix using `--skip_dada_addspecies` without `--dada_ref_tax_custom_sp` which was broken in 2.6.0 & 2.6.1
+- [#643](https://github.com/nf-core/ampliseq/pull/643) - Fix using `--skip_dada_addspecies` without `--dada_ref_tax_custom_sp` which was broken in 2.6.0 & 2.6.1
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#628](https://github.com/nf-core/ampliseq/pull/628) - Fix edge case for sample sheet input when using specific combinations of sampleID and forwardReads or reverseReads that will forward one file too much to cutadapt
 - [#630](https://github.com/nf-core/ampliseq/pull/630) - ASV rRNA (barrnap), length, and codon filter now work with ASV fasta file input
 - [#633](https://github.com/nf-core/ampliseq/pull/633) - UNIFRAC in QIIME2_DIVERSITY_CORE is now prevented from using a GPU to avoid errors
+- [#642](https://github.com/nf-core/ampliseq/pull/642) - Fix using `--skip_dada_addspecies` without `--dada_ref_tax_custom_sp` which was broken in 2.6.0 & 2.6.1
 
 ### `Dependencies`
 

--- a/conf/test_failed.config
+++ b/conf/test_failed.config
@@ -24,14 +24,19 @@ params {
     RV_primer = "GGACTACNVGGGTWTCTAAT"
     input = "https://raw.githubusercontent.com/nf-core/test-datasets/ampliseq/samplesheets/Samplesheet_failed_sample.tsv"
     metadata = "https://raw.githubusercontent.com/nf-core/test-datasets/ampliseq/samplesheets/Metadata_failed_sample.tsv"
-    dada_ref_taxonomy = "gtdb"
+    dada_ref_tax_custom = "https://zenodo.org/record/4310151/files/rdp_train_set_18.fa.gz"
+    skip_dada_addspecies = true
     cut_dada_ref_taxonomy = true
-    qiime_ref_taxonomy = "greengenes85"
     max_len_asv = 255
     filter_ssu = "bac"
+    ignore_failed_trimming = true
+    ignore_empty_input_files = true
     ignore_failed_filtering = true
 
     //this is to remove low abundance ASVs to reduce runtime of downstream processes
     min_samples = 2
     min_frequency = 10
+
+    // Skipping steps
+    skip_fastqc = true
 }

--- a/tests/pipeline/failed.nf.test
+++ b/tests/pipeline/failed.nf.test
@@ -1,0 +1,36 @@
+nextflow_pipeline {
+
+    name "Test Workflow main.nf"
+    script "main.nf"
+    tag "test_failed"
+    tag "pipeline"
+
+    test("Failing samples") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert new File("$outputDir/overall_summary.tsv").exists() },
+                { assert new File("$outputDir/barrnap/summary.tsv").exists() },
+                { assert new File("$outputDir/cutadapt/cutadapt_summary.tsv").exists() },
+                { assert new File("$outputDir/dada2/DADA2_table.tsv").exists() },
+                { assert new File("$outputDir/dada2/ASV_tax.user.tsv").exists() },
+                { assert new File("$outputDir/qiime2/abundance_tables/count_table_filter_stats.tsv").exists() },
+                { assert new File("$outputDir/qiime2/abundance_tables/feature-table.tsv").exists() },
+                { assert new File("$outputDir/qiime2/ancom/Category-treatment1-ASV/ancom.tsv").exists() },
+                { assert new File("$outputDir/qiime2/barplot/index.html").exists() },
+                { assert new File("$outputDir/qiime2/alpha-rarefaction/index.html").exists() },
+                { assert new File("$outputDir/qiime2/diversity/alpha_diversity/shannon_vector/kruskal-wallis-pairwise-treatment1.csv").exists() },
+                { assert new File("$outputDir/qiime2/diversity/beta_diversity/bray_curtis_pcoa_results-PCoA/index.html").exists() },
+                { assert new File("$outputDir/summary_report/summary_report.html").exists() },
+                { assert new File("$outputDir/phyloseq/dada2_phyloseq.rds").exists() }
+            )
+        }
+    }
+}

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -47,7 +47,7 @@ if (params.dada_ref_tax_custom) {
     ch_assigntax = Channel.fromPath("${params.dada_ref_tax_custom}", checkIfExists: true)
     if (params.dada_ref_tax_custom_sp) {
         ch_addspecies = Channel.fromPath("${params.dada_ref_tax_custom_sp}", checkIfExists: true)
-    }
+    } else { ch_addspecies = Channel.empty() }
     ch_dada_ref_taxonomy = Channel.empty()
     val_dada_ref_taxonomy = "user"
 } else if (params.dada_ref_taxonomy && !params.skip_dada_taxonomy && !params.skip_taxonomy) {


### PR DESCRIPTION
This is a bug fix: 
`nextflow run nf-core/ampliseq -r 2.5.0 -profile test_reftaxcustom,singularity --outdir results --dada_ref_tax_custom_sp false --skip_dada_addspecies`
was fine but 
`nextflow run nf-core/ampliseq -r 2.6.1 -profile test_reftaxcustom,singularity --outdir results --dada_ref_tax_custom_sp false --skip_dada_addspecies`
failed with 
`ERROR ~ No such variable: ch_addspecies`

Obviously that function was broken after introduction, so I added a test in the new `test_failed.conf` that should prevent that in future.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
