### PR TITLE
Allow multiregion analysis without alignment file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-- [#871](https://github.com/nf-core/ampliseq/pull/871) - Multi-region analysis is now easier with cusom databases. No alignment file of the reference sequences are needed.
+- [#871](https://github.com/nf-core/ampliseq/pull/871) - Multi-region analysis is now easier with custom databases. No alignment file of the reference sequences are needed.
 
 | **Parameter**             | **Description**                                                                                         |
 | ------------------------- | ------------------------------------------------------------------------------------------------------- |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [# #TODO ](https://github.com/nf-core/ampliseq/pull/ #TODO ) - Multi-region analysis is now easier with cusom databases. No alignment file of the reference sequences are needed.
+
+| **Parameter**             | **Description**                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **sidle_ref_tax_custom**  | Changed: Previously three files, now one file: path to reference taxonomy strings                       |
+| **sidle_ref_seq_custom**  | New: Path to reference taxonomy sequences in fasta format                                               |
+| **sidle_ref_aln_custom**  | New: Path to multiple sequence alignment of reference taxonomy sequences in fasta format                |
+| **sidle_ref_degenerates** | New: Only effective with `--sidle_ref_tax_custom`, filter reference sequences, default: 5               |
+| **sidle_ref_cleaning**    | New: Arguments regarding ad-hoc cleaning, with `--sidle_ref_tax_custom` default is '--p-database silva' |
+
 ### `Fixed`
 
 ### `Dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-- [# #TODO ](https://github.com/nf-core/ampliseq/pull/ #TODO ) - Multi-region analysis is now easier with cusom databases. No alignment file of the reference sequences are needed.
+- [#871](https://github.com/nf-core/ampliseq/pull/871) - Multi-region analysis is now easier with cusom databases. No alignment file of the reference sequences are needed.
 
 | **Parameter**             | **Description**                                                                                         |
 | ------------------------- | ------------------------------------------------------------------------------------------------------- |

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -286,8 +286,12 @@ process {
     }
 
     withName: SIDLE_DBFILT {
-        ext.args = { params.sidle_ref_taxonomy.startsWith("greengenes") ? '--p-num-degenerates 3' : '--p-num-degenerates 5' } // 3 for greengenes, 5 for SILVA 128
-        ext.args2 = { params.sidle_ref_taxonomy.startsWith("greengenes") ? '--p-exclude "p__;,k__;,mitochondria,chloroplast" --p-mode contains' : '--p-exclude "mitochondria,chloroplast" --p-mode contains' } // "p__;,k__;" for greengenes
+        ext.args = {
+            params.sidle_ref_tax_custom ? "--p-num-degenerates ${params.sidle_ref_degenerates}" :
+                params.sidle_ref_taxonomy.startsWith("greengenes") ? '--p-num-degenerates 3' : '--p-num-degenerates 5' } // 3 for greengenes, 5 for SILVA 128
+        ext.args2 = {
+            params.sidle_ref_tax_custom ? '--p-exclude "mitochondria,chloroplast" --p-mode contains' :
+                params.sidle_ref_taxonomy.startsWith("greengenes") ? '--p-exclude "p__;,k__;,mitochondria,chloroplast" --p-mode contains' : '--p-exclude "mitochondria,chloroplast" --p-mode contains' } // "p__;,k__;" for greengenes
         publishDir = [
             path: { "${params.outdir}/sidle/DB/1_prefiltering" },
             mode: params.publish_dir_mode,
@@ -361,7 +365,9 @@ process {
 
     withName: SIDLE_TAXRECON {
         ext.args = {
-            params.sidle_ref_taxonomy.startsWith("greengenes") ? '--p-database "greengenes"' :
+            params.sidle_ref_cleaning ?:
+                params.sidle_ref_tax_custom ? '--p-database "silva"' :
+                params.sidle_ref_taxonomy.startsWith("greengenes") ? '--p-database "greengenes"' :
                 params.sidle_ref_taxonomy.startsWith("silva") ? '--p-database "silva"' : '--p-database "none"'
             }
         publishDir = [

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -253,7 +253,7 @@ Instead of relying on one short amplicon, scaffolding multiple regions along a r
 
 For example, multiple variable regions of the 16S rRNA gene were sequenced with various primers and need to be unified. This leads to one unified abundance and taxonomy profile over all variable regions. However, ASV sequences are only available separately, there is no reconstruction of complete de-novo sequences feasible.
 
-Information about sequencing data via [`--input`](#samplesheet-input), region primers length information via [`--multiregion`](https://nf-co.re/ampliseq/parameters#multiregion), and a taxonomic database via [`--sidle_ref_taxonomy`](https://nf-co.re/ampliseq/parameters#sidle_ref_taxonomy) or [`--sidle_ref_tax_custom`](https://nf-co.re/ampliseq/parameters#sidle_ref_tax_custom) is required.
+Information about sequencing data via [`--input`](#samplesheet-input), region primers length information via [`--multiregion`](https://nf-co.re/ampliseq/parameters#multiregion), and a taxonomic database via [`--sidle_ref_taxonomy`](https://nf-co.re/ampliseq/parameters#sidle_ref_taxonomy) or [`--sidle_ref_tax_custom`](https://nf-co.re/ampliseq/parameters#sidle_ref_tax_custom) with [`--sidle_ref_seq_custom`](https://nf-co.re/ampliseq/parameters#sidle_ref_seq_custom) is required.
 
 ```bash
 --input "samplesheet_multiregion.tsv"  --multiregion "regions_multiregion.tsv" --sidle_ref_taxonomy "silva=128"

--- a/nextflow.config
+++ b/nextflow.config
@@ -136,6 +136,10 @@ params {
     kraken2_confidence       = 0.0
     sidle_ref_taxonomy       = null
     sidle_ref_tax_custom     = null
+    sidle_ref_seq_custom     = null
+    sidle_ref_aln_custom     = null
+    sidle_ref_degenerates    = 5
+    sidle_ref_cleaning       = null
     sidle_ref_tree_custom    = null
 
     // MultiQC options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -63,7 +63,7 @@
                     "pattern": "^\\S+\\.(tsv|csv|yml|yaml|txt)$",
                     "fa_icon": "fas fa-dna",
                     "description": "Path to multi-region definition sheet, for multi-region analysis with Sidle",
-                    "help_text": "Path to file with information about sequenced regions, either tab-separated (.tsv), comma-separated (.csv), or in YAML format (.yml/.yaml). This initiates scaffolding multiple regions along a reference.\n\nThe file must have four headers: \n- `region`: Unique region identifier\n- `region_length`: Minimal length of region\n- `FW_primer`: Forward primer sequence\n- `RV_primer`: Reverse primer sequence\n\nFor more details check the usage documentation.\n\nRelated parameters are:\n- `--sidle_ref_taxonomy` to select the reference taxonomic database\n- `--sidle_ref_tax_custom` for custom reference taxonomic database files\n- `--sidle_ref_tree_custom` for custom phylogenetic tree of reference taxonomic database",
+                    "help_text": "Path to file with information about sequenced regions, either tab-separated (.tsv), comma-separated (.csv), or in YAML format (.yml/.yaml). This initiates scaffolding multiple regions along a reference.\n\nThe file must have four headers: \n- `region`: Unique region identifier\n- `region_length`: Minimal length of region\n- `FW_primer`: Forward primer sequence\n- `RV_primer`: Reverse primer sequence\n\nFor more details check the usage documentation.\n\nRelated parameters are:\n- `--sidle_ref_taxonomy` to select the reference taxonomic database\n- `--sidle_ref_tax_custom`, `--sidle_ref_seq_custom` and related parameters for custom reference taxonomic database files",
                     "schema": "assets/schema_multiregion.json"
                 },
                 "outdir": {
@@ -627,8 +627,8 @@
                 },
                 "sidle_ref_tax_custom": {
                     "type": "string",
-                    "help_text": "Use with `--sidle_ref_seq_custom`. Consider also setting `--sidle_ref_aln_custom` and `--sidle_ref_tree_custom`. Example usage: `--sidle_ref_tax_custom 'taxonomy_99_taxonomy.txt'`",
-                    "description": "Path to reference taxonomy strings (*.txt)",
+                    "help_text": "Use with `--sidle_ref_seq_custom`. Consider also setting `--sidle_ref_aln_custom` and `--sidle_ref_tree_custom`. The taxonomy file must be headerless and follow the format of `qiime tools import`'s `HeaderlessTSVTaxonomyFormat`. Example usage: `--sidle_ref_tax_custom 'taxonomy_99_taxonomy.txt'`",
+                    "description": "Path to reference taxonomy strings (headerless, *.txt)",
                     "pattern": "^.*\\.txt$"
                 },
                 "sidle_ref_seq_custom": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -627,14 +627,39 @@
                 },
                 "sidle_ref_tax_custom": {
                     "type": "string",
-                    "help_text": "Consider also setting `--sidle_ref_tree_custom`. Example usage: `--sidle_ref_tax_custom 'rep_set_99.fasta,rep_set_aligned_99.fasta,taxonomy_99_taxonomy.txt'`",
-                    "description": "Comma separated paths to three files: reference taxonomy sequences (*.fasta), reference taxonomy strings (*.txt)"
+                    "help_text": "Use with `--sidle_ref_seq_custom`. Consider also setting `--sidle_ref_aln_custom` and `--sidle_ref_tree_custom`. Example usage: `--sidle_ref_tax_custom 'taxonomy_99_taxonomy.txt'`",
+                    "description": "Path to reference taxonomy strings (*.txt)",
+                    "pattern": "^.*\\.txt$"
+                },
+                "sidle_ref_seq_custom": {
+                    "type": "string",
+                    "help_text": "Use with `--sidle_ref_tax_custom`. Example usage: `--sidle_ref_seq_custom 'rep_set_99.fasta'`",
+                    "description": "Path to reference taxonomy sequences in fasta format",
+                    "pattern": "^.*\\.(fasta|fas|fna|fa|ffn)$"
+                },
+                "sidle_ref_aln_custom": {
+                    "type": "string",
+                    "help_text": "May be used with `--sidle_ref_tax_custom`. Allows sequence reconstruction. Example usage: `--sidle_ref_aln_custom 'rep_set_aligned_99.fasta'`",
+                    "description": "Path to multiple sequence alignment of reference taxonomy sequences in fasta format",
+                    "pattern": "^.*\\.(fasta|fas|fna|fa|ffn)$"
                 },
                 "sidle_ref_tree_custom": {
                     "type": "string",
-                    "help_text": "Overwrites tree chosen by `--sidle_ref_taxonomy`",
+                    "help_text": "Use with `--sidle_ref_aln_custom`. Recommended with `--sidle_ref_tax_custom`. Allows phylogenetic tree reconstruction and therefore diversity analysis. Overwrites tree chosen by `--sidle_ref_taxonomy`",
                     "description": "Path to SIDLE reference taxonomy tree (*.qza)",
                     "pattern": "^.*\\.qza$"
+                },
+                "sidle_ref_degenerates": {
+                    "type": "integer",
+                    "default": 5,
+                    "min": 0,
+                    "help_text": "Only effective with `--sidle_ref_tax_custom`. Recommended with `--sidle_ref_tax_custom`, default 5 was recommended with SILVA 128. Sets `--p-num-degenerates` for `qiime rescript cull-seqs`.",
+                    "description": "Exclude reference sequences with more than this much degenerates"
+                },
+                "sidle_ref_cleaning": {
+                    "type": "string",
+                    "help_text": "Recommended with `--sidle_ref_tax_custom`, default '--p-database silva' was recommended with SILVA 128. Therefore, ad-hoc database cleaning will be performed automatically, specifically with regard to the `define-missing` and `ambiguity-handling` parameters.  Overwrites recommended settings for database chosen by `--sidle_ref_taxonomy`",
+                    "description": "Arguments for `qiime sidle reconstruct-taxonomy` regarding ad-hoc cleaning"
                 }
             }
         },

--- a/subworkflows/local/sidle_wf.nf
+++ b/subworkflows/local/sidle_wf.nf
@@ -36,10 +36,10 @@ workflow SIDLE_WF {
         ch_db_alignedsequences = FORMAT_TAXONOMY_SIDLE.out.alnseq
         ch_db_taxonomy = FORMAT_TAXONOMY_SIDLE.out.tax
     } else {
-        //input from params.sidle_ref_tax_custom: it[0] = fasta = ch_db_sequences, it[1] = aligned fasta = ch_db_alignedsequences, it[2] = taxonomy txt = ch_db_taxonomy
-        ch_db_sequences = ch_sidle_ref_taxonomy.map{ it[0] }
-        ch_db_alignedsequences = ch_sidle_ref_taxonomy.map{ it[1] }
-        ch_db_taxonomy = ch_sidle_ref_taxonomy.map{ it[2] }
+        //input from params.sidle_ref_tax_custom: it[0] = taxonomy txt = ch_db_taxonomy, it[1] = fasta = ch_db_sequences, it[2] = aligned fasta = ch_db_alignedsequences
+        ch_db_taxonomy = ch_sidle_ref_taxonomy.map{ it[0] }
+        ch_db_sequences = ch_sidle_ref_taxonomy.map{ it[1] }
+        ch_db_alignedsequences = params.sidle_ref_aln_custom ? ch_sidle_ref_taxonomy.map{ it[2] } : Channel.empty()
     }
     SIDLE_INDB ( ch_db_sequences, ch_db_taxonomy )
     ch_sidle_versions = ch_sidle_versions.mix(SIDLE_INDB.out.versions)

--- a/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
@@ -271,7 +271,13 @@ def validateInputParameters() {
     // When multi-region analysis is used, some parameter combinations are required or not allowed:
     if ( params.multiregion ) {
         if ( !params.sidle_ref_taxonomy && !params.sidle_ref_tree_custom ) {
-            log.warn "Missing parameter: Either use `--sidle_ref_taxonomy` or `--sidle_ref_tree_custom` to get (unified) taxonomic classifications"
+            log.warn "Missing parameter: Either use `--sidle_ref_taxonomy` or `--sidle_ref_tree_custom` to perform diversity analysis"
+        }
+        if ( !params.sidle_ref_taxonomy && !params.sidle_ref_aln_custom ) {
+            log.warn "Missing parameter: Either use `--sidle_ref_taxonomy` or `--sidle_ref_aln_custom` to reconstruct sequences/fragments and with `--sidle_ref_tree_custom` the phylogenetic tree"
+        }
+        if ( !params.sidle_ref_taxonomy && ( !params.sidle_ref_tax_custom || !params.sidle_ref_seq_custom ) ) {
+            error("Missing parameter: Either use `--sidle_ref_taxonomy` or `--sidle_ref_tax_custom` and `--sidle_ref_seq_custom`")
         }
         if ( (params.dada_ref_tax_custom || params.dada_ref_taxonomy) && !params.skip_dada_taxonomy ) {
             error("Incompatible parameters: Multiple region analysis with `--multiregion` does not work with `--dada_ref_tax_custom`, `--dada_ref_taxonomy`")

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -15,18 +15,16 @@ if (params.classifier) {
 } else { ch_qiime_classifier = Channel.empty() }
 
 if (params.sidle_ref_tax_custom) {
-    if ("${params.sidle_ref_tax_custom}".contains(",")) {
-        sidle_ref_paths = "${params.sidle_ref_tax_custom}".split(",")
-        if (sidle_ref_paths.length != 3) {
-            error "--sidle_ref_tax_custom exately three filepaths separated by a comma (fasta, aligned fasta, taxonomy). Please review input."
-        }
-        ch_sidle_ref_taxonomy = Channel.fromPath( Arrays.asList(sidle_ref_paths), checkIfExists: true )
-    } else {
-        error "--sidle_ref_tax_custom accepts exately three filepaths separated by a comma. Please review input."
-    }
-    val_sidle_ref_taxonomy = "user"
+    //custom ref taxonomy input from params.sidle_ref_tax_custom & params.sidle_ref_seq_custom & [optionallly] params.sidle_ref_aln_custom
+    //NO INPUT IS OPTIONAL: ch_sidle_ref_taxonomy = Channel.fromPath( Arrays.asList( params.sidle_ref_tax_custom, params.sidle_ref_seq_custom, params.sidle_ref_aln_custom ), checkIfExists: true )
+    Channel.fromPath("${params.sidle_ref_tax_custom}", checkIfExists: true)
+        .combine( Channel.fromPath("${params.sidle_ref_seq_custom}", checkIfExists: true) )
+        .combine( params.sidle_ref_aln_custom ? Channel.fromPath("${params.sidle_ref_aln_custom}", checkIfExists: true) : Channel.of("EMPTY") )
+        .set{ ch_sidle_ref_taxonomy }
     ch_sidle_ref_taxonomy_tree = params.sidle_ref_tree_custom ? Channel.fromPath("${params.sidle_ref_tree_custom}", checkIfExists: true) : Channel.empty()
+    val_sidle_ref_taxonomy = "user"
 } else if (params.sidle_ref_taxonomy) {
+    //standard ref taxonomy input from params.sidle_ref_taxonomy & conf/ref_databases.config
     ch_sidle_ref_taxonomy = Channel.fromList( params.sidle_ref_databases[params.sidle_ref_taxonomy]["file"] ).map { file(it) }
     ch_sidle_ref_taxonomy_tree = params.sidle_ref_tree_custom ? Channel.fromPath("${params.sidle_ref_tree_custom}", checkIfExists: true) :
         params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ? Channel.fromList( params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ).map { file(it) } : Channel.empty()

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -16,7 +16,6 @@ if (params.classifier) {
 
 if (params.sidle_ref_tax_custom) {
     //custom ref taxonomy input from params.sidle_ref_tax_custom & params.sidle_ref_seq_custom & [optionallly] params.sidle_ref_aln_custom
-    //NO INPUT IS OPTIONAL: ch_sidle_ref_taxonomy = Channel.fromPath( Arrays.asList( params.sidle_ref_tax_custom, params.sidle_ref_seq_custom, params.sidle_ref_aln_custom ), checkIfExists: true )
     Channel.fromPath("${params.sidle_ref_tax_custom}", checkIfExists: true)
         .combine( Channel.fromPath("${params.sidle_ref_seq_custom}", checkIfExists: true) )
         .combine( params.sidle_ref_aln_custom ? Channel.fromPath("${params.sidle_ref_aln_custom}", checkIfExists: true) : Channel.of("EMPTY") )


### PR DESCRIPTION
Reorganization of input for custom databases for SIDLE, i.e. multi-region analysis such as 5R.
Now the multiple sequence alignment file for reference sequences has its own parameter and is optional instead of required. That allows much easier usage of custom reference databases, because only taxonomic strings and reference sequences are required.
For this, `sidle_ref_tax_custom` was changed so that it accepts only the taxonomy file instead of requiring 3 files. New params are `sidle_ref_seq_custom` and `sidle_ref_aln_custom` that accept the other 2 files that were previously required by `sidle_ref_tax_custom`. `sidle_ref_degenerates` and `sidle_ref_cleaning` allow easier manipulation of the custom database than before.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
