### PR TITLE
Add Greengenes2 for taxonomic classification with DADA2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | **mergepairs_consensus_percentile_cutoff** | The percentile cutoff determining the minimum observed overlap in the dataset.            | 0.001             |
 
 - [#833](https://github.com/nf-core/ampliseq/pull/833) - Add paths to updated version of SBDI-GTDB database.
+- [#849](https://github.com/nf-core/ampliseq/pull/849) - Added Greengenes version 2024.09 of DADA2 taxonomy database: `greengenes2=2024.09` or `greengenes2` as parameter to `--dada2_ref_taxonomy`
 
 ### `Changed`
 

--- a/bin/taxref_reformat_gg2.sh
+++ b/bin/taxref_reformat_gg2.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Handles the Greengenes2 DADA2 database.
+
+# Write the assignTaxonomy() fasta file: assignTaxonomy.fna
+zcat *.gz | sed '/^>/s/>[^ ]\+ \([^[]\+\) \[.*/>\1/' | sed '/^>/s/ \[.*//' | sed 's/[a-z]__//g' | gzip -c > assignTaxonomy.fna.gz
+
+# Write the addSpecies() fasta file: addSpecies.fna
+# remove last ";", remove last ";" to preserve genus, take last field separated by ";", add line number after '>' as fake ID
+zcat assignTaxonomy.fna.gz | sed 's/;*$//g' | sed 's/\(.*\);/\1 /' | sed 's/.*;/> /' | awk '$1 == ">" {print $1 FNR, $2, $3; next} {print}' | gzip -c > addSpecies.fna.gz

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -25,6 +25,20 @@ params {
             fmtscript = "taxref_reformat_coidb.sh"
             dbversion = "COIDB 221216 (https://doi.org/10.17044/scilifelab.20514192.v2)"
         }
+        'greengenes2' {
+            title = "Greengenes2 release version 2024.09 formatted for DADA2"
+            file = [ "https://zenodo.org/records/14169078/files/gg2_2024_09_toSpecies_trainset.fa.gz" ]
+            citation = "McDonald D, Jiang Y, Balaban M, Cantrell K, Zhu Q, Gonzalez A, Morton JT, Nicolaou G, Parks DH, Karst SM, Albertsen M. Greengenes2 unifies microbial data in a single reference tree. Nature biotechnology. 2024 May;42(5):715-8."
+            fmtscript = ""
+            dbversion = "Greengenes2 2024.09 (https://zenodo.org/records/14169078)"
+        }
+        'greengenes2=2024.09' {
+            title = "Greengenes2 release version 2024.09 formatted for DADA2"
+            file = [ "https://zenodo.org/records/14169078/files/gg2_2024_09_toSpecies_trainset.fa.gz" ]
+            citation = "McDonald D, Jiang Y, Balaban M, Cantrell K, Zhu Q, Gonzalez A, Morton JT, Nicolaou G, Parks DH, Karst SM, Albertsen M. Greengenes2 unifies microbial data in a single reference tree. Nature biotechnology. 2024 May;42(5):715-8."
+            fmtscript = ""
+            dbversion = "Greengenes2 2024.09 (https://zenodo.org/records/14169078)"
+        }
         'gtdb' {
             title = "GTDB - Genome Taxonomy Database - Release R09-RS220"
             file = [ "https://data.gtdb.ecogenomic.org/releases/release220/220.0/genomic_files_reps/bac120_ssu_reps_r220.fna.gz", "https://data.gtdb.ecogenomic.org/releases/release220/220.0/genomic_files_reps/ar53_ssu_reps_r220.fna.gz" ]

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -29,14 +29,14 @@ params {
             title = "Greengenes2 release version 2024.09 formatted for DADA2"
             file = [ "https://zenodo.org/records/14169078/files/gg2_2024_09_toSpecies_trainset.fa.gz" ]
             citation = "McDonald D, Jiang Y, Balaban M, Cantrell K, Zhu Q, Gonzalez A, Morton JT, Nicolaou G, Parks DH, Karst SM, Albertsen M. Greengenes2 unifies microbial data in a single reference tree. Nature biotechnology. 2024 May;42(5):715-8."
-            fmtscript = ""
+            fmtscript = "taxref_reformat_gg2.sh"
             dbversion = "Greengenes2 2024.09 (https://zenodo.org/records/14169078)"
         }
         'greengenes2=2024.09' {
             title = "Greengenes2 release version 2024.09 formatted for DADA2"
             file = [ "https://zenodo.org/records/14169078/files/gg2_2024_09_toSpecies_trainset.fa.gz" ]
             citation = "McDonald D, Jiang Y, Balaban M, Cantrell K, Zhu Q, Gonzalez A, Morton JT, Nicolaou G, Parks DH, Karst SM, Albertsen M. Greengenes2 unifies microbial data in a single reference tree. Nature biotechnology. 2024 May;42(5):715-8."
-            fmtscript = ""
+            fmtscript = "taxref_reformat_gg2.sh"
             dbversion = "Greengenes2 2024.09 (https://zenodo.org/records/14169078)"
         }
         'gtdb' {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -225,7 +225,7 @@ Pre-configured reference taxonomy databases are:
 | sbdi-gtdb    | +     | -      | -       | -      | 16S rRNA                                      |
 | rdp          | +     | -      | +       | -      | 16S rRNA                                      |
 | greengenes   | -     | -      | +       | (+)³   | 16S rRNA                                      |
-| greengenes2  | -     | -      | -       | +      | 16S rRNA                                      |
+| greengenes2  | +     | -      | -       | +      | 16S rRNA                                      |
 | pr2          | +     | -      | -       | -      | 18S rRNA                                      |
 | unite-fungi  | +     | +      | -       | -      | eukaryotic nuclear ribosomal ITS region       |
 | unite-alleuk | +     | +      | -       | -      | eukaryotic nuclear ribosomal ITS region       |

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -402,6 +402,8 @@
                     "enum": [
                         "coidb",
                         "coidb=221216",
+                        "greengenes2",
+                        "greengenes2=2024.09",
                         "gtdb",
                         "gtdb=R05-RS95",
                         "gtdb=R06-RS202",

--- a/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
@@ -229,6 +229,7 @@ def validateInputParameters() {
 
     String[] sbdi_compatible_databases = [
         "coidb","coidb=221216",
+        "greengenes2","greengenes2=2024.09",
         "gtdb","gtdb=R09-RS220","gtdb=R08-RS214","gtdb=R07-RS207","gtdb=R06-RS202","gtdb=R05-RS95",
         "midori2-co1","midori2-co1=gb250",
         "pr2","pr2=5.0.0","pr2=4.14.0","pr2=4.13.0",


### PR DESCRIPTION
Closes https://github.com/nf-core/ampliseq/issues/828

I tested locally and worked out fine. I didnt try to activate it in any test, I assume (but dont know) that the DB is too large for github CI.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
