### PR TITLE
Downgrade nf-schema from 2.3.0 to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#872](https://github.com/nf-core/ampliseq/pull/872) - Follow nextflow's strict syntax
 - [#876](https://github.com/nf-core/ampliseq/pull/876) - Pulled the updated vsearch/clusters module from nf-core to fix a bug where a wildcard expansion trigging an arguments-too-long error.
+- [#878](https://github.com/nf-core/ampliseq/pull/878) - Downgraded nf-schema from 2.3.0 to 2.2.0 due to incompatibilities with nextflow stable versions 25.05 and newer
 
 ### `Dependencies`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -417,7 +417,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.3.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.2.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {


### PR DESCRIPTION
The recent nextflow edge release is not compatible with nf-schema versions 2.3.0 - 2.4.1 but with 2.2.0. These breaking changes are going to be in at least one upcoming nextflow release. This PR downgrades nf-schema from 2.3.0 to 2.2.0.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
