### PR TITLE
Retrieve Sidle container from quay.io/nf-core instead of docker.io/d4straub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - [#700](https://github.com/nf-core/ampliseq/pull/700) - Optional `--save_intermediates` to publish QIIME2 data objects (.qza) and visualisation objects (.qzv)
-- [#702](https://github.com/nf-core/ampliseq/pull/702),[#723](https://github.com/nf-core/ampliseq/pull/723),[#728](https://github.com/nf-core/ampliseq/pull/728) - Add multiple regions analysis (including 5R / SMURF / q2-sidle)
+- [#702](https://github.com/nf-core/ampliseq/pull/702),[#723](https://github.com/nf-core/ampliseq/pull/723),[#728](https://github.com/nf-core/ampliseq/pull/728),[#729](https://github.com/nf-core/ampliseq/pull/729) - Add multiple regions analysis (including 5R / SMURF / q2-sidle)
 
 ### `Changed`
 

--- a/modules/local/sidle_align.nf
+++ b/modules/local/sidle_align.nf
@@ -2,7 +2,7 @@ process SIDLE_ALIGN {
     tag "$meta.region"
     label 'process_medium'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     tuple val(meta), path(kmers), path(seq)

--- a/modules/local/sidle_dbextract.nf
+++ b/modules/local/sidle_dbextract.nf
@@ -3,7 +3,7 @@ process SIDLE_DBEXTRACT {
     tag "$meta.region,$meta.region_length"
     label 'process_medium'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     tuple val(meta), path(table), path(seq), path(db_seq), path(db_tax)

--- a/modules/local/sidle_dbfilt.nf
+++ b/modules/local/sidle_dbfilt.nf
@@ -1,7 +1,7 @@
 process SIDLE_DBFILT {
     label 'process_low'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     path(seq)

--- a/modules/local/sidle_dbrecon.nf
+++ b/modules/local/sidle_dbrecon.nf
@@ -1,7 +1,7 @@
 process SIDLE_DBRECON {
     label 'process_medium'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     val(metaid)

--- a/modules/local/sidle_filttax.nf
+++ b/modules/local/sidle_filttax.nf
@@ -2,7 +2,7 @@
 process SIDLE_FILTTAX {
     label 'process_single'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     path(table_tofilter)

--- a/modules/local/sidle_in.nf
+++ b/modules/local/sidle_in.nf
@@ -2,7 +2,7 @@ process SIDLE_IN {
     tag "$meta.region"
     label 'process_single'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     tuple val(meta), path(table), path(seq)

--- a/modules/local/sidle_indb.nf
+++ b/modules/local/sidle_indb.nf
@@ -1,7 +1,7 @@
 process SIDLE_INDB {
     label 'process_single'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     path(seq)

--- a/modules/local/sidle_indbaligned.nf
+++ b/modules/local/sidle_indbaligned.nf
@@ -1,7 +1,7 @@
 process SIDLE_INDBALIGNED {
     label 'process_single'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     path(seq)

--- a/modules/local/sidle_seqrecon.nf
+++ b/modules/local/sidle_seqrecon.nf
@@ -2,7 +2,7 @@ process SIDLE_SEQRECON {
     label 'process_medium'
     label 'single_cpu'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     path(reconstruction_map)

--- a/modules/local/sidle_tablerecon.nf
+++ b/modules/local/sidle_tablerecon.nf
@@ -1,7 +1,7 @@
 process SIDLE_TABLERECON {
     label 'process_medium'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     val(metaid)

--- a/modules/local/sidle_taxrecon.nf
+++ b/modules/local/sidle_taxrecon.nf
@@ -1,7 +1,7 @@
 process SIDLE_TAXRECON {
     label 'process_single'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     path(reconstruction_map)

--- a/modules/local/sidle_treerecon.nf
+++ b/modules/local/sidle_treerecon.nf
@@ -1,7 +1,7 @@
 process SIDLE_TREERECON {
     label 'process_medium'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     path(reconstruction_fragments)

--- a/modules/local/sidle_trim.nf
+++ b/modules/local/sidle_trim.nf
@@ -2,7 +2,7 @@ process SIDLE_TRIM {
     tag "$meta.region,$meta.region_length"
     label 'process_single'
 
-    container 'docker.io/d4straub/pipesidle:0.1.0-beta'
+    container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
     tuple val(meta), path(table), path(seq)


### PR DESCRIPTION
For a new software (Sidle) I produced a container and deposited it at dockerhub. The processes that use that software did so with `container 'docker.io/d4straub/pipesidle:0.1.0-beta'`. My proposal to put the tool (pypi packaged) to conda was rejected by the developer of said tool. I generated the container with [Dockerfile](https://github.com/d4straub/pipesidle/blob/83600d3b4068526e19d8f9db7a1c716c2a7c5c0a/Dockerfile) & [environment.yml](https://github.com/d4straub/pipesidle/blob/83600d3b4068526e19d8f9db7a1c716c2a7c5c0a/environment.yml). This container was now pushed to `quay.io/nf-core`, therefore now retrieved by `container 'nf-core/pipesidle:0.1.0-beta'`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
