### PR TITLE
Provide users the ability to not bump stack size.

### DIFF
--- a/modules/local/filter_clusters.nf
+++ b/modules/local/filter_clusters.nf
@@ -23,8 +23,9 @@ process FILTER_CLUSTERS {
     script:
     def prefix   = task.ext.prefix ?: "'$meta.id'"
     def clusters = "'$clusters'"
+    def ulimiter = params.raise_filter_stacksize ? "ulimit -s unlimited" : ""
     """
-    ulimit -s unlimited
+    ${ulimiter}
     echo ${clusters} | filt_clusters.py -t ${asv} -p ${prefix} -c -
 
     cat <<-END_VERSIONS > versions.yml

--- a/nextflow.config
+++ b/nextflow.config
@@ -82,6 +82,7 @@ params {
     ancombc_significance       = 0.05
     ancombc_formula            = null
     ancombc_formula_reflvl     = null
+    raise_filter_stacksize     = true
 
     // Report options
     report_template   = "${projectDir}/assets/report_template.Rmd"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -591,6 +591,13 @@
                     "default": 1,
                     "description": "Prevalence filtering",
                     "help_text": "Filtering low prevalent features from the feature table, e.g. keeping only features that are present in at least two samples can be achived by choosing a value of 2 (default: 1, meaning filter is disabled). Typically only used when having replicates for all samples.\n\nFor example to retain features that are present in at least two sample:\n\n```bash\n--min_samples 2\n```\n\nPlease note this is independent of abundance."
+                },
+                "raise_filter_stacksize": {
+                    "type": "boolean",
+                    "default": true,
+                    "fa_icon": "fas fa-angle-double-up",
+                    "description": "Raise stack size when filtering VSEARCH clusters",
+                    "help_text": "Setting to true adds 'ulimit -s unlimited' to the beginning of the filt_clusters.py command."
                 }
             }
         },


### PR DESCRIPTION
Not all environments have permissions to set an unlimited stack size. Particularly for smaller samples, this provides the ability to not set an unlimited stack size.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
