### PR TITLE
Fix sorting in overall_summary.tsv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#747](https://github.com/nf-core/ampliseq/pull/747) - Template update for nf-core/tools version 2.14.1
-- [#750](https://github.com/nf-core/ampliseq/pull/750) - Numbers in `overall_summary.tsv` were fix (sometimes misleading in 2.9.0 for columns "denoised[F/R]", "merged", and "nochim")
+- [#750](https://github.com/nf-core/ampliseq/pull/750) - Numbers in `overall_summary.tsv` were fixed (sometimes misleading in 2.9.0 for columns "denoised[F/R]", "merged", and "nochim")
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#747](https://github.com/nf-core/ampliseq/pull/747) - Template update for nf-core/tools version 2.14.1
+- [#750](https://github.com/nf-core/ampliseq/pull/750) - Numbers in `overall_summary.tsv` were fix (sometimes misleading in 2.9.0 for columns "denoised[F/R]", "merged", and "nochim")
 
 ### `Dependencies`
 


### PR DESCRIPTION
`overall_summary.tsv` had sometimes misleading numbers in 2.9.0. This was due to a new sorting method added in https://github.com/nf-core/ampliseq/pull/717 (necessary due to bad forward & reverse read pairing due to edge case sample names). 

This PR makes sure that all tables that are merged are identically sorted (merged by `cbind` rather than `merge` due to different row names (contain sampleID), e.g. `sample1.trimmed_1.trim.fastq.gz` & `sample1_1.filt.fastq.gz` & `sample1_2.filt.fastq.gz`).
I also considered correcting the row names for each table and subsequently apply `merge`, but because row names are so divers, that seems not great. I do have the feeling correcting row names and use `merge` might be safer, but I couldnt find any example where it would matter, but I am open to change the implementation.

Using the example above, the sorting should be fine:
```
> sort( c("sample1.trimmed_1.trim.fastq.gz","sample2.trimmed_1.trim.fastq.gz","sample10.trimmed_1.trim.fastq.gz","sample10_1.trimmed_1.trim.fastq.gz") )
[1] "sample1.trimmed_1.trim.fastq.gz"    "sample10_1.trimmed_1.trim.fastq.gz"
[3] "sample10.trimmed_1.trim.fastq.gz"   "sample2.trimmed_1.trim.fastq.gz"   
> sort( c("sample1_1.filt.fastq.gz","sample2_1.filt.fastq.gz","sample10_1.filt.fastq.gz","sample10_1_1.filt.fastq.gz") )
[1] "sample1_1.filt.fastq.gz"    "sample10_1_1.filt.fastq.gz"
[3] "sample10_1.filt.fastq.gz"   "sample2_1.filt.fastq.gz"
```

Closes https://github.com/nf-core/ampliseq/issues/742.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
