### PR TITLE
Export all process software versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#719](https://github.com/nf-core/ampliseq/pull/719) - Versions of all (instead of selected) processes are now exported to `pipeline_info/software_versions.yml`
+
 ### `Fixed`
 
 - [#697](https://github.com/nf-core/ampliseq/pull/697),[#699](https://github.com/nf-core/ampliseq/pull/699),[#713](https://github.com/nf-core/ampliseq/pull/713) - Template update for nf-core/tools version 2.13.1

--- a/modules/local/barrnapsummary.nf
+++ b/modules/local/barrnapsummary.nf
@@ -11,7 +11,8 @@ process BARRNAPSUMMARY {
 
     output:
     path "summary.tsv" , emit: summary
-    path "*warning.txt" , emit: warning
+    path "*warning.txt", emit: warning
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/format_taxonomy.nf
+++ b/modules/local/format_taxonomy.nf
@@ -31,7 +31,6 @@ process FORMAT_TAXONOMY {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        bash: \$(bash --version | sed -n 1p | sed 's/GNU bash, version //g')
-    END_VERSIONS
+        bash: \$(bash --version | sed -n 1p | grep -Eo 'version [[:alnum:].]+' | sed 's/version //')
     """
 }

--- a/modules/local/format_taxonomy_qiime.nf
+++ b/modules/local/format_taxonomy_qiime.nf
@@ -31,7 +31,6 @@ process FORMAT_TAXONOMY_QIIME {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        bash: \$(bash --version | sed -n 1p | sed 's/GNU bash, version //g')
-    END_VERSIONS
+        bash: \$(bash --version | sed -n 1p | grep -Eo 'version [[:alnum:].]+' | sed 's/version //')
     """
 }

--- a/modules/local/format_taxonomy_sidle.nf
+++ b/modules/local/format_taxonomy_sidle.nf
@@ -33,7 +33,6 @@ process FORMAT_TAXONOMY_SIDLE {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        bash: \$(bash --version | sed -n 1p | sed 's/GNU bash, version //g')
-    END_VERSIONS
+        bash: \$(bash --version | sed -n 1p | grep -Eo 'version [[:alnum:].]+' | sed 's/version //')
     """
 }

--- a/modules/local/format_taxonomy_sintax.nf
+++ b/modules/local/format_taxonomy_sintax.nf
@@ -29,7 +29,6 @@ process FORMAT_TAXONOMY_SINTAX {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        bash: \$(bash --version | sed -n 1p | sed 's/GNU bash, version //g')
-    END_VERSIONS
+        bash: \$(bash --version | sed -n 1p | grep -Eo 'version [[:alnum:].]+' | sed 's/version //')
     """
 }

--- a/modules/local/phyloseq_inasv.nf
+++ b/modules/local/phyloseq_inasv.nf
@@ -22,7 +22,6 @@ process PHYLOSEQ_INASV {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        bash: \$(bash --version | sed -n 1p | sed 's/GNU bash, version //g')
-    END_VERSIONS
+        bash: \$(bash --version | sed -n 1p | grep -Eo 'version [[:alnum:].]+' | sed 's/version //')
     """
 }

--- a/subworkflows/local/dada2_preprocessing.nf
+++ b/subworkflows/local/dada2_preprocessing.nf
@@ -132,6 +132,7 @@ workflow DADA2_PREPROCESSING {
     ch_DADA2_QUALITY2_SVG = Channel.empty()
     if ( !params.skip_dada_quality ) {
         DADA2_QUALITY2 ( ch_all_preprocessed_reads.dump(tag: 'into_dada2_quality2') )
+        ch_versions_dada2_preprocessing = ch_versions_dada2_preprocessing.mix(DADA2_QUALITY2.out.versions)
         DADA2_QUALITY2.out.warning.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn it.baseName.toString().replace("WARNING ","DADA2_QUALITY2: ") }
         ch_DADA2_QUALITY2_SVG = DADA2_QUALITY2.out.svg
     }

--- a/subworkflows/local/dada2_taxonomy_wf.nf
+++ b/subworkflows/local/dada2_taxonomy_wf.nf
@@ -46,6 +46,7 @@ workflow DADA2_TAXONOMY_WF {
         CUTADAPT_TAXONOMY ( ch_assigntax ).reads
             .map { meta, db -> db }
             .set { ch_assigntax }
+        ch_versions_dada_taxonomy = ch_versions_dada_taxonomy.mix( CUTADAPT_TAXONOMY.out.versions )
     }
 
     //set file name prefix

--- a/subworkflows/local/kraken2_taxonomy_wf.nf
+++ b/subworkflows/local/kraken2_taxonomy_wf.nf
@@ -32,6 +32,7 @@ workflow KRAKEN2_TAXONOMY_WF {
                     def meta = [:]
                     meta.id = val_kraken2_ref_taxonomy
                     [ meta, db ] } )
+    ch_versions_kraken2_taxonomy = ch_versions_kraken2_taxonomy.mix(UNTAR.out.versions)
     ch_kraken2db = UNTAR.out.untar.map{ it[1] }
     ch_kraken2db = ch_kraken2db.mix(ch_kraken2_ref_taxonomy.dir)
 

--- a/subworkflows/local/phyloseq_workflow.nf
+++ b/subworkflows/local/phyloseq_workflow.nf
@@ -39,6 +39,6 @@ workflow PHYLOSEQ_WORKFLOW {
     PHYLOSEQ ( ch_tax.combine(ch_phyloseq_inasv), ch_phyloseq_inmeta, ch_phyloseq_intree )
 
     emit:
-    rds     = PHYLOSEQ.out.rds
-    versions= PHYLOSEQ.out.versions
+    rds      = PHYLOSEQ.out.rds
+    versions = PHYLOSEQ.out.versions
 }

--- a/subworkflows/local/qiime2_ancom.nf
+++ b/subworkflows/local/qiime2_ancom.nf
@@ -16,12 +16,15 @@ workflow QIIME2_ANCOM {
     tax_agglom_max
 
     main:
+    ch_versions_qiime2_ancom = Channel.empty()
+
     //Filter ASV table to get rid of samples that have no metadata values
     ch_metadata
         .combine( ch_asv )
         .combine( ch_metacolumn_all )
         .set{ ch_for_filtersamples }
     QIIME2_FILTERSAMPLES_ANCOM ( ch_for_filtersamples )
+    ch_versions_qiime2_ancom = ch_versions_qiime2_ancom.mix(QIIME2_FILTERSAMPLES_ANCOM.out.versions)
 
     //ANCOM on various taxonomic levels
     ch_taxlevel = Channel.of( tax_agglom_min..tax_agglom_max )
@@ -31,10 +34,13 @@ workflow QIIME2_ANCOM {
         .combine( ch_taxlevel )
         .set{ ch_for_ancom_tax }
     QIIME2_ANCOM_TAX ( ch_for_ancom_tax )
+    ch_versions_qiime2_ancom = ch_versions_qiime2_ancom.mix(QIIME2_ANCOM_TAX.out.versions)
     QIIME2_ANCOM_TAX.out.ancom.subscribe { if ( it.baseName[0].toString().startsWith("WARNING") ) log.warn it.baseName[0].toString().replace("WARNING ","QIIME2_ANCOM_TAX: ") }
 
     QIIME2_ANCOM_ASV ( ch_metadata.combine( QIIME2_FILTERSAMPLES_ANCOM.out.qza.flatten() ) )
+    ch_versions_qiime2_ancom = ch_versions_qiime2_ancom.mix(QIIME2_ANCOM_ASV.out.versions)
 
     emit:
-    ancom = QIIME2_ANCOM_ASV.out.ancom.mix(QIIME2_ANCOM_TAX.out.ancom)
+    ancom    = QIIME2_ANCOM_ASV.out.ancom.mix(QIIME2_ANCOM_TAX.out.ancom)
+    versions = ch_versions_qiime2_ancom
 }

--- a/subworkflows/local/qiime2_barplotavg.nf
+++ b/subworkflows/local/qiime2_barplotavg.nf
@@ -14,10 +14,12 @@ workflow QIIME2_BARPLOTAVG {
     metadata_category_barplot
 
     main:
+    ch_versions_qiime2_barplotavg = Channel.empty()
     ch_metadata_category_barplot = Channel.fromList(metadata_category_barplot.tokenize(','))
 
     //Import raltive ASV table
     QIIME2_INASV_BPAVG ( ch_rel_tsv )
+    ch_versions_qiime2_barplotavg = ch_versions_qiime2_barplotavg.mix(QIIME2_INASV_BPAVG.out.versions)
 
     //group by metadata category (ch_metadata_category_barplot)
     QIIME2_FEATURETABLE_GROUP (
@@ -25,8 +27,12 @@ workflow QIIME2_BARPLOTAVG {
         .combine(ch_metadata)
         .combine(ch_metadata_category_barplot)
     )
+    ch_versions_qiime2_barplotavg = ch_versions_qiime2_barplotavg.mix(QIIME2_FEATURETABLE_GROUP.out.versions)
 
     //Barplot
     QIIME2_BPAVG ( [], QIIME2_FEATURETABLE_GROUP.out.qza, ch_tax, 'average' )
+    ch_versions_qiime2_barplotavg = ch_versions_qiime2_barplotavg.mix(QIIME2_BPAVG.out.versions)
 
+    emit:
+    versions = ch_versions_qiime2_barplotavg
 }

--- a/subworkflows/local/qiime2_diversity.nf
+++ b/subworkflows/local/qiime2_diversity.nf
@@ -24,21 +24,26 @@ workflow QIIME2_DIVERSITY {
     diversity_rarefaction_depth
 
     main:
+    ch_versions_qiime2_diversity = Channel.empty()
+
     //Phylogenetic tree for beta & alpha diversities
     if (!ch_tree) {
         QIIME2_TREE ( ch_seq )
+        ch_versions_qiime2_diversity = ch_versions_qiime2_diversity.mix(QIIME2_TREE.out.versions)
         ch_tree = QIIME2_TREE.out.qza
     }
 
     //Alpha-rarefaction
     if (!skip_alpha_rarefaction) {
         QIIME2_ALPHARAREFACTION ( ch_metadata, ch_asv, ch_tree, ch_stats )
+        ch_versions_qiime2_diversity = ch_versions_qiime2_diversity.mix(QIIME2_ALPHARAREFACTION.out.versions)
     }
 
     //Calculate diversity indices
     if (!skip_diversity_indices) {
 
         QIIME2_DIVERSITY_CORE ( ch_metadata, ch_asv, ch_tree, ch_stats, diversity_rarefaction_depth )
+        ch_versions_qiime2_diversity = ch_versions_qiime2_diversity.mix(QIIME2_DIVERSITY_CORE.out.versions)
         //Print warning if rarefaction depth is <10000
         QIIME2_DIVERSITY_CORE.out.depth.subscribe { if ( it.baseName.toString().startsWith("WARNING") ) log.warn it.baseName.toString().replace("WARNING ","QIIME2_DIVERSITY_CORE: ") }
 
@@ -47,6 +52,7 @@ workflow QIIME2_DIVERSITY {
             .combine( QIIME2_DIVERSITY_CORE.out.vector.flatten() )
             .set{ ch_to_diversity_alpha }
         QIIME2_DIVERSITY_ALPHA ( ch_to_diversity_alpha )
+        ch_versions_qiime2_diversity = ch_versions_qiime2_diversity.mix(QIIME2_DIVERSITY_ALPHA.out.versions)
 
         //beta_diversity ( ch_metadata, DIVERSITY_CORE.out.qza, ch_metacolumn_pairwise )
         ch_metadata
@@ -54,6 +60,7 @@ workflow QIIME2_DIVERSITY {
             .combine( ch_metacolumn_pairwise )
             .set{ ch_to_diversity_beta }
         QIIME2_DIVERSITY_BETA ( ch_to_diversity_beta )
+        ch_versions_qiime2_diversity = ch_versions_qiime2_diversity.mix(QIIME2_DIVERSITY_BETA.out.versions)
 
         //adonis ( ch_metadata, DIVERSITY_CORE.out.qza )
         if (params.qiime_adonis_formula) {
@@ -63,6 +70,7 @@ workflow QIIME2_DIVERSITY {
                 .combine( ch_qiime_adonis_formula )
                 .set{ ch_to_diversity_beta }
             QIIME2_DIVERSITY_ADONIS ( ch_to_diversity_beta )
+            ch_versions_qiime2_diversity = ch_versions_qiime2_diversity.mix(QIIME2_DIVERSITY_ADONIS.out.versions)
         }
 
         //beta_diversity_ordination ( ch_metadata, DIVERSITY_CORE.out.qza )
@@ -70,12 +78,14 @@ workflow QIIME2_DIVERSITY {
             .combine( QIIME2_DIVERSITY_CORE.out.pcoa.flatten() )
             .set{ ch_to_diversity_betaord }
         QIIME2_DIVERSITY_BETAORD ( ch_to_diversity_betaord )
+        ch_versions_qiime2_diversity = ch_versions_qiime2_diversity.mix(QIIME2_DIVERSITY_BETAORD.out.versions)
     }
 
     emit:
-    depth   = !skip_diversity_indices ? QIIME2_DIVERSITY_CORE.out.depth : []
-    alpha   = !skip_diversity_indices ? QIIME2_DIVERSITY_ALPHA.out.alpha : []
-    beta    = !skip_diversity_indices ? QIIME2_DIVERSITY_BETA.out.beta : []
-    betaord = !skip_diversity_indices ? QIIME2_DIVERSITY_BETAORD.out.beta : []
-    adonis  = !skip_diversity_indices && params.qiime_adonis_formula ? QIIME2_DIVERSITY_ADONIS.out.html : []
+    depth    = !skip_diversity_indices ? QIIME2_DIVERSITY_CORE.out.depth : []
+    alpha    = !skip_diversity_indices ? QIIME2_DIVERSITY_ALPHA.out.alpha : []
+    beta     = !skip_diversity_indices ? QIIME2_DIVERSITY_BETA.out.beta : []
+    betaord  = !skip_diversity_indices ? QIIME2_DIVERSITY_BETAORD.out.beta : []
+    adonis   = !skip_diversity_indices && params.qiime_adonis_formula ? QIIME2_DIVERSITY_ADONIS.out.html : []
+    versions = ch_versions_qiime2_diversity
 }

--- a/subworkflows/local/qiime2_export.nf
+++ b/subworkflows/local/qiime2_export.nf
@@ -23,29 +23,39 @@ workflow QIIME2_EXPORT {
     tax_agglom_max
 
     main:
+    ch_versions_qiime2_export = Channel.empty()
+
     //export_filtered_dada_output (optional)
     QIIME2_EXPORT_ABSOLUTE ( ch_asv, ch_seq, ch_tax, tax_agglom_min, tax_agglom_max )
+    ch_versions_qiime2_export = ch_versions_qiime2_export.mix(QIIME2_EXPORT_ABSOLUTE.out.versions)
 
     //RelativeAbundanceASV (optional)
     QIIME2_EXPORT_RELASV ( ch_asv )
+    ch_versions_qiime2_export = ch_versions_qiime2_export.mix(QIIME2_EXPORT_RELASV.out.versions)
 
     //RelativeAbundanceReducedTaxa (optional)
     QIIME2_EXPORT_RELTAX ( ch_asv, ch_tax, tax_agglom_min, tax_agglom_max )
+    ch_versions_qiime2_export = ch_versions_qiime2_export.mix(QIIME2_EXPORT_RELTAX.out.versions)
 
     //combine_table.r (optional), similar to DADA2_table.tsv but with additionally taxonomy merged
     COMBINE_TABLE_QIIME2 ( QIIME2_EXPORT_RELASV.out.tsv, QIIME2_EXPORT_ABSOLUTE.out.fasta, ch_QIIME2_tax_tsv, 'rel-table-ASV_with-QIIME2-tax.tsv' )
+    ch_versions_qiime2_export = ch_versions_qiime2_export.mix(COMBINE_TABLE_QIIME2.out.versions)
 
     //combine_table.r (optional), similar to DADA2_table.tsv but with additionally taxonomy merged
     COMBINE_TABLE_DADA2 ( QIIME2_EXPORT_RELASV.out.tsv, QIIME2_EXPORT_ABSOLUTE.out.fasta, ch_DADA2_tax_tsv, 'rel-table-ASV_with-DADA2-tax.tsv' )
+    ch_versions_qiime2_export = ch_versions_qiime2_export.mix(COMBINE_TABLE_DADA2.out.versions)
 
     //combine_table.r (optional), similar to DADA2_table.tsv but with additionally taxonomy merged
     COMBINE_TABLE_PPLACE ( QIIME2_EXPORT_RELASV.out.tsv, QIIME2_EXPORT_ABSOLUTE.out.fasta, ch_pplace_tax_tsv, 'rel-table-ASV_with-PPLACE-tax.tsv' )
+    ch_versions_qiime2_export = ch_versions_qiime2_export.mix(COMBINE_TABLE_PPLACE.out.versions)
 
     //combine_table.r (optional), similar to DADA2_table.tsv but with additionally taxonomy merged
     COMBINE_TABLE_SINTAX ( QIIME2_EXPORT_RELASV.out.tsv, QIIME2_EXPORT_ABSOLUTE.out.fasta, ch_SINTAX_tax_tsv, 'rel-table-ASV_with-SINTAX-tax.tsv' )
+    ch_versions_qiime2_export = ch_versions_qiime2_export.mix(COMBINE_TABLE_SINTAX.out.versions)
 
     emit:
-    abs_fasta      = QIIME2_EXPORT_ABSOLUTE.out.fasta
-    abs_tsv        = QIIME2_EXPORT_ABSOLUTE.out.tsv
-    rel_tsv        = QIIME2_EXPORT_RELASV.out.tsv
+    abs_fasta = QIIME2_EXPORT_ABSOLUTE.out.fasta
+    abs_tsv   = QIIME2_EXPORT_ABSOLUTE.out.tsv
+    rel_tsv   = QIIME2_EXPORT_RELASV.out.tsv
+    versions  = ch_versions_qiime2_export
 }

--- a/subworkflows/local/qiime2_taxonomy.nf
+++ b/subworkflows/local/qiime2_taxonomy.nf
@@ -15,7 +15,7 @@ workflow QIIME2_TAXONOMY {
     QIIME2_CLASSIFY ( ch_classifier, QIIME2_INSEQ.out.qza )
 
     emit:
-    qza     = QIIME2_CLASSIFY.out.qza
-    tsv     = QIIME2_CLASSIFY.out.tsv
-    versions= QIIME2_INSEQ.out.versions
+    qza      = QIIME2_CLASSIFY.out.qza
+    tsv      = QIIME2_CLASSIFY.out.tsv
+    versions = QIIME2_INSEQ.out.versions.mix(QIIME2_CLASSIFY.out.versions)
 }

--- a/subworkflows/local/sidle_wf.nf
+++ b/subworkflows/local/sidle_wf.nf
@@ -31,6 +31,7 @@ workflow SIDLE_WF {
     if (!params.sidle_ref_tax_custom) {
         //standard ref taxonomy input from conf/ref_databases.config, one tar.gz / tgz with all files
         FORMAT_TAXONOMY_SIDLE ( ch_sidle_ref_taxonomy, val_sidle_ref_taxonomy )
+        ch_sidle_versions = ch_sidle_versions.mix(FORMAT_TAXONOMY_SIDLE.out.versions)
         ch_db_sequences = FORMAT_TAXONOMY_SIDLE.out.seq
         ch_db_alignedsequences = FORMAT_TAXONOMY_SIDLE.out.alnseq
         ch_db_taxonomy = FORMAT_TAXONOMY_SIDLE.out.tax

--- a/subworkflows/local/sintax_taxonomy_wf.nf
+++ b/subworkflows/local/sintax_taxonomy_wf.nf
@@ -20,6 +20,7 @@ workflow SINTAX_TAXONOMY_WF {
 
     //format taxonomy file
     FORMAT_TAXONOMY_SINTAX ( ch_sintax_ref_taxonomy )
+    ch_versions_sintax_taxonomy = ch_versions_sintax_taxonomy.mix(FORMAT_TAXONOMY_SINTAX.out.versions)
     ch_sintaxdb = FORMAT_TAXONOMY_SINTAX.out.db
 
     //set file prefix
@@ -44,6 +45,7 @@ workflow SINTAX_TAXONOMY_WF {
 
     //convert SINTAX output to DADA2 like taxonomy table
     FORMAT_TAXRESULTS_SINTAX( VSEARCH_SINTAX.out.tsv, ch_full_fasta, ASV_tax_name2 + '.tsv', sintax_taxlevels )
+    ch_versions_sintax_taxonomy = ch_versions_sintax_taxonomy.mix(FORMAT_TAXRESULTS_SINTAX.out.versions)
     ch_sintax_tax = FORMAT_TAXRESULTS_SINTAX.out.tsv
 
     emit:


### PR DESCRIPTION
Until now only software versions of selected processes were listed, this is changed here so that software versions of all processes are now exported to `pipeline_info/software_versions.yml`.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
