### PR TITLE
Add truncq parameter for quality score-based read truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## nf-core/ampliseq version 2.15.0dev
 
 ### `Added`
+- [#909](https://github.com/nf-core/ampliseq/pull/909) - Parameter `--truncq` allows read truncation by quality score, where each read is truncated at the first instance of a quality score less than or equal to `truncq` (default value is 2). This quality score-based truncation occurs before read length truncation. If `--trunc_qmin` and `--trunc_rmin` are used to automatically calculate the values for `trunclenf` and `trunclenr` used for read length truncation, those calculations are based on the read metrics before quality score-based truncation (using `truncq`) is performed. `truncq` is passed directly as `truncQ` into DADA2's [filterAndTrim](https://rdrr.io/bioc/dada2/man/filterAndTrim.html) method.
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## nf-core/ampliseq version 2.15.0dev
 
 ### `Added`
+
 - [#909](https://github.com/nf-core/ampliseq/pull/909) - Parameter `--truncq` allows read truncation by quality score, where each read is truncated at the first instance of a quality score less than or equal to `truncq` (default value is 2). This quality score-based truncation occurs before read length truncation. If `--trunc_qmin` and `--trunc_rmin` are used to automatically calculate the values for `trunclenf` and `trunclenr` used for read length truncation, those calculations are based on the read metrics before quality score-based truncation (using `truncq`) is performed. `truncq` is passed directly as `truncQ` into DADA2's [filterAndTrim](https://rdrr.io/bioc/dada2/man/filterAndTrim.html) method.
 
 ### `Changed`

--- a/assets/report_template.Rmd
+++ b/assets/report_template.Rmd
@@ -30,6 +30,7 @@ params:
     barplot: FALSE
     abundance_tables: FALSE
     alpha_rarefaction: FALSE
+    truncq: ""
     trunclenf: ""
     trunclenr: ""
     max_ee: ""
@@ -299,6 +300,9 @@ Additional quality filtering can improve sequence recovery.
 Often it is advised trimming the last few nucleotides to avoid less well-controlled errors that can arise there.
 "))
 
+if (params$truncq) {
+    cat("Each read was truncated at the first instance of a quality score less than or equal to ", params$truncq, ". ", sep = "")
+}
 if (params$trunc_qmin) {
     f_and_tr_args <- readLines(params$dada_filtntrim_args)
     trunc_len <- strsplit(gsub(".*truncLen = c\\((.+)\\),maxN.*", "\\1",
@@ -313,7 +317,7 @@ if (params$trunc_qmin) {
         "forward reads at ", tr_len_f, " bp and reverse ",
         "reads at ", tr_len_r, " bp, reads shorter than this were discarded. ", sep = "")
 } else if (params$trunclenf == "null" && params$trunclenr == "null") {
-    cat("Reads were not trimmed. ")
+    cat("Reads were not trimmed to a specific length. ")
 } else if (params$trunclenf != 0 && params$trunclenr != 0) {
     cat("Forward reads were trimmed at ", params$trunclenf,
             " bp and reverse reads were trimmed at ", params$trunclenr,
@@ -1700,6 +1704,9 @@ if ( params$dada_sample_inference == "independent" ) {
 
 cat("with DADA2 ([Callahan et al., 2016](https://pubmed.ncbi.nlm.nih.gov/27214047/)) to eliminate PhiX contamination, ")
 
+if (params$truncq) {
+    cat("truncate reads at the first instance of a quality score less than or equal to ", params$truncq, ", ", sep = "")
+}
 if (params$trunc_qmin) {
     cat("trim reads (before median quality drops below ", params$trunc_qmin,
         " and at least ",params$trunc_rmin*100, "% of reads are retained; ",

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -139,8 +139,9 @@ process {
     max_len = params.max_len ?: "Inf"
     withName: DADA2_FILTNTRIM {
         ext.args = [
-            'maxN = 0, truncQ = 2, trimRight = 0, minQ = 0, rm.lowcomplex = 0, orient.fwd = NULL, matchIDs = FALSE, id.sep = "\\\\s", id.field = NULL, n = 1e+05, OMP = TRUE',
+            'maxN = 0, trimRight = 0, minQ = 0, rm.lowcomplex = 0, orient.fwd = NULL, matchIDs = FALSE, id.sep = "\\\\s", id.field = NULL, n = 1e+05, OMP = TRUE',
             "qualityType = \"${params.quality_type}\"",
+            "truncQ = ${params.truncq}",
             params.pacbio || params.iontorrent || params.single_end ? "maxEE = ${params.max_ee}" : "maxEE = c(${params.max_ee}, ${params.max_ee})",
             params.pacbio ? "trimLeft = 0, minLen = ${params.min_len}, maxLen = $max_len, rm.phix = FALSE" :
                 params.iontorrent ? "trimLeft = 15, minLen = ${params.min_len}, maxLen = $max_len, rm.phix = TRUE" :

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,6 +13,7 @@
     - [Samplesheet input](#samplesheet-input)
     - [ASV/OTU fasta input](#asvotu-fasta-input)
     - [Direct FASTQ input](#direct-fastq-input)
+  - [Regions of variable length e.g. ITS](#regions-of-variable-length-eg-its)
   - [Taxonomic classification](#taxonomic-classification)
   - [Multiple region analysis with Sidle](#multiple-region-analysis-with-sidle)
   - [Metadata](#metadata)
@@ -208,6 +209,10 @@ Please note the following additional requirements:
 - To run single-end data you must additionally specify `--single_end` and `--extension` may not include curly brackets `{}`
 - Sample identifiers are extracted from file names, i.e. the string before the first underscore `_`, these must be unique (also across sequencing runs) and only contain letters, numbers or underscores
 - If your data is scattered, produce a sample sheet
+
+### Regions of variable length (e.g. ITS)
+
+Special considerations should be made when pre-processing reads for regions of variable length, e.g. ITS for fungal barcoding. For ITS regions e.g. ITS1 or ITS2, it is recommended to use the `--illumina_pe_its` parameter for paired-end Illumina reads, which disables fixed-length read truncation. Also consider adjusting `--truncq` to a value higher than the default value of 2 if you find that a high proportion of reads is excluded by DADA2 filtering.
 
 ### Taxonomic classification
 

--- a/modules/local/summary_report.nf
+++ b/modules/local/summary_report.nf
@@ -86,6 +86,7 @@ process SUMMARY_REPORT  {
         cutadapt_summary ?
             params.retain_untrimmed ? "flag_retain_untrimmed=TRUE,cutadapt_summary='$cutadapt_summary'" :
             "cutadapt_summary='$cutadapt_summary'" : "",
+        "truncq=$params.truncq",
         find_truncation_values ? "trunc_qmin=$params.trunc_qmin,trunc_rmin=$params.trunc_rmin" : "",
         "trunclenf='$params.trunclenf'",
         "trunclenr='$params.trunclenr'",

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,6 +29,7 @@ params {
     trunc_rmin                                = 0.75
     trunclenf                                 = null
     trunclenr                                 = null
+    truncq                                    = 2
     max_ee                                    = 2
     max_len                                   = null
     ignore_failed_filtering                   = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -203,6 +203,13 @@
             "description": "Read trimming and quality filtering is supposed to reduce spurious results and aid error correction",
             "default": "",
             "properties": {
+                "truncq": {
+                    "type": "integer",
+                    "default": 2,
+                    "fa_icon": "fas fa-greater-than-equal",
+                    "minimum": 0,
+                    "description": "Truncate each read at the first instance of a quality score less than or equal to truncq. Applied before read length truncation."
+                },
                 "trunclenf": {
                     "type": "integer",
                     "description": "DADA2 read truncation value for forward strand, set this to 0 for no truncation",
@@ -219,7 +226,7 @@
                     "type": "integer",
                     "default": 25,
                     "description": "If --trunclenf and --trunclenr are not set, these values will be automatically determined using this median quality score",
-                    "help_text": "Automatically determine `--trunclenf` and `--trunclenr` before the median quality score drops below `--trunc_qmin`. The fraction of reads retained is defined by `--trunc_rmin`, which might override the quality cutoff.\n\nFor example:\n\n```bash\n--trunc_qmin 35\n```\n\nPlease note:\n\n1. The code choosing `--trunclenf` and `--trunclenr` using `--trunc_qmin` automatically cannot take amplicon length or overlap requirements for merging into account, therefore use with caution.\n2. A minimum value of 25 is recommended. However, high quality data with a large paired sequence overlap might justify a higher value (e.g. 35). Also, very low quality data might require a lower value.\n3. If the quality cutoff is too low to include a certain fraction of reads that is specified by `--trunc_rmin` (e.g. 0.75 means at least 75% percent of reads are retained), a lower cutoff according to `--trunc_rmin` superseeds the quality cutoff.",
+                    "help_text": "Automatically determine `--trunclenf` and `--trunclenr` before the median quality score drops below `--trunc_qmin`. The fraction of reads retained is defined by `--trunc_rmin`, which might override the quality cutoff.\n\nFor example:\n\n```bash\n--trunc_qmin 35\n```\n\nPlease note:\n\n1. The code choosing `--trunclenf` and `--trunclenr` using `--trunc_qmin` automatically cannot take amplicon length or overlap requirements for merging into account, therefore use with caution.\n2. A minimum value of 25 is recommended. However, high quality data with a large paired sequence overlap might justify a higher value (e.g. 35). Also, very low quality data might require a lower value.\n3. If the quality cutoff is too low to include a certain fraction of reads that is specified by `--trunc_rmin` (e.g. 0.75 means at least 75% percent of reads are retained), a lower cutoff according to `--trunc_rmin` superseeds the quality cutoff.\n4. The calculations for the values of `--trunclenf` and `--trunclenr` are made before any quality score-based read truncation (using `--truncq`) is performed.",
                     "fa_icon": "fas fa-greater-than-equal"
                 },
                 "trunc_rmin": {

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -202,7 +202,7 @@ workflow AMPLISEQ {
     trunclenr = params.trunclenr ?: 0
     if ( !single_end && !params.illumina_pe_its && (params.trunclenf == null || params.trunclenr == null) && !params.input_fasta ) {
         find_truncation_values = true
-        log.warn "No DADA2 cutoffs were specified (`--trunclenf` & `--trunclenr`), therefore reads will be truncated where median quality drops below ${params.trunc_qmin} (defined by `--trunc_qmin`) but at least a fraction of ${params.trunc_rmin} (defined by `--trunc_rmin`) of the reads will be retained.\nThe chosen cutoffs do not account for required overlap for merging, therefore DADA2 might have poor merging efficiency or even fail.\n"
+        log.warn "No DADA2 read truncation cutoffs were specified (`--trunclenf` & `--trunclenr`), therefore reads will be truncated where median quality drops below ${params.trunc_qmin} (defined by `--trunc_qmin`) but at least a fraction of ${params.trunc_rmin} (defined by `--trunc_rmin`) of the reads will be retained.\nThe chosen cutoffs do not account for required overlap for merging, therefore DADA2 might have poor merging efficiency or even fail.\nThe cutoffs are chosen before any quality score-based read truncation (using `--truncq`) is performed.\n"
     } else { find_truncation_values = false }
 
     // save params to values to be able to overwrite it


### PR DESCRIPTION
<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] ~~If you've fixed a bug or added code that should be tested, add tests!~~ I don't think this warrants an addition of an automated test.
- [ ] ~~If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)~~ Did not add a new tool
- [ ] ~~If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.~~ N/A
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] ~~Usage Documentation in `docs/usage.md` is updated.~~ No relevant docs in `docs/usage.md`. Other relevant docs are updated.
- [ ] ~~Output Documentation in `docs/output.md` is updated.~~ No relevant docs in `docs/output.md`. Other relevant docs are updated.
- [x] `CHANGELOG.md` is updated.
- [ ] ~~`README.md` is updated (including new tool citations and authors/contributors).~~ N/A


Adds a parameter,`--truncq`, that allows read truncation by quality score, where each read is truncated at the first instance of a quality score less than or equal to `truncq`. The parameter is equivalent to `truncQ` in DADA2's [filterAndTrim](https://rdrr.io/bioc/dada2/man/filterAndTrim.html) method. `truncq` defaults to 2, which was already the default in the DADA2_FILTNTRIM module (https://github.com/nf-core/ampliseq/blob/2.14.0/conf/modules.config#L142).
In the DADA2 filtering and trimming steps, the truncQ parameter is applied before read length truncation for both [single](https://github.com/benjjneb/dada2/blob/ab844341c47d8fe922c2e9dea849bf2167bcd445/R/filter.R#L669-L684) and [paired](https://github.com/benjjneb/dada2/blob/ab844341c47d8fe922c2e9dea849bf2167bcd445/R/filter.R#L1031-L1068) reads.

The primary rationale for adding this parameter is to better handle ITS amplicons, but this parameter is applicable for any kind of amplicon e.g. 16S. Since ITS amplicons are variable-length by fungal species, it doesn't make sense to truncate all the reads to the same length using the `--trunclenf` and `--trunclenr` parameters. Truncation by quality score is an option to apply consistent truncation criteria while not having to do fixed-length truncation. In our lab's experiments so far using `truncq` and setting `trunclenf` and `trunclenr` to 0 (turning read length truncation off), we've found that a `truncq` value between 2 and 8 works best for Illumina paired-end reads (MiSeq v3 600 cycle kit). For more context, see the [thread on the nf-core #ampliseq channel](https://nfcore.slack.com/archives/CEA7TBJGJ/p1741801358033799).

Quality score truncation (using `--truncq`) and read length truncation (using `--trunclenf` and `--trunclenr`) all happen as part of the same DADA2 filterAndTrim method. If `--trunc_qmin` and `---trunc_rmin` are used to automatically calculate `trunclenf` and `trunclenr`, these values are determined using the read metrics calculated on the read input before DADA2 filterAndTrim is called, and so before `truncq` is applied. I added documentation accordingly, but if I need to make any further changes or rework how `truncq` interacts with the other read truncation parameters, please let me know.

Since I made some minor additions to `summary_report.html`, here is an example of the text in the relevant sections of the report, after running with the test profile with this command: `nextflow run ../../ampliseq/main.nf -profile test,singularity --truncq 7 --outdir .` New portions are _italicized_.

> Additional quality filtering can improve sequence recovery. Often it is advised trimming the last few nucleotides to avoid less well-controlled errors that can arise there. _Each read was truncated at the first instance of a quality score less than or equal to 7._ Reads were trimmed to a specific length and the length cutoff was automatically determined by the median quality of all input reads. Reads were trimmed before median quality drops below 25 and at least 75% of reads are retained, resulting in a trim of forward reads at 230 bp and reverse reads at 229 bp, reads shorter than this were discarded. Reads with more than 2 expected errors were discarded. Read counts passing the filter are shown in section ‘Read counts per sample’ column ‘filtered’.

> Data quality was evaluated with FastQC (Andrews, 2010) and summarized with MultiQC (Ewels et al., 2016). Cutadapt (Marcel et al., 2011) trimmed primers and all untrimmed sequences were discarded. Sequences that did not contain primer sequences were considered artifacts. Less than 27.5% of the sequences were discarded per sample and a mean of 86.3% of the sequences per sample passed the filtering. Adapter and primer-free sequences were processed sample-wise (independent) with DADA2 (Callahan et al., 2016) to eliminate PhiX contamination, _truncate reads at the first instance of a quality score less than or equal to 7_, trim reads (before median quality drops below 25 and at least 75% of reads are retained; forward reads at 230 bp and reverse reads at 229 bp, reads shorter than this were discarded), discard reads with > 2 expected errors, correct errors, merge read pairs, and remove polymerase chain reaction (PCR) chimeras; ultimately, 347 amplicon sequencing variants (ASVs) were obtained across all samples. Between 55.34% and 59.02% reads per sample (average 57%) were retained. The ASV count table contained in total 4921 counts, at least 1030 and at most 1387 per sample (average 1230).