### PR TITLE
pulling and updated vsearch/cluster module from nf-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#869](https://github.com/nf-core/ampliseq/issues/869) Pulled the updated vsearch/clusters module from nf-core to fix a bug where a wildcard expansion trigging an arguments-too-long error.
+
 ### `Dependencies`
 
 ### `Removed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#869](https://github.com/nf-core/ampliseq/issues/869) Pulled the updated vsearch/clusters module from nf-core to fix a bug where a wildcard expansion trigging an arguments-too-long error.
+- [#876](https://github.com/nf-core/ampliseq/pull/876) Pulled the updated vsearch/clusters module from nf-core to fix a bug where a wildcard expansion trigging an arguments-too-long error.
 
 ### `Dependencies`
 

--- a/modules.json
+++ b/modules.json
@@ -89,7 +89,7 @@
                     },
                     "vsearch/cluster": {
                         "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "git_sha": "f10b2465108305544f708389324480db1b5e9f34",
                         "installed_by": ["modules"]
                     },
                     "vsearch/sintax": {

--- a/modules/nf-core/vsearch/cluster/environment.yml
+++ b/modules/nf-core/vsearch/cluster/environment.yml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
   - bioconda

--- a/modules/nf-core/vsearch/cluster/main.nf
+++ b/modules/nf-core/vsearch/cluster/main.nf
@@ -60,7 +60,7 @@ process VSEARCH_CLUSTER {
 
     if [[ $args3 == "--clusters" ]]
     then
-        gzip -n ${prefix}.${out_ext}*
+        find . -type f -name \"${prefix}.${out_ext}*[0-9]\" | xargs gzip -n
     elif [[ $args3 != "--samout" ]]
     then
         gzip -n ${prefix}.${out_ext}

--- a/modules/nf-core/vsearch/cluster/tests/tags.yml
+++ b/modules/nf-core/vsearch/cluster/tests/tags.yml
@@ -1,2 +1,0 @@
-vsearch/cluster:
-  - "modules/nf-core/vsearch/cluster/**"


### PR DESCRIPTION
Fixing bug https://github.com/nf-core/ampliseq/issues/869 

I have pulled the updated nf-core/modules vsearc/cluster module into the dev branch of ampliseq. 
This should fix an arguments too long error froma wildcard expansion.

## PR checklist

- [ yes] This comment contains a description of changes (with reason).
- [ n/a] If you've fixed a bug or added code that should be tested, add tests!
- [ n/a] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ n/a] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ yes] Make sure your code lints (`nf-core pipelines lint`).
- [ yes] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ yes] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ n/a] Usage Documentation in `docs/usage.md` is updated.
- [ n/a] Output Documentation in `docs/output.md` is updated.
- [ yes] `CHANGELOG.md` is updated.
- [ n/a] `README.md` is updated (including new tool citations and authors/contributors).
