### PR TITLE
fix DADA2_SPLITREGIONS with one sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#893](https://github.com/nf-core/ampliseq/pull/893),[#896](https://github.com/nf-core/ampliseq/pull/896) - Template update for nf-core/tools version 3.3.1
+- [#897](https://github.com/nf-core/ampliseq/pull/897) - Allow multiple region analysis with one sample
 
 ### `Dependencies`
 

--- a/modules/local/dada2_splitregions.nf
+++ b/modules/local/dada2_splitregions.nf
@@ -43,7 +43,7 @@ process DADA2_SPLITREGIONS {
     }
 
     # filter rows with only 0, occurring because many samples were removed
-    df <- df[as.logical(rowSums(df[,2:(ncol(df)-1)] != 0)), ]
+    df <- df[as.logical(rowSums(df[,2:(ncol(df)-1), drop = FALSE] != 0)), ]
 
     # Write file with ASV abdundance and sequences to file
     write.table(df, file = "DADA2_table_${suffix}.tsv", sep = "\\t", row.names = FALSE, quote = FALSE, na = '')


### PR DESCRIPTION
Closes https://github.com/nf-core/ampliseq/issues/891

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
