### PR TITLE
Move conda check to script section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#656](https://github.com/nf-core/ampliseq/pull/656) - Moved conda-check to script-section and replaced `exit 1` with `error()`
+
 ### `Dependencies`
 
 ### `Removed`

--- a/modules/local/qiime2_alphararefaction.nf
+++ b/modules/local/qiime2_alphararefaction.nf
@@ -3,11 +3,6 @@ process QIIME2_ALPHARAREFACTION {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(metadata)
     path(table)
@@ -22,6 +17,10 @@ process QIIME2_ALPHARAREFACTION {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_ancom_asv.nf
+++ b/modules/local/qiime2_ancom_asv.nf
@@ -7,11 +7,6 @@ process QIIME2_ANCOM_ASV {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple path(metadata), path(table)
 
@@ -23,6 +18,10 @@ process QIIME2_ANCOM_ASV {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_ancom_tax.nf
+++ b/modules/local/qiime2_ancom_tax.nf
@@ -5,11 +5,6 @@ process QIIME2_ANCOM_TAX {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple path(metadata), path(table), path(taxonomy) ,val(taxlevel)
 
@@ -21,6 +16,10 @@ process QIIME2_ANCOM_TAX {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
     mkdir ancom

--- a/modules/local/qiime2_barplot.nf
+++ b/modules/local/qiime2_barplot.nf
@@ -3,11 +3,6 @@ process QIIME2_BARPLOT {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(metadata)
     path(table)
@@ -22,6 +17,10 @@ process QIIME2_BARPLOT {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     suffix = setting ? "_${table.baseName}" : ""
     def metadata_cmd = metadata ? "--m-metadata-file ${metadata}": ""
     """

--- a/modules/local/qiime2_classify.nf
+++ b/modules/local/qiime2_classify.nf
@@ -4,11 +4,6 @@ process QIIME2_CLASSIFY {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(trained_classifier)
     path(repseq)
@@ -22,6 +17,10 @@ process QIIME2_CLASSIFY {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_diversity_adonis.nf
+++ b/modules/local/qiime2_diversity_adonis.nf
@@ -4,11 +4,6 @@ process QIIME2_DIVERSITY_ADONIS {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple path(metadata), path(core), val(formula)
 
@@ -20,6 +15,10 @@ process QIIME2_DIVERSITY_ADONIS {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def args = task.ext.args ?: ''
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"

--- a/modules/local/qiime2_diversity_alpha.nf
+++ b/modules/local/qiime2_diversity_alpha.nf
@@ -4,11 +4,6 @@ process QIIME2_DIVERSITY_ALPHA {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple path(metadata), path(core)
 
@@ -20,6 +15,10 @@ process QIIME2_DIVERSITY_ALPHA {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_diversity_beta.nf
+++ b/modules/local/qiime2_diversity_beta.nf
@@ -4,11 +4,6 @@ process QIIME2_DIVERSITY_BETA {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple path(metadata), path(core), val(category)
 
@@ -20,6 +15,10 @@ process QIIME2_DIVERSITY_BETA {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_diversity_betaord.nf
+++ b/modules/local/qiime2_diversity_betaord.nf
@@ -4,11 +4,6 @@ process QIIME2_DIVERSITY_BETAORD {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple path(metadata), path(core)
 
@@ -20,6 +15,10 @@ process QIIME2_DIVERSITY_BETAORD {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
     mkdir beta_diversity

--- a/modules/local/qiime2_diversity_core.nf
+++ b/modules/local/qiime2_diversity_core.nf
@@ -3,11 +3,6 @@ process QIIME2_DIVERSITY_CORE {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(metadata)
     path(table)
@@ -26,6 +21,10 @@ process QIIME2_DIVERSITY_CORE {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     # FIX: detecting a viable GPU on your system, but the GPU is unavailable for compute, causing UniFrac to fail.
     # COMMENT: might be fixed in version after QIIME2 2023.5

--- a/modules/local/qiime2_export_absolute.nf
+++ b/modules/local/qiime2_export_absolute.nf
@@ -3,11 +3,6 @@ process QIIME2_EXPORT_ABSOLUTE {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(table)
     path(repseq)
@@ -28,6 +23,10 @@ process QIIME2_EXPORT_ABSOLUTE {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_export_relasv.nf
+++ b/modules/local/qiime2_export_relasv.nf
@@ -3,11 +3,6 @@ process QIIME2_EXPORT_RELASV {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(table)
 
@@ -19,6 +14,10 @@ process QIIME2_EXPORT_RELASV {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_export_reltax.nf
+++ b/modules/local/qiime2_export_reltax.nf
@@ -3,11 +3,6 @@ process QIIME2_EXPORT_RELTAX {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(table)
     path(taxonomy)
@@ -22,6 +17,10 @@ process QIIME2_EXPORT_RELTAX {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_extract.nf
+++ b/modules/local/qiime2_extract.nf
@@ -5,11 +5,6 @@ process QIIME2_EXTRACT {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple val(meta), path(database)
 
@@ -21,6 +16,10 @@ process QIIME2_EXTRACT {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_featuretable_group.nf
+++ b/modules/local/qiime2_featuretable_group.nf
@@ -4,11 +4,6 @@ process QIIME2_FEATURETABLE_GROUP {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple path(table), path(metadata), val(category)
 
@@ -20,6 +15,10 @@ process QIIME2_FEATURETABLE_GROUP {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_filtersamples.nf
+++ b/modules/local/qiime2_filtersamples.nf
@@ -4,11 +4,6 @@ process QIIME2_FILTERSAMPLES {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple path(metadata), path(table), val(filter)
 
@@ -20,6 +15,10 @@ process QIIME2_FILTERSAMPLES {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def args = task.ext.args ?: "--p-where \'${filter}<>\"\"\'"
     def prefix = task.ext.prefix ?: "${filter}"
     """

--- a/modules/local/qiime2_filtertaxa.nf
+++ b/modules/local/qiime2_filtertaxa.nf
@@ -4,11 +4,6 @@ process QIIME2_FILTERTAXA {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(table)
     path(repseq)
@@ -27,6 +22,10 @@ process QIIME2_FILTERTAXA {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_inasv.nf
+++ b/modules/local/qiime2_inasv.nf
@@ -4,11 +4,6 @@ process QIIME2_INASV {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(asv)
 
@@ -20,6 +15,10 @@ process QIIME2_INASV {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     # remove first line if needed
     sed '/^# Constructed from biom file/d' "$asv" > biom-table.txt

--- a/modules/local/qiime2_inseq.nf
+++ b/modules/local/qiime2_inseq.nf
@@ -4,11 +4,6 @@ process QIIME2_INSEQ {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(seq)
 
@@ -20,6 +15,10 @@ process QIIME2_INSEQ {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     qiime tools import \\
         --input-path "$seq" \\

--- a/modules/local/qiime2_intax.nf
+++ b/modules/local/qiime2_intax.nf
@@ -4,11 +4,6 @@ process QIIME2_INTAX {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(tax) //ASV_tax_species.tsv
     val(script)
@@ -21,6 +16,10 @@ process QIIME2_INTAX {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def script_cmd = script ? "$script $tax" : "cp $tax tax.tsv"
     """
     $script_cmd

--- a/modules/local/qiime2_intree.nf
+++ b/modules/local/qiime2_intree.nf
@@ -4,11 +4,6 @@ process QIIME2_INTREE {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple val(meta), path(tree)
 
@@ -20,6 +15,10 @@ process QIIME2_INTREE {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     qiime tools import \\
         --type 'Phylogeny[Rooted]' \\

--- a/modules/local/qiime2_train.nf
+++ b/modules/local/qiime2_train.nf
@@ -5,11 +5,6 @@ process QIIME2_TRAIN {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple val(meta), path(qza)
 
@@ -21,6 +16,10 @@ process QIIME2_TRAIN {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 

--- a/modules/local/qiime2_tree.nf
+++ b/modules/local/qiime2_tree.nf
@@ -3,11 +3,6 @@ process QIIME2_TREE {
 
     container "qiime2/core:2023.7"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path(repseq)
 
@@ -20,6 +15,10 @@ process QIIME2_TREE {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "QIIME2 does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     export XDG_CONFIG_HOME="\${PWD}/HOME"
 


### PR DESCRIPTION
Moved the conda check to script section to avoid any problems when running with conda, see https://github.com/nf-core/modules/issues/3683

- Moved conda-check to script-section
- replaced `exit 1` with `error()`


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
