### PR TITLE
Fix split_regions error with only single sample

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -45,7 +45,7 @@ process {
         time   = { check_max( 36.h  * task.attempt, 'time'    ) }
     }
     withLabel:process_long {
-        time   = { check_max( 48.h  * task.attempt, 'time'    ) }
+        time   = { check_max( 10.h  * task.attempt, 'time'    ) }
     }
     withLabel:single_cpu {
         cpus   = { check_max( 1                  , 'cpus'    ) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -179,7 +179,7 @@ process {
         ext.seed = "${params.seed}"
         ext.prefix = { meta.region ? "region-${meta.region}_run-${meta.run}" : "${meta.run}" }
         ext.args = [
-            'nbases = 1e8, nreads = NULL, randomize = TRUE, MAX_CONSIST = 10, OMEGA_C = 0, qualityType = "Auto"',
+            'nbases = 1e8, nreads = NULL, randomize = FALSE, MAX_CONSIST = 10, OMEGA_C = 0, qualityType = "Auto"',
             params.pacbio ? "errorEstimationFunction = PacBioErrfun" : "errorEstimationFunction = loessErrfun"
         ].join(',').replaceAll('(,)*$', "")
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -179,7 +179,7 @@ process {
         ext.seed = "${params.seed}"
         ext.prefix = { meta.region ? "region-${meta.region}_run-${meta.run}" : "${meta.run}" }
         ext.args = [
-            'nbases = 1e8, nreads = NULL, randomize = FALSE, MAX_CONSIST = 10, OMEGA_C = 0, qualityType = "Auto"',
+            'nbases = 1e8, nreads = NULL, randomize = TRUE, MAX_CONSIST = 10, OMEGA_C = 0, qualityType = "Auto"',
             params.pacbio ? "errorEstimationFunction = PacBioErrfun" : "errorEstimationFunction = loessErrfun"
         ].join(',').replaceAll('(,)*$', "")
         publishDir = [

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -1,6 +1,6 @@
 process DADA2_ADDSPECIES {
     tag "${taxtable},${database}"
-    label 'process_high'
+    label 'process_medium'
     label 'single_cpu'
 
     conda "bioconda::bioconductor-dada2=1.30.0"

--- a/modules/local/dada2_denoising.nf
+++ b/modules/local/dada2_denoising.nf
@@ -1,7 +1,7 @@
 process DADA2_DENOISING {
     tag "$meta.run"
     label 'process_medium'
-    label 'process_long'
+    label 'process_medium'
 
     conda "bioconda::bioconductor-dada2=1.30.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/dada2_splitregions.nf
+++ b/modules/local/dada2_splitregions.nf
@@ -46,7 +46,7 @@ process DADA2_SPLITREGIONS {
     }
 
     # filter rows with only 0, occurring because many samples were removed
-    df <- df[as.logical(rowSums(df[,2:(ncol(df)-1)] != 0)), ]
+    df <- df[as.logical(rowSums(df[,2:(ncol(df)-1), drop=FALSE] != 0)), ]
 
     # Write file with ASV abdundance and sequences to file
     write.table(df, file = "DADA2_table_${suffix}.tsv", sep = "\\t", row.names = FALSE, quote = FALSE, na = '')

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -1,6 +1,6 @@
 process DADA2_TAXONOMY {
     tag "${fasta},${database}"
-    label 'process_high'
+    label 'process_medium'
 
     conda "bioconda::bioconductor-dada2=1.30.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/format_pplacetax.nf
+++ b/modules/local/format_pplacetax.nf
@@ -1,6 +1,6 @@
 process FORMAT_PPLACETAX {
     tag "${tax.baseName}"
-    label 'process_high'
+    label 'process_medium'
 
     conda "bioconda::bioconductor-dada2=1.30.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/qiime2_ancom_asv.nf
+++ b/modules/local/qiime2_ancom_asv.nf
@@ -2,7 +2,7 @@ process QIIME2_ANCOM_ASV {
     tag "${table.baseName}"
     label 'process_medium'
     label 'single_cpu'
-    label 'process_long'
+    label 'process_medium'
     label 'error_ignore'
 
     container "qiime2/core:2023.7"

--- a/modules/local/qiime2_classify.nf
+++ b/modules/local/qiime2_classify.nf
@@ -1,6 +1,6 @@
 process QIIME2_CLASSIFY {
     tag "${repseq},${trained_classifier}"
-    label 'process_high'
+    label 'process_medium'
 
     container "qiime2/core:2023.7"
 

--- a/modules/local/qiime2_train.nf
+++ b/modules/local/qiime2_train.nf
@@ -1,6 +1,6 @@
 process QIIME2_TRAIN {
     tag "${meta.FW_primer}-${meta.RV_primer}"
-    label 'process_high'
+    label 'process_medium'
     label 'single_cpu'
 
     container "qiime2/core:2023.7"

--- a/modules/nf-core/epang/place/main.nf
+++ b/modules/nf-core/epang/place/main.nf
@@ -1,6 +1,6 @@
 process EPANG_PLACE {
     tag "$meta.id"
-    label 'process_high'
+    label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/kraken2/kraken2/main.nf
+++ b/modules/nf-core/kraken2/kraken2/main.nf
@@ -1,6 +1,6 @@
 process KRAKEN2_KRAKEN2 {
     tag "$meta.id"
-    label 'process_high'
+    label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/mafft/main.nf
+++ b/modules/nf-core/mafft/main.nf
@@ -1,6 +1,6 @@
 process MAFFT {
     tag "$meta.id"
-    label 'process_high'
+    label 'process_medium'
 
     conda "bioconda::mafft=7.520"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
Single line change in Rscript.
With only one sample available the fixed line would drop data.frame format and rowSums throws an error. with "drop=FALSE" the data.frame format is retained. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
