### PR TITLE
Create barplot also without metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#749](https://github.com/nf-core/ampliseq/pull/749) - Create barplot also when no metadata is given
+
 ### `Fixed`
 
 - [#747](https://github.com/nf-core/ampliseq/pull/747) - Template update for nf-core/tools version 2.14.1

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -772,7 +772,7 @@ workflow AMPLISEQ {
         }
 
         if (!params.skip_barplot) {
-            QIIME2_BARPLOT ( ch_metadata, ch_asv, ch_tax, '' )
+            QIIME2_BARPLOT ( ch_metadata.ifEmpty([]), ch_asv, ch_tax, '' )
             ch_versions = ch_versions.mix( QIIME2_BARPLOT.out.versions )
         }
 


### PR DESCRIPTION
The taxonomic barplot is now also created when no metadata is supplied.
Closes https://github.com/nf-core/ampliseq/issues/738

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
