### PR TITLE
Fix --*_ref_taxonomy validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#762](https://github.com/nf-core/ampliseq/pull/762) - Improved output documentation section "Optional ASV filtering" and parameter documentation
 - [#766](https://github.com/nf-core/ampliseq/pull/766) - Modified warning filenames from `QIIME2_ANCOM` to avoid collisions
-- [#766](https://github.com/nf-core/ampliseq/pull/766) - Disabled Unite databases from the `--qiime_ref_taxonomy` because of divergent results compared to the other classifiers
+- [#766](https://github.com/nf-core/ampliseq/pull/766),[#769](https://github.com/nf-core/ampliseq/pull/769) - Disabled Unite databases from the `--qiime_ref_taxonomy` because of divergent results compared to the other classifiers
 
 ### `Fixed`
 
 - [#761](https://github.com/nf-core/ampliseq/pull/761) - Some sample sheet checks were not applied due to changes in the metadata ["meta"] structure in version 2.9.0
 - [#766](https://github.com/nf-core/ampliseq/pull/766) - Fixed broken urls for Unite databases (issue [#764](https://github.com/nf-core/ampliseq/issues/764))
+- [#769](https://github.com/nf-core/ampliseq/pull/769) - Reference taxonomy database values were not properly validated in versions 2.9.0 and 2.10.0
 
 ### `Dependencies`
 

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -296,6 +296,12 @@ params {
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = "taxref_reformat_qiime_silva138.sh"
         }
+
+        // We have disabled all Unite databases for the QIIME2 classifiers
+        // since we get results that differ considerably from the Sintax and
+        // DADA2 classifiers with the corresponding databases.
+
+        /***
         //UNITE for QIIME2, see https://unite.ut.ee/repository.php
         'unite-fungi' {
             title = "UNITE QIIME release for Fungi - Version 10.0"
@@ -309,13 +315,6 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2024): UNITE QIIME release for Fungi. Version 04.04.2024. UNITE Community. https://doi.org/10.15156/BIO/2959336"
             fmtscript = "taxref_reformat_qiime_unite.sh"
         }
-
-        // We have disabled all Unite databases for the QIIME2 classifiers
-        // since we get results that differ considerably from the Sintax and
-        // DADA2 classifiers with the corresponding databases.
-
-        // The unite-fungi=9.0 fails
-        /***
         'unite-fungi=9.0' {
             title = "UNITE QIIME release for Fungi - Version 9.0"
             file = [ "https://s3.hpc.ut.ee/plutof-public/original/3c22fbc5-ed9e-47a6-a85b-6c81268657e9.tgz" ]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -229,8 +229,8 @@ Pre-configured reference taxonomy databases are:
 | greengenes   | -     | -      | +       | (+)²   | 16S rRNA                                      |
 | greengenes2  | -     | -      | -       | +      | 16S rRNA                                      |
 | pr2          | +     | -      | -       | -      | 18S rRNA                                      |
-| unite-fungi  | +     | +      | -       | +      | eukaryotic nuclear ribosomal ITS region       |
-| unite-alleuk | +     | +      | -       | +      | eukaryotic nuclear ribosomal ITS region       |
+| unite-fungi  | +     | +      | -       | -      | eukaryotic nuclear ribosomal ITS region       |
+| unite-alleuk | +     | +      | -       | -      | eukaryotic nuclear ribosomal ITS region       |
 | coidb        | +     | +      | -       | -      | eukaryotic Cytochrome Oxidase I (COI)         |
 | midori2-co1  | +     | -      | -       | -      | eukaryotic Cytochrome Oxidase I (COI)         |
 | phytoref     | +     | -      | -       | -      | eukaryotic plastid 16S rRNA                   |

--- a/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
@@ -162,14 +162,6 @@ def validateInputParameters() {
         error("Invalid command: `--trunclenr` is set, but `--trunclenf` is not. Either both parameters `--trunclenf` and `--trunclenr` must be set or none.")
     }
 
-    if (!["pooled", "independent", "pseudo"].contains(params.sample_inference)) {
-        def error_string = "Please set `--sample_inference` to one of the following:\n" +
-            "\t-\"independent\" (lowest sensitivity and lowest resources),\n" +
-            "\t-\"pseudo\" (balance between required resources and sensitivity),\n" +
-            "\t-\"pooled\" (highest sensitivity and resources)."
-        error(error_string)
-    }
-
     if (params.double_primer && params.retain_untrimmed) {
         error("Incompatible parameters `--double_primer` and `--retain_untrimmed` cannot be set at the same time.")
     }

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -47,7 +47,7 @@ if (params.dada_ref_tax_custom) {
     val_dada_ref_taxonomy = "user"
 } else if (params.dada_ref_taxonomy && !params.skip_dada_taxonomy && !params.skip_taxonomy) {
     //standard ref taxonomy input from params.dada_ref_taxonomy & conf/ref_databases.config
-    ch_dada_ref_taxonomy = Channel.fromList(params.dada_ref_databases[params.dada_ref_taxonomy]["file"]).map { file(it) }
+    ch_dada_ref_taxonomy = params.dada_ref_databases.containsKey(params.dada_ref_taxonomy) ? Channel.fromList(params.dada_ref_databases[params.dada_ref_taxonomy]["file"]).map { file(it) } : Channel.empty()
     val_dada_ref_taxonomy = params.dada_ref_taxonomy.replace('=','_').replace('.','_')
 } else {
     ch_dada_ref_taxonomy = Channel.empty()
@@ -67,7 +67,7 @@ if (params.qiime_ref_tax_custom) {
     }
     val_qiime_ref_taxonomy = "user"
 } else if (params.qiime_ref_taxonomy && !params.skip_taxonomy && !params.classifier) {
-    ch_qiime_ref_taxonomy = Channel.fromList(params.qiime_ref_databases[params.qiime_ref_taxonomy]["file"]).map { file(it) }
+    ch_qiime_ref_taxonomy = params.qiime_ref_databases.containsKey(params.qiime_ref_taxonomy) ? Channel.fromList(params.qiime_ref_databases[params.qiime_ref_taxonomy]["file"]).map { file(it) } : Channel.empty()
     val_qiime_ref_taxonomy = params.qiime_ref_taxonomy.replace('=','_').replace('.','_')
 } else {
     ch_qiime_ref_taxonomy = Channel.empty()
@@ -75,7 +75,7 @@ if (params.qiime_ref_tax_custom) {
 }
 
 if (params.sintax_ref_taxonomy && !params.skip_taxonomy) {
-    ch_sintax_ref_taxonomy = Channel.fromList(params.sintax_ref_databases[params.sintax_ref_taxonomy]["file"]).map { file(it) }
+    ch_sintax_ref_taxonomy = params.sintax_ref_databases.containsKey(params.sintax_ref_taxonomy) ? Channel.fromList(params.sintax_ref_databases[params.sintax_ref_taxonomy]["file"]).map { file(it) } : Channel.empty()
     val_sintax_ref_taxonomy = params.sintax_ref_taxonomy.replace('=','_').replace('.','_')
 } else {
     ch_sintax_ref_taxonomy = Channel.empty()
@@ -88,7 +88,7 @@ if (params.kraken2_ref_tax_custom) {
     val_kraken2_ref_taxonomy = "user"
 } else if (params.kraken2_ref_taxonomy && !params.skip_taxonomy) {
     //standard ref taxonomy input from params.dada_ref_taxonomy & conf/ref_databases.config
-    ch_kraken2_ref_taxonomy = Channel.fromList(params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["file"]).map { file(it) }
+    ch_kraken2_ref_taxonomy = params.kraken2_ref_databases.containsKey(params.kraken2_ref_taxonomy) ? Channel.fromList(params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["file"]).map { file(it) } : Channel.empty()
     val_kraken2_ref_taxonomy = params.kraken2_ref_taxonomy.replace('=','_').replace('.','_')
 } else {
     ch_kraken2_ref_taxonomy = Channel.empty()
@@ -122,16 +122,16 @@ tax_agglom_max = params.tax_agglom_max
 //use custom taxlevels from --dada_assign_taxlevels or database specific taxlevels if specified in conf/ref_databases.config
 if ( params.dada_ref_taxonomy ) {
     taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" :
-        params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] ?: ""
+        params.dada_ref_databases.containsKey(params.dada_ref_taxonomy) && params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] ?: ""
 } else { taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" : "" }
 if ( params.sintax_ref_taxonomy ) {
-    sintax_taxlevels = params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] ?: ""
+    sintax_taxlevels = params.sintax_ref_databases.containsKey(params.sintax_ref_taxonomy) && params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] ?: ""
 } else {
     sintax_taxlevels = ""
 }
 if ( params.kraken2_ref_taxonomy ) {
     kraken2_taxlevels = params.kraken2_assign_taxlevels ? "${params.kraken2_assign_taxlevels}" :
-        params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] ?: ""
+        params.kraken2_ref_databases.containsKey(params.kraken2_ref_taxonomy) && params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] ?: ""
 } else { kraken2_taxlevels = params.kraken2_assign_taxlevels ? "${params.kraken2_assign_taxlevels}" : "" }
 
 //make sure that taxlevels adheres to requirements when mixed with addSpecies

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -122,16 +122,16 @@ tax_agglom_max = params.tax_agglom_max
 //use custom taxlevels from --dada_assign_taxlevels or database specific taxlevels if specified in conf/ref_databases.config
 if ( params.dada_ref_taxonomy ) {
     taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" :
-        params.dada_ref_databases.containsKey(params.dada_ref_taxonomy) && params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] ?: ""
+        params.dada_ref_databases.containsKey(params.dada_ref_taxonomy) && params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] ? params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] : ""
 } else { taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" : "" }
 if ( params.sintax_ref_taxonomy ) {
-    sintax_taxlevels = params.sintax_ref_databases.containsKey(params.sintax_ref_taxonomy) && params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] ?: ""
+    sintax_taxlevels = params.sintax_ref_databases.containsKey(params.sintax_ref_taxonomy) && params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] ? params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] : ""
 } else {
     sintax_taxlevels = ""
 }
 if ( params.kraken2_ref_taxonomy ) {
     kraken2_taxlevels = params.kraken2_assign_taxlevels ? "${params.kraken2_assign_taxlevels}" :
-        params.kraken2_ref_databases.containsKey(params.kraken2_ref_taxonomy) && params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] ?: ""
+        params.kraken2_ref_databases.containsKey(params.kraken2_ref_taxonomy) && params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] ? params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] : ""
 } else { kraken2_taxlevels = params.kraken2_assign_taxlevels ? "${params.kraken2_assign_taxlevels}" : "" }
 
 //make sure that taxlevels adheres to requirements when mixed with addSpecies


### PR DESCRIPTION
Fix for https://github.com/nf-core/ampliseq/issues/767: Reference taxonomy database values were not properly validated in versions 2.9.0 and 2.10.0
Update docs for removed UNITE databases for QIIME2 in https://github.com/nf-core/ampliseq/pull/766.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
