### PR TITLE
Fix nextflow version 23.10.0 with QIIME2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#655](https://github.com/nf-core/ampliseq/pull/655) - Added `NUMBA_CACHE_DIR` to fix downstream analysis with QIIME2 that failed on some systems
+
 ### `Dependencies`
 
 ### `Removed`

--- a/modules/local/qiime2_alphararefaction.nf
+++ b/modules/local/qiime2_alphararefaction.nf
@@ -24,7 +24,7 @@ process QIIME2_ALPHARAREFACTION {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     maxdepth=\$(count_table_minmax_reads.py $stats maximum 2>&1)

--- a/modules/local/qiime2_alphararefaction.nf
+++ b/modules/local/qiime2_alphararefaction.nf
@@ -23,8 +23,9 @@ process QIIME2_ALPHARAREFACTION {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     maxdepth=\$(count_table_minmax_reads.py $stats maximum 2>&1)
 

--- a/modules/local/qiime2_alphararefaction.nf
+++ b/modules/local/qiime2_alphararefaction.nf
@@ -24,6 +24,7 @@ process QIIME2_ALPHARAREFACTION {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     maxdepth=\$(count_table_minmax_reads.py $stats maximum 2>&1)
 

--- a/modules/local/qiime2_alphararefaction.nf
+++ b/modules/local/qiime2_alphararefaction.nf
@@ -23,9 +23,9 @@ process QIIME2_ALPHARAREFACTION {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     maxdepth=\$(count_table_minmax_reads.py $stats maximum 2>&1)
 

--- a/modules/local/qiime2_ancom_asv.nf
+++ b/modules/local/qiime2_ancom_asv.nf
@@ -25,6 +25,7 @@ process QIIME2_ANCOM_ASV {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime composition add-pseudocount \\
         --i-table ${table} \\

--- a/modules/local/qiime2_ancom_asv.nf
+++ b/modules/local/qiime2_ancom_asv.nf
@@ -25,7 +25,7 @@ process QIIME2_ANCOM_ASV {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     qiime composition add-pseudocount \\

--- a/modules/local/qiime2_ancom_asv.nf
+++ b/modules/local/qiime2_ancom_asv.nf
@@ -24,8 +24,9 @@ process QIIME2_ANCOM_ASV {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     qiime composition add-pseudocount \\
         --i-table ${table} \\

--- a/modules/local/qiime2_ancom_asv.nf
+++ b/modules/local/qiime2_ancom_asv.nf
@@ -24,9 +24,9 @@ process QIIME2_ANCOM_ASV {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     qiime composition add-pseudocount \\
         --i-table ${table} \\

--- a/modules/local/qiime2_ancom_tax.nf
+++ b/modules/local/qiime2_ancom_tax.nf
@@ -22,8 +22,9 @@ process QIIME2_ANCOM_TAX {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
     mkdir ancom
 
     # Sum data at the specified level

--- a/modules/local/qiime2_ancom_tax.nf
+++ b/modules/local/qiime2_ancom_tax.nf
@@ -23,6 +23,7 @@ process QIIME2_ANCOM_TAX {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
     mkdir ancom
 
     # Sum data at the specified level

--- a/modules/local/qiime2_ancom_tax.nf
+++ b/modules/local/qiime2_ancom_tax.nf
@@ -23,7 +23,7 @@ process QIIME2_ANCOM_TAX {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
     mkdir ancom
 

--- a/modules/local/qiime2_ancom_tax.nf
+++ b/modules/local/qiime2_ancom_tax.nf
@@ -22,9 +22,9 @@ process QIIME2_ANCOM_TAX {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
     mkdir ancom
 
     # Sum data at the specified level

--- a/modules/local/qiime2_barplot.nf
+++ b/modules/local/qiime2_barplot.nf
@@ -25,9 +25,9 @@ process QIIME2_BARPLOT {
     suffix = setting ? "_${table.baseName}" : ""
     def metadata_cmd = metadata ? "--m-metadata-file ${metadata}": ""
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     qiime taxa barplot  \\
         --i-table ${table}  \\

--- a/modules/local/qiime2_barplot.nf
+++ b/modules/local/qiime2_barplot.nf
@@ -25,8 +25,9 @@ process QIIME2_BARPLOT {
     suffix = setting ? "_${table.baseName}" : ""
     def metadata_cmd = metadata ? "--m-metadata-file ${metadata}": ""
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     qiime taxa barplot  \\
         --i-table ${table}  \\

--- a/modules/local/qiime2_barplot.nf
+++ b/modules/local/qiime2_barplot.nf
@@ -26,6 +26,7 @@ process QIIME2_BARPLOT {
     def metadata_cmd = metadata ? "--m-metadata-file ${metadata}": ""
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime taxa barplot  \\
         --i-table ${table}  \\

--- a/modules/local/qiime2_barplot.nf
+++ b/modules/local/qiime2_barplot.nf
@@ -26,7 +26,7 @@ process QIIME2_BARPLOT {
     def metadata_cmd = metadata ? "--m-metadata-file ${metadata}": ""
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     qiime taxa barplot  \\

--- a/modules/local/qiime2_classify.nf
+++ b/modules/local/qiime2_classify.nf
@@ -24,6 +24,7 @@ process QIIME2_CLASSIFY {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime feature-classifier classify-sklearn  \\
         --i-classifier ${trained_classifier}  \\

--- a/modules/local/qiime2_classify.nf
+++ b/modules/local/qiime2_classify.nf
@@ -24,7 +24,7 @@ process QIIME2_CLASSIFY {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     qiime feature-classifier classify-sklearn  \\

--- a/modules/local/qiime2_classify.nf
+++ b/modules/local/qiime2_classify.nf
@@ -23,8 +23,9 @@ process QIIME2_CLASSIFY {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     qiime feature-classifier classify-sklearn  \\
         --i-classifier ${trained_classifier}  \\

--- a/modules/local/qiime2_classify.nf
+++ b/modules/local/qiime2_classify.nf
@@ -23,9 +23,9 @@ process QIIME2_CLASSIFY {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     qiime feature-classifier classify-sklearn  \\
         --i-classifier ${trained_classifier}  \\

--- a/modules/local/qiime2_diversity_adonis.nf
+++ b/modules/local/qiime2_diversity_adonis.nf
@@ -22,8 +22,9 @@ process QIIME2_DIVERSITY_ADONIS {
     script:
     def args = task.ext.args ?: ''
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     qiime diversity adonis \\
         --p-n-jobs $task.cpus \\

--- a/modules/local/qiime2_diversity_adonis.nf
+++ b/modules/local/qiime2_diversity_adonis.nf
@@ -22,9 +22,9 @@ process QIIME2_DIVERSITY_ADONIS {
     script:
     def args = task.ext.args ?: ''
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     qiime diversity adonis \\
         --p-n-jobs $task.cpus \\

--- a/modules/local/qiime2_diversity_adonis.nf
+++ b/modules/local/qiime2_diversity_adonis.nf
@@ -23,6 +23,7 @@ process QIIME2_DIVERSITY_ADONIS {
     def args = task.ext.args ?: ''
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime diversity adonis \\
         --p-n-jobs $task.cpus \\

--- a/modules/local/qiime2_diversity_adonis.nf
+++ b/modules/local/qiime2_diversity_adonis.nf
@@ -23,7 +23,7 @@ process QIIME2_DIVERSITY_ADONIS {
     def args = task.ext.args ?: ''
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     qiime diversity adonis \\

--- a/modules/local/qiime2_diversity_alpha.nf
+++ b/modules/local/qiime2_diversity_alpha.nf
@@ -22,7 +22,7 @@ process QIIME2_DIVERSITY_ALPHA {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     qiime diversity alpha-group-significance \\

--- a/modules/local/qiime2_diversity_alpha.nf
+++ b/modules/local/qiime2_diversity_alpha.nf
@@ -22,6 +22,7 @@ process QIIME2_DIVERSITY_ALPHA {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime diversity alpha-group-significance \\
         --i-alpha-diversity ${core} \\

--- a/modules/local/qiime2_diversity_alpha.nf
+++ b/modules/local/qiime2_diversity_alpha.nf
@@ -21,8 +21,9 @@ process QIIME2_DIVERSITY_ALPHA {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     qiime diversity alpha-group-significance \\
         --i-alpha-diversity ${core} \\

--- a/modules/local/qiime2_diversity_alpha.nf
+++ b/modules/local/qiime2_diversity_alpha.nf
@@ -21,9 +21,9 @@ process QIIME2_DIVERSITY_ALPHA {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     qiime diversity alpha-group-significance \\
         --i-alpha-diversity ${core} \\

--- a/modules/local/qiime2_diversity_beta.nf
+++ b/modules/local/qiime2_diversity_beta.nf
@@ -22,7 +22,7 @@ process QIIME2_DIVERSITY_BETA {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     qiime diversity beta-group-significance \\

--- a/modules/local/qiime2_diversity_beta.nf
+++ b/modules/local/qiime2_diversity_beta.nf
@@ -21,9 +21,9 @@ process QIIME2_DIVERSITY_BETA {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     qiime diversity beta-group-significance \\
         --i-distance-matrix ${core} \\

--- a/modules/local/qiime2_diversity_beta.nf
+++ b/modules/local/qiime2_diversity_beta.nf
@@ -21,8 +21,9 @@ process QIIME2_DIVERSITY_BETA {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     qiime diversity beta-group-significance \\
         --i-distance-matrix ${core} \\

--- a/modules/local/qiime2_diversity_beta.nf
+++ b/modules/local/qiime2_diversity_beta.nf
@@ -22,6 +22,7 @@ process QIIME2_DIVERSITY_BETA {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime diversity beta-group-significance \\
         --i-distance-matrix ${core} \\

--- a/modules/local/qiime2_diversity_betaord.nf
+++ b/modules/local/qiime2_diversity_betaord.nf
@@ -22,6 +22,7 @@ process QIIME2_DIVERSITY_BETAORD {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
     mkdir beta_diversity
 
     qiime emperor plot \\

--- a/modules/local/qiime2_diversity_betaord.nf
+++ b/modules/local/qiime2_diversity_betaord.nf
@@ -21,9 +21,9 @@ process QIIME2_DIVERSITY_BETAORD {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
     mkdir beta_diversity
 
     qiime emperor plot \\

--- a/modules/local/qiime2_diversity_betaord.nf
+++ b/modules/local/qiime2_diversity_betaord.nf
@@ -21,8 +21,9 @@ process QIIME2_DIVERSITY_BETAORD {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
     mkdir beta_diversity
 
     qiime emperor plot \\

--- a/modules/local/qiime2_diversity_betaord.nf
+++ b/modules/local/qiime2_diversity_betaord.nf
@@ -22,7 +22,7 @@ process QIIME2_DIVERSITY_BETAORD {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
     mkdir beta_diversity
 

--- a/modules/local/qiime2_diversity_core.nf
+++ b/modules/local/qiime2_diversity_core.nf
@@ -31,9 +31,9 @@ process QIIME2_DIVERSITY_CORE {
     # COMMENT: might be fixed in version after QIIME2 2023.5
     export UNIFRAC_USE_GPU=N
 
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     mindepth=\$(count_table_minmax_reads.py $stats minimum 2>&1)
     if [ \"\$mindepth\" -lt \"$mindepth\" ]; then mindepth=$mindepth; fi

--- a/modules/local/qiime2_diversity_core.nf
+++ b/modules/local/qiime2_diversity_core.nf
@@ -32,6 +32,7 @@ process QIIME2_DIVERSITY_CORE {
     export UNIFRAC_USE_GPU=N
 
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     mindepth=\$(count_table_minmax_reads.py $stats minimum 2>&1)
     if [ \"\$mindepth\" -lt \"$mindepth\" ]; then mindepth=$mindepth; fi

--- a/modules/local/qiime2_diversity_core.nf
+++ b/modules/local/qiime2_diversity_core.nf
@@ -32,7 +32,7 @@ process QIIME2_DIVERSITY_CORE {
     export UNIFRAC_USE_GPU=N
 
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     mindepth=\$(count_table_minmax_reads.py $stats minimum 2>&1)

--- a/modules/local/qiime2_diversity_core.nf
+++ b/modules/local/qiime2_diversity_core.nf
@@ -31,8 +31,9 @@ process QIIME2_DIVERSITY_CORE {
     # COMMENT: might be fixed in version after QIIME2 2023.5
     export UNIFRAC_USE_GPU=N
 
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     mindepth=\$(count_table_minmax_reads.py $stats minimum 2>&1)
     if [ \"\$mindepth\" -lt \"$mindepth\" ]; then mindepth=$mindepth; fi

--- a/modules/local/qiime2_export_absolute.nf
+++ b/modules/local/qiime2_export_absolute.nf
@@ -30,6 +30,7 @@ process QIIME2_EXPORT_ABSOLUTE {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     #produce raw count table in biom format "table/feature-table.biom"
     qiime tools export \\

--- a/modules/local/qiime2_export_absolute.nf
+++ b/modules/local/qiime2_export_absolute.nf
@@ -30,7 +30,7 @@ process QIIME2_EXPORT_ABSOLUTE {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     #produce raw count table in biom format "table/feature-table.biom"

--- a/modules/local/qiime2_export_absolute.nf
+++ b/modules/local/qiime2_export_absolute.nf
@@ -29,9 +29,9 @@ process QIIME2_EXPORT_ABSOLUTE {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     #produce raw count table in biom format "table/feature-table.biom"
     qiime tools export \\

--- a/modules/local/qiime2_export_absolute.nf
+++ b/modules/local/qiime2_export_absolute.nf
@@ -29,8 +29,9 @@ process QIIME2_EXPORT_ABSOLUTE {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     #produce raw count table in biom format "table/feature-table.biom"
     qiime tools export \\

--- a/modules/local/qiime2_export_relasv.nf
+++ b/modules/local/qiime2_export_relasv.nf
@@ -21,6 +21,7 @@ process QIIME2_EXPORT_RELASV {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     #convert to relative abundances
     qiime feature-table relative-frequency \\

--- a/modules/local/qiime2_export_relasv.nf
+++ b/modules/local/qiime2_export_relasv.nf
@@ -20,9 +20,9 @@ process QIIME2_EXPORT_RELASV {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     #convert to relative abundances
     qiime feature-table relative-frequency \\

--- a/modules/local/qiime2_export_relasv.nf
+++ b/modules/local/qiime2_export_relasv.nf
@@ -20,8 +20,9 @@ process QIIME2_EXPORT_RELASV {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     #convert to relative abundances
     qiime feature-table relative-frequency \\

--- a/modules/local/qiime2_export_relasv.nf
+++ b/modules/local/qiime2_export_relasv.nf
@@ -21,7 +21,7 @@ process QIIME2_EXPORT_RELASV {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     #convert to relative abundances

--- a/modules/local/qiime2_export_reltax.nf
+++ b/modules/local/qiime2_export_reltax.nf
@@ -23,8 +23,9 @@ process QIIME2_EXPORT_RELTAX {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     ##on several taxa level
     array=(\$(seq ${tax_agglom_min} 1 ${tax_agglom_max}))

--- a/modules/local/qiime2_export_reltax.nf
+++ b/modules/local/qiime2_export_reltax.nf
@@ -24,6 +24,7 @@ process QIIME2_EXPORT_RELTAX {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     ##on several taxa level
     array=(\$(seq ${tax_agglom_min} 1 ${tax_agglom_max}))

--- a/modules/local/qiime2_export_reltax.nf
+++ b/modules/local/qiime2_export_reltax.nf
@@ -24,7 +24,7 @@ process QIIME2_EXPORT_RELTAX {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     ##on several taxa level

--- a/modules/local/qiime2_export_reltax.nf
+++ b/modules/local/qiime2_export_reltax.nf
@@ -23,9 +23,9 @@ process QIIME2_EXPORT_RELTAX {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     ##on several taxa level
     array=(\$(seq ${tax_agglom_min} 1 ${tax_agglom_max}))

--- a/modules/local/qiime2_extract.nf
+++ b/modules/local/qiime2_extract.nf
@@ -23,7 +23,7 @@ process QIIME2_EXTRACT {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     ### Import

--- a/modules/local/qiime2_extract.nf
+++ b/modules/local/qiime2_extract.nf
@@ -23,6 +23,7 @@ process QIIME2_EXTRACT {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     ### Import
     qiime tools import \\

--- a/modules/local/qiime2_extract.nf
+++ b/modules/local/qiime2_extract.nf
@@ -22,8 +22,9 @@ process QIIME2_EXTRACT {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     ### Import
     qiime tools import \\

--- a/modules/local/qiime2_extract.nf
+++ b/modules/local/qiime2_extract.nf
@@ -22,9 +22,9 @@ process QIIME2_EXTRACT {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     ### Import
     qiime tools import \\

--- a/modules/local/qiime2_featuretable_group.nf
+++ b/modules/local/qiime2_featuretable_group.nf
@@ -21,9 +21,9 @@ process QIIME2_FEATURETABLE_GROUP {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     qiime feature-table filter-samples \\
         --i-table "${table}" \\

--- a/modules/local/qiime2_featuretable_group.nf
+++ b/modules/local/qiime2_featuretable_group.nf
@@ -22,7 +22,7 @@ process QIIME2_FEATURETABLE_GROUP {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     qiime feature-table filter-samples \\

--- a/modules/local/qiime2_featuretable_group.nf
+++ b/modules/local/qiime2_featuretable_group.nf
@@ -21,8 +21,9 @@ process QIIME2_FEATURETABLE_GROUP {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     qiime feature-table filter-samples \\
         --i-table "${table}" \\

--- a/modules/local/qiime2_featuretable_group.nf
+++ b/modules/local/qiime2_featuretable_group.nf
@@ -22,6 +22,7 @@ process QIIME2_FEATURETABLE_GROUP {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime feature-table filter-samples \\
         --i-table "${table}" \\

--- a/modules/local/qiime2_filtersamples.nf
+++ b/modules/local/qiime2_filtersamples.nf
@@ -24,6 +24,7 @@ process QIIME2_FILTERSAMPLES {
     def prefix = task.ext.prefix ?: "${filter}"
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime feature-table filter-samples \\
         --i-table ${table} \\

--- a/modules/local/qiime2_filtersamples.nf
+++ b/modules/local/qiime2_filtersamples.nf
@@ -23,9 +23,9 @@ process QIIME2_FILTERSAMPLES {
     def args = task.ext.args ?: "--p-where \'${filter}<>\"\"\'"
     def prefix = task.ext.prefix ?: "${filter}"
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     qiime feature-table filter-samples \\
         --i-table ${table} \\

--- a/modules/local/qiime2_filtersamples.nf
+++ b/modules/local/qiime2_filtersamples.nf
@@ -24,7 +24,7 @@ process QIIME2_FILTERSAMPLES {
     def prefix = task.ext.prefix ?: "${filter}"
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     qiime feature-table filter-samples \\

--- a/modules/local/qiime2_filtersamples.nf
+++ b/modules/local/qiime2_filtersamples.nf
@@ -23,8 +23,9 @@ process QIIME2_FILTERSAMPLES {
     def args = task.ext.args ?: "--p-where \'${filter}<>\"\"\'"
     def prefix = task.ext.prefix ?: "${filter}"
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     qiime feature-table filter-samples \\
         --i-table ${table} \\

--- a/modules/local/qiime2_filtertaxa.nf
+++ b/modules/local/qiime2_filtertaxa.nf
@@ -28,8 +28,9 @@ process QIIME2_FILTERTAXA {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     if ! [ \"${exclude_taxa}\" = \"none\" ]; then
         #filter sequences

--- a/modules/local/qiime2_filtertaxa.nf
+++ b/modules/local/qiime2_filtertaxa.nf
@@ -28,9 +28,9 @@ process QIIME2_FILTERTAXA {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     if ! [ \"${exclude_taxa}\" = \"none\" ]; then
         #filter sequences

--- a/modules/local/qiime2_filtertaxa.nf
+++ b/modules/local/qiime2_filtertaxa.nf
@@ -29,6 +29,7 @@ process QIIME2_FILTERTAXA {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     if ! [ \"${exclude_taxa}\" = \"none\" ]; then
         #filter sequences

--- a/modules/local/qiime2_filtertaxa.nf
+++ b/modules/local/qiime2_filtertaxa.nf
@@ -29,7 +29,7 @@ process QIIME2_FILTERTAXA {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     if ! [ \"${exclude_taxa}\" = \"none\" ]; then

--- a/modules/local/qiime2_inasv.nf
+++ b/modules/local/qiime2_inasv.nf
@@ -21,7 +21,8 @@ process QIIME2_INASV {
 
     script:
     """
-    export MPLCONFIGDIR="\${PWD}/HOME"
+    export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     # remove first line if needed
     sed '/^# Constructed from biom file/d' "$asv" > biom-table.txt

--- a/modules/local/qiime2_inasv.nf
+++ b/modules/local/qiime2_inasv.nf
@@ -21,6 +21,8 @@ process QIIME2_INASV {
 
     script:
     """
+    export MPLCONFIGDIR="\${PWD}/HOME"
+
     # remove first line if needed
     sed '/^# Constructed from biom file/d' "$asv" > biom-table.txt
 

--- a/modules/local/qiime2_inasv.nf
+++ b/modules/local/qiime2_inasv.nf
@@ -21,8 +21,8 @@ process QIIME2_INASV {
 
     script:
     """
-    export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     # remove first line if needed
     sed '/^# Constructed from biom file/d' "$asv" > biom-table.txt

--- a/modules/local/qiime2_inseq.nf
+++ b/modules/local/qiime2_inseq.nf
@@ -21,7 +21,8 @@ process QIIME2_INSEQ {
 
     script:
     """
-    export MPLCONFIGDIR="\${PWD}/HOME"
+    export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     qiime tools import \\
         --input-path "$seq" \\

--- a/modules/local/qiime2_inseq.nf
+++ b/modules/local/qiime2_inseq.nf
@@ -21,8 +21,8 @@ process QIIME2_INSEQ {
 
     script:
     """
-    export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     qiime tools import \\
         --input-path "$seq" \\

--- a/modules/local/qiime2_inseq.nf
+++ b/modules/local/qiime2_inseq.nf
@@ -21,6 +21,8 @@ process QIIME2_INSEQ {
 
     script:
     """
+    export MPLCONFIGDIR="\${PWD}/HOME"
+
     qiime tools import \\
         --input-path "$seq" \\
         --type 'FeatureData[Sequence]' \\

--- a/modules/local/qiime2_intax.nf
+++ b/modules/local/qiime2_intax.nf
@@ -23,8 +23,8 @@ process QIIME2_INTAX {
     script:
     def script_cmd = script ? "$script $tax" : "cp $tax tax.tsv"
     """
-    export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     $script_cmd
 

--- a/modules/local/qiime2_intax.nf
+++ b/modules/local/qiime2_intax.nf
@@ -23,7 +23,8 @@ process QIIME2_INTAX {
     script:
     def script_cmd = script ? "$script $tax" : "cp $tax tax.tsv"
     """
-    export MPLCONFIGDIR="\${PWD}/HOME"
+    export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     $script_cmd
 

--- a/modules/local/qiime2_intax.nf
+++ b/modules/local/qiime2_intax.nf
@@ -23,6 +23,8 @@ process QIIME2_INTAX {
     script:
     def script_cmd = script ? "$script $tax" : "cp $tax tax.tsv"
     """
+    export MPLCONFIGDIR="\${PWD}/HOME"
+
     $script_cmd
 
     qiime tools import \\

--- a/modules/local/qiime2_intree.nf
+++ b/modules/local/qiime2_intree.nf
@@ -21,7 +21,8 @@ process QIIME2_INTREE {
 
     script:
     """
-    export MPLCONFIGDIR="\${PWD}/HOME"
+    export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     qiime tools import \\
         --type 'Phylogeny[Rooted]' \\

--- a/modules/local/qiime2_intree.nf
+++ b/modules/local/qiime2_intree.nf
@@ -21,6 +21,8 @@ process QIIME2_INTREE {
 
     script:
     """
+    export MPLCONFIGDIR="\${PWD}/HOME"
+
     qiime tools import \\
         --type 'Phylogeny[Rooted]' \\
         --input-path $tree \\

--- a/modules/local/qiime2_intree.nf
+++ b/modules/local/qiime2_intree.nf
@@ -21,8 +21,8 @@ process QIIME2_INTREE {
 
     script:
     """
-    export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     qiime tools import \\
         --type 'Phylogeny[Rooted]' \\

--- a/modules/local/qiime2_train.nf
+++ b/modules/local/qiime2_train.nf
@@ -22,9 +22,9 @@ process QIIME2_TRAIN {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     #Train classifier
     qiime feature-classifier fit-classifier-naive-bayes \\

--- a/modules/local/qiime2_train.nf
+++ b/modules/local/qiime2_train.nf
@@ -23,7 +23,7 @@ process QIIME2_TRAIN {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     #Train classifier

--- a/modules/local/qiime2_train.nf
+++ b/modules/local/qiime2_train.nf
@@ -22,8 +22,9 @@ process QIIME2_TRAIN {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     #Train classifier
     qiime feature-classifier fit-classifier-naive-bayes \\

--- a/modules/local/qiime2_train.nf
+++ b/modules/local/qiime2_train.nf
@@ -23,6 +23,7 @@ process QIIME2_TRAIN {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     #Train classifier
     qiime feature-classifier fit-classifier-naive-bayes \\

--- a/modules/local/qiime2_tree.nf
+++ b/modules/local/qiime2_tree.nf
@@ -22,7 +22,7 @@ process QIIME2_TREE {
     script:
     """
     export XDG_CONFIG_HOME="./xdgconfig"
-	export MPLCONFIGDIR="./mplconfigdir"
+    export MPLCONFIGDIR="./mplconfigdir"
     export NUMBA_CACHE_DIR="./numbacache"
 
     qiime alignment mafft \\

--- a/modules/local/qiime2_tree.nf
+++ b/modules/local/qiime2_tree.nf
@@ -21,8 +21,9 @@ process QIIME2_TREE {
 
     script:
     """
-    export XDG_CONFIG_HOME="\${PWD}/HOME"
-	export MPLCONFIGDIR="\${PWD}/HOME"
+    export XDG_CONFIG_HOME="/tmp/xdgconfig"
+	export MPLCONFIGDIR="/tmp/mplconfigdir"
+    export NUMBA_CACHE_DIR="/tmp/numbacache"
 
     qiime alignment mafft \\
         --i-sequences ${repseq} \\

--- a/modules/local/qiime2_tree.nf
+++ b/modules/local/qiime2_tree.nf
@@ -21,9 +21,9 @@ process QIIME2_TREE {
 
     script:
     """
-    export XDG_CONFIG_HOME="/tmp/xdgconfig"
-	export MPLCONFIGDIR="/tmp/mplconfigdir"
-    export NUMBA_CACHE_DIR="/tmp/numbacache"
+    export XDG_CONFIG_HOME="./xdgconfig"
+	export MPLCONFIGDIR="./mplconfigdir"
+    export NUMBA_CACHE_DIR="./numbacache"
 
     qiime alignment mafft \\
         --i-sequences ${repseq} \\

--- a/modules/local/qiime2_tree.nf
+++ b/modules/local/qiime2_tree.nf
@@ -22,6 +22,7 @@ process QIIME2_TREE {
     script:
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
+	export MPLCONFIGDIR="\${PWD}/HOME"
 
     qiime alignment mafft \\
         --i-sequences ${repseq} \\

--- a/subworkflows/local/dada2_taxonomy_wf.nf
+++ b/subworkflows/local/dada2_taxonomy_wf.nf
@@ -83,7 +83,7 @@ workflow DADA2_TAXONOMY_WF {
         //set file name prefix for SH assignments
         if (!params.skip_dada_addspecies) {
             ASV_SH_name = "ASV_tax_species_SH"
-	} else {
+    } else {
             ASV_SH_name = "ASV_tax_SH"
         }
         //find SHs


### PR DESCRIPTION
This fixes the issue with nextflow version 23.10.0 on some systems, see https://github.com/nf-core/ampliseq/issues/654

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
