### PR TITLE
fix: rm sampleid dashes in doc and add check for directory input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#800](https://github.com/nf-core/ampliseq/pull/800) - Fixed SH files for UNITE9.0, they were missing some entries due to a bug caused by API update in PlutoF
 - [#808](https://github.com/nf-core/ampliseq/pull/808) - Add missing library declaration in R script.
 - [#832](https://github.com/nf-core/ampliseq/pull/832) - Add pattern to input field
+- [#847](https://github.com/nf-core/ampliseq/pull/847) - update the `usage.md` about sample id format (no dashes allowed)
 
 ### `Dependencies`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,12 +20,13 @@
   - [Updating the pipeline](#updating-the-pipeline)
   - [Reproducibility](#reproducibility)
 - [Core Nextflow arguments](#core-nextflow-arguments)
-  - [-profile](#profile)
-  - [-resume](#resume)
-  - [-c](#c)
+  - [`-profile`](#-profile)
+  - [`-resume`](#-resume)
+  - [`-c`](#-c)
 - [Custom configuration](#custom-configuration)
   - [Resource requests](#resource-requests)
-  - [Updating containers](#updating-containers)
+  - [Custom Containers](#custom-containers)
+  - [Custom Tool Arguments](#custom-tool-arguments)
   - [nf-core/configs](#nf-coreconfigs)
 - [Running in the background](#running-in-the-background)
 - [Nextflow memory requirements](#nextflow-memory-requirements)
@@ -116,7 +117,7 @@ The sample sheet file can be tab-separated (.tsv), comma-separated (.csv), or in
 
 | Column       | Necessity | Description                                                                   |
 | ------------ | --------- | ----------------------------------------------------------------------------- |
-| sampleID     | required  | Unique sample identifiers                                                     |
+| sampleID     | required  | Unique sample identifiers (see below for requirements)                        |
 | forwardReads | required  | Paths to (forward) reads zipped FastQ files                                   |
 | reverseReads | optional  | Paths to reverse reads zipped FastQ files, required if the data is paired-end |
 | run          | optional  | If the data was produced by multiple sequencing runs, any string              |
@@ -207,7 +208,7 @@ Please note the following additional requirements:
 - `--extension` must have at least one `*` wildcard character
 - When using the pipeline with paired end data, the `--extension` must use `{1,2}` (or similar) notation to specify read pairs
 - To run single-end data you must additionally specify `--single_end` and `--extension` may not include curly brackets `{}`
-- Sample identifiers are extracted from file names, i.e. the string before the first underscore `_`, these must be unique (also across sequencing runs)
+- Sample identifiers are extracted from file names, i.e. the string before the first underscore `_`, these must be unique (also across sequencing runs) and only contain letters, numbers or underscores
 - If your data is scattered, produce a sample sheet
 
 ### Taxonomic classification
@@ -303,7 +304,7 @@ Please note the following requirements:
 
 The metadata file must be tab-separated with a header line. The first column in the tab-separated metadata file is the sample identifier column (required header: ID) and defines the sample or feature IDs associated with the dataset. In addition to the sample identifier column, the metadata file is required to have at least one column with multiple different non-numeric values but not all unique.
 
-Sample identifiers should be 36 characters long or less, and also contain only ASCII alphanumeric characters (i.e. in the range of [a-z], [A-Z], or [0-9]), or the dash (-) character. For downstream analysis, by default all numeric columns, blanks or NA are removed, and only columns with multiple different values but not all unique are selected.
+Sample identifiers should be 36 characters long or less, and also contain only ASCII alphanumeric characters (i.e. in the range of [a-z], [A-Z], or [0-9]), or the underscore (_) character. For downstream analysis, by default all numeric columns, blanks or NA are removed, and only columns with multiple different values but not all unique are selected.
 
 The columns which are to be assessed can be specified by `--metadata_category`. If `--metadata_category` isn't specified than all columns that fit the specification are automatically chosen.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -302,7 +302,7 @@ Please note the following requirements:
 
 The metadata file must be tab-separated with a header line. The first column in the tab-separated metadata file is the sample identifier column (required header: ID) and defines the sample or feature IDs associated with the dataset. In addition to the sample identifier column, the metadata file is required to have at least one column with multiple different non-numeric values but not all unique.
 
-Sample identifiers should be 36 characters long or less, and also contain only ASCII alphanumeric characters (i.e. in the range of [a-z], [A-Z], or [0-9]), or the underscore (_) character. For downstream analysis, by default all numeric columns, blanks or NA are removed, and only columns with multiple different values but not all unique are selected.
+Sample identifiers should be 36 characters long or less, and also contain only ASCII alphanumeric characters (i.e. in the range of [a-z], [A-Z], or [0-9]), or the underscore (\_) character. For downstream analysis, by default all numeric columns, blanks or NA are removed, and only columns with multiple different values but not all unique are selected.
 
 The columns which are to be assessed can be specified by `--metadata_category`. If `--metadata_category` isn't specified than all columns that fit the specification are automatically chosen.
 

--- a/subworkflows/local/parse_input.nf
+++ b/subworkflows/local/parse_input.nf
@@ -70,10 +70,10 @@ workflow PARSE_INPUT {
             }
         }
 
-    //Check that no dots "." are in sampleID
+    //Check that sampleIDs contain only letter, number and underscore characters
     ch_reads
         .map { meta, reads -> meta.sample }
-        .subscribe { if ( "$it".contains(".") ) error("Please review data input, sampleIDs may not contain dots, but \"$it\" does.") }
+        .subscribe { if ( ! "$it".matches(/^[a-zA-Z0-9_]+$/) ) error("Please review data input, sampleIDs may not contain characters other than letters, numbers or underscores, but \"$it\" does.") }
 
     //Check that sampleIDs do not start with a number when using metadata (sampleID gets X prepended by R and metadata wont match any more!)
     ch_reads


### PR DESCRIPTION
## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Changes

- update the`usage.md` sections Metadata and Sample input to remove the dashes (closes #821)
- update TOC in `usage.md`
- check if sample id extracted from input dir are only composed by letters, numbers and underscores