### PR TITLE
Update Output Docs for Collapsed Abundance Tables

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -407,7 +407,7 @@ All following analysis is based on these filtered tables.
   - `seven_number_summary.tsv`: Length of ASV sequences in different quantiles.
   - `filtered-sequences.qza`: QIIME2 fragment.
 - `qiime2/abundance_tables/`
-  - `abs-abund-table-*.tsv`: Tab-separated absolute abundance table at taxa level `*`, where `*` ranges by default from 2 to 6 or 7, depending on the used reference taxonomy database.
+  - `abs-abund-table-*.tsv`: Tab-separated absolute abundance table at taxa level `*`, where `*` ranges by default from 2 to 6, specified by the `--tax_agglom_min` and `--tax_agglom_max` parameters.
   - `count_table_filter_stats.tsv`: Tab-separated table with information on how much counts were filtered for each sample.
   - `feature-table.biom`: Abundance table in biom format for importing into downstream analysis tools.
   - `feature-table.tsv`: Tab-separated abundance table for each ASV and each sample.
@@ -423,7 +423,7 @@ Absolute abundance tables produced by the previous steps contain count data, but
 <summary>Output files</summary>
 
 - `qiime2/rel_abundance_tables/`
-  - `rel-table-*.tsv`: Tab-separated absolute abundance table at taxa level `*`, where `*` ranges by default from 2 to 6 or 7, depending on the used reference taxonomy database.
+  - `rel-table-*.tsv`: Tab-separated absolute abundance table at taxa level `*`, where `*` ranges by default from 2 to 6, specified by the `--tax_agglom_min` and `--tax_agglom_max` parameters.
   - `rel-table-ASV.tsv`: Tab-separated relative abundance table for all ASVs.
   - `rel-table-ASV_with-DADA2-tax.tsv`: Tab-separated table for all ASVs with DADA2 taxonomic classification, sequence and relative abundance.
   - `rel-table-ASV_with-QIIME2-tax.tsv`: Tab-separated table for all ASVs with QIIME2 taxonomic classification, sequence and relative abundance.


### PR DESCRIPTION
Hi,

This PR is a minor output documentation update.

Recently I was confused why the qiime output relative abundance tsvs only went to level 6, not level 7 when the reference database we are using includes level 7. In the parameter schema, it shows that the level is controlled by `--tax_agglom_max` which defaults to 6, so hopefully the output docs better reflect the situation with this change.

I agree that level 6 is a sensible default, I am not proposing to change that, just the output docs! :)

To verify the changed documentation, I believe this is the code that collapses the taxa for [absolute abundance counts](https://github.com/nf-core/ampliseq/blob/113e90bdff42a52807f5c8b3cbaafaa31c145b9d/modules/local/qiime2_export_absolute.nf#L57-L75), and [relative abundance counts](https://github.com/nf-core/ampliseq/blob/113e90bdff42a52807f5c8b3cbaafaa31c145b9d/modules/local/qiime2_export_reltax.nf#L30-L52).