### PR TITLE
Fix SH files for unite9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#800](https://github.com/nf-core/ampliseq/pull/800) - Fixed SH files for UNITE9.0 that were missing entries after API update in PlutoF
+- [#800](https://github.com/nf-core/ampliseq/pull/800) - Fixed SH files for UNITE9.0, they were missing some entries due to a bug caused by API update in PlutoF
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#800](https://github.com/nf-core/ampliseq/pull/800) - Fixed SH files for UNITE9.0 that were missing entries after API update in PlutoF
+
 ### `Dependencies`
 
 ### `Removed`

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -204,7 +204,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2023): UNITE general FASTA release for Fungi. Version 18.07.2023. UNITE Community. https://doi.org/10.15156/BIO/2938067"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = "UNITE-fungi v9.0 (https://doi.org/10.15156/BIO/2938067)"
-            shfile = [ "https://figshare.scilifelab.se/ndownloader/files/40788767", "https://figshare.scilifelab.se/ndownloader/files/40788770"]
+            shfile = [ "https://figshare.scilifelab.se/ndownloader/files/50055762", "https://figshare.scilifelab.se/ndownloader/files/50055765"]
         }
         'unite-fungi=9.0' {
             title = "UNITE general FASTA release for Fungi - Version 9.0"
@@ -212,7 +212,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2023): UNITE general FASTA release for Fungi. Version 18.07.2023. UNITE Community. https://doi.org/10.15156/BIO/2938067"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = "UNITE-fungi v9.0 (https://doi.org/10.15156/BIO/2938067)"
-            shfile = [ "https://figshare.scilifelab.se/ndownloader/files/40788767", "https://figshare.scilifelab.se/ndownloader/files/40788770"]
+            shfile = [ "https://figshare.scilifelab.se/ndownloader/files/50055762", "https://figshare.scilifelab.se/ndownloader/files/50055765"]
         }
         'unite-fungi=8.3' {
             title = "UNITE general FASTA release for Fungi - Version 8.3"
@@ -236,7 +236,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2023): UNITE general FASTA release for eukaryotes. Version 18.07.2023. UNITE Community. https://doi.org/10.15156/BIO/2938069"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = "UNITE-alleuk v9.0 (https://doi.org/10.15156/BIO/2938069)"
-            shfile = [ "https://figshare.scilifelab.se/ndownloader/files/40788773", "https://figshare.scilifelab.se/ndownloader/files/40788776"]
+            shfile = [ "https://figshare.scilifelab.se/ndownloader/files/50055768", "https://figshare.scilifelab.se/ndownloader/files/50055771"]
         }
         'unite-alleuk=9.0' {
             title = "UNITE general FASTA release for eukaryotes - Version 9.0"
@@ -244,7 +244,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2023): UNITE general FASTA release for eukaryotes. Version 18.07.2023. UNITE Community. https://doi.org/10.15156/BIO/2938069"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = "UNITE-alleuk v9.0 (https://doi.org/10.15156/BIO/2938069)"
-            shfile = [ "https://figshare.scilifelab.se/ndownloader/files/40788773", "https://figshare.scilifelab.se/ndownloader/files/40788776"]
+            shfile = [ "https://figshare.scilifelab.se/ndownloader/files/50055768", "https://figshare.scilifelab.se/ndownloader/files/50055771"]
         }
         'unite-alleuk=8.3' {
             title = "UNITE general FASTA release for eukaryotes - Version 8.3"


### PR DESCRIPTION
The files used to assign SH for UNITE 9.0 are missing some taxonomies due to an update of the PlutoF API that partially broke the scripts used. This PR gives links to the new, corrected files.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
