### PR TITLE
Improved pipeline summary report & error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#672](https://github.com/nf-core/ampliseq/pull/672) - Update output docs for collapsed abundance tables
 - [#673](https://github.com/nf-core/ampliseq/pull/673) - Fix logic relating to generation of qiime2 taxonomy part of summary report
 - [#676](https://github.com/nf-core/ampliseq/pull/676) - Phyloseq sometimes only produced one of multiple output files
+- [#680](https://github.com/nf-core/ampliseq/pull/680) - Improved pipeline summary report & error messages
 
 ### `Dependencies`
 

--- a/assets/report_template.Rmd
+++ b/assets/report_template.Rmd
@@ -181,17 +181,13 @@ supporting denoising of any amplicon and supports a variety of taxonomic databas
 
 ```{r, results='asis'}
 if ( !isFALSE(params$metadata) ) {
-    cat(paste0("
-# Data input and Metadata
-
-Pipeline input was saved to the [input](../input) directory.
-    "))
+    cat("# Data input and Metadata\n\n")
 } else {
-    cat(paste0("
-# Data input
+    cat("# Data input\n\n")
+}
 
-Pipeline input was saved in folder [input](../input).
-    "))
+if ( !isFALSE(params$metadata) || !isFALSE(params$input_samplesheet) ) {
+    cat("Pipeline input was saved in folder [input](../input).\n\n")
 }
 
 if ( !isFALSE(params$input_samplesheet) ) {

--- a/assets/report_template.Rmd
+++ b/assets/report_template.Rmd
@@ -258,8 +258,7 @@ the denoising tool or sequences might be lost due to being labelled as PCR chime
 # import tsv
 cutadapt_summary <- read.table(file = params$cutadapt_summary, header = TRUE, sep = "\t")
 
-cutadapt_passed_col <- as.numeric(substr(
-        cutadapt_summary$cutadapt_passing_filters_percent, 1, 4))
+cutadapt_passed_col <- as.numeric( gsub("%","",cutadapt_summary$cutadapt_passing_filters_percent) )
 
 cutadapt_max_discarded <- round( 100 - min(cutadapt_passed_col), 1 )
 cutadapt_avg_passed <- round(mean(cutadapt_passed_col),1)

--- a/subworkflows/local/parse_input.nf
+++ b/subworkflows/local/parse_input.nf
@@ -11,7 +11,7 @@ workflow PARSE_INPUT {
     //Check folders in folder when multiple_sequencing_runs
     folders = multiple_sequencing_runs ? "/*" : ""
     error_message = "\nCannot find any reads matching: \"${input}${folders}${extension}\"\n"
-    error_message += "Please revise the input folder (\"--input\"): \"${input}\"\n"
+    error_message += "Please revise the input folder (\"--input_folder\"): \"${input}\"\n"
     error_message += "and the input file pattern (\"--extension\"): \"${extension}\"\n"
     error_message += "*Please note: Path needs to be enclosed in quotes!*\n"
     error_message += multiple_sequencing_runs ? "If you do not have multiple sequencing runs, please do not use \"--multiple_sequencing_runs\"!\n" : "If you have multiple sequencing runs, please add \"--multiple_sequencing_runs\"!\n"


### PR DESCRIPTION
Minor improvements to error messages and pipeline report:
- one error message referred to `--input` when it should be `--input_folder`
- report folder `<outdir>/input` only when its actually created (when there is a metadata sheet and/or sample sheet)
- reporting % discarded reads by cutadapt trimming were not reported (`NA`) when the percentages were less than `10.0%`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
