### PR TITLE
Fix ITSx filtering

### DIFF
--- a/modules/local/filter_len.nf
+++ b/modules/local/filter_len.nf
@@ -8,8 +8,8 @@ process FILTER_LEN {
         'biocontainers/bioconductor-biostrings:2.58.0--r40h037d062_0' }"
 
     input:
-    path(fasta)
-    path(table)
+    path(fasta, stageAs: 'input/*')
+    path(table, stageAs: 'input/*')
 
     output:
     path( "stats.len.tsv" )      , emit: stats

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -579,8 +579,9 @@ workflow AMPLISEQ {
         }
         ITSX_CUTASV ( ch_full_fasta, outfile )
         ch_versions = ch_versions.mix(ITSX_CUTASV.out.versions)
-        FILTER_LEN_ITSX ( ITSX_CUTASV.out.fasta, [] )
+        FILTER_LEN_ITSX ( ITSX_CUTASV.out.fasta, ch_dada2_asv.ifEmpty( [] ) )
         ch_fasta = FILTER_LEN_ITSX.out.fasta
+        ch_dada2_asv = FILTER_LEN_ITSX.out.asv
     }
 
     //


### PR DESCRIPTION
Closes https://github.com/nf-core/ampliseq/issues/857

ITSx removed some sequences without explicitly stating so, but the abundance table remained untouched. Now the abundance table is filtered based on the sequences that pass ITSx.


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
