### PR TITLE
Update summarize_barrnap.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#715](https://github.com/nf-core/ampliseq/pull/715) - Fix filtering vsearch clusters for high number of clusters
 - [#717](https://github.com/nf-core/ampliseq/pull/717) - Fix edge case for sorting file names by using radix method
 - [#718](https://github.com/nf-core/ampliseq/pull/718) - Require a minimum sequence length of 50bp for taxonomic classifcation after using ITSx
+- [#722](https://github.com/nf-core/ampliseq/pull/722) - When barrnap detects several genes select the lowest e-value
 
 ### `Dependencies`
 

--- a/bin/summarize_barrnap.py
+++ b/bin/summarize_barrnap.py
@@ -3,7 +3,8 @@
 # Takes a list of files with barrnap predictions (rrna.arc.gff, rrna.bac.gff, etc)
 # for ASV sequences, extracts evalues for each prediction and summarize the results
 # in a new file "summary.gff". Assumes that the same program/barrnap version is
-# used for all predictions.
+# used for all predictions. If there is more than one gene for a given domain,
+# retains the lowest e-value (case of full rRNA operon sequences).
 
 # import pandas as pd
 import sys
@@ -27,7 +28,8 @@ for file in sys.argv[1:]:
         method[asv] = rowparts[1]
         if asv not in evalues:
             evalues[asv] = dict()
-        evalues[asv][org] = rowparts[5]
+        if (org not in evalues[asv]) or (float(evalues[asv][org]) > float(rowparts[5])) : 
+           evalues[asv][org] = rowparts[5]
     fh.close()
 
 # Write results

--- a/bin/summarize_barrnap.py
+++ b/bin/summarize_barrnap.py
@@ -28,7 +28,7 @@ for file in sys.argv[1:]:
         method[asv] = rowparts[1]
         if asv not in evalues:
             evalues[asv] = dict()
-        if (org not in evalues[asv]) or (float(evalues[asv][org]) > float(rowparts[5])) : 
+        if (org not in evalues[asv]) or (float(evalues[asv][org]) > float(rowparts[5])):
            evalues[asv][org] = rowparts[5]
     fh.close()
 


### PR DESCRIPTION
If there is more than one gene for a given domain, retains the lowest e-value (case of full rRNA operon sequences).

<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
