### PR TITLE
Add min boot param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#913](https://github.com/nf-core/ampliseq/pull/913) - Parameter `--dada_min_boot` allows the user to specify a minimum bootstrap confidence (out of 100 trials) for assigning a taxonomic level with DADA2's [assignTaxonomy](https://rdrr.io/bioc/dada2/man/assignTaxonomy.html) method.
 - [#909](https://github.com/nf-core/ampliseq/pull/909) - Parameter `--truncq` allows read truncation by quality score, where each read is truncated at the first instance of a quality score less than or equal to `truncq` (default value is 2). This quality score-based truncation occurs before read length truncation. If `--trunc_qmin` and `--trunc_rmin` are used to automatically calculate the values for `trunclenf` and `trunclenr` used for read length truncation, those calculations are based on the read metrics before quality score-based truncation (using `truncq`) is performed. `truncq` is passed directly as `truncQ` into DADA2's [filterAndTrim](https://rdrr.io/bioc/dada2/man/filterAndTrim.html) method.
 
 ### `Changed`

--- a/assets/report_template.Rmd
+++ b/assets/report_template.Rmd
@@ -42,6 +42,7 @@ params:
     filter_ssu: FALSE
     min_len_asv: ""
     max_len_asv: ""
+    dada_min_boot: ""
     cut_its: FALSE
     dada2_ref_tax_title: FALSE
     qiime2_ref_tax_title: FALSE
@@ -905,11 +906,16 @@ cat("## DADA2\n")
 if ( !isFALSE(params$dada2_ref_tax_title) ) {
     cat("The taxonomic classification was performed by [DADA2](https://pubmed.ncbi.nlm.nih.gov/27214047/)
         using the database: `", params$dada2_ref_tax_title, "`.
-        More details about the reference taxonomy database can be found in the ['Methods section'](#methods).\n\n", sep = "")
+        More details about the reference taxonomy database can be found in the ['Methods section'](#methods).", sep = "")
 } else {
     cat("The taxonomic classification was performed by DADA2 using a custom database ",
-            "provided by the user.\n\n", sep = "")
+            "provided by the user.", sep = "")
 }
+if (params$dada_min_boot) {
+    cat(" A minimum bootstrap confidence of ", params$dada_min_boot, " (out of 100 trials) ",
+        "was used for assigning a taxonomic level.", sep="")
+}
+cat ("\n\n")
 
 # mention if taxonomy was cut by cutadapt
 if ( !isFALSE(params$cut_dada_ref_taxonomy) ) {
@@ -1783,10 +1789,15 @@ cat(filter_codons_fasta_passed,"ASVs had no stop codons (",params$stop_codons,")
 ```{r, eval = any_taxonomy, results='asis'}
 methods_taxonomic_classification <- c("Taxonomic classification was performed by ")
 if ( !isFALSE(params$dada2_taxonomy) ) {
-    if ( !isFALSE(params$dada2_ref_tax_title) ) {
-        methods_taxonomic_classification_dada <- paste("DADA2 and the database '",params$dada2_ref_tax_title,"' (`", params$dada2_ref_tax_citation,"`)", sep="")
+    if (params$dada_min_boot) {
+        dada_min_boot_part <- paste("(with a minimum bootstrap confidence of ",params$dada_min_boot," out of 100 trials for assigning a taxonomic level) " )
     } else {
-        methods_taxonomic_classification_dada <- paste("DADA2 with a user provided database", sep="")
+        dada_min_boot_part <- ""
+    }
+    if ( !isFALSE(params$dada2_ref_tax_title) ) {
+        methods_taxonomic_classification_dada <- paste("DADA2 ",dada_min_boot_part,"and the database '",params$dada2_ref_tax_title,"' (`", params$dada2_ref_tax_citation,"`)", sep="")
+    } else {
+        methods_taxonomic_classification_dada <- paste("DADA2 ",dada_min_boot_part,"with a user provided database", sep="")
     }
     if ( !isFALSE(params$cut_dada_ref_taxonomy) ) {
         methods_taxonomic_classification_dada <- paste(methods_taxonomic_classification_dada,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -518,7 +518,7 @@ process {
     withName: DADA2_TAXONOMY {
         ext.seed = "${params.seed}"
         ext.args = [
-            'minBoot = 50',
+            "minBoot = ${params.dada_min_boot}",
             params.dada_taxonomy_rc || params.pacbio || params.iontorrent ? "tryRC = TRUE" : "tryRC = FALSE"
         ].join(',').replaceAll('(,)*$', "")
         publishDir = [

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -250,7 +250,7 @@ Special features of taxonomic classification tools:
 - QIIME2's reference taxonomy databases will have regions matching the amplicon extracted with primer sequences.
 - DADA2, Kraken2, and QIIME2 have specific parameters to accept custom databases (but theoretically possible with all classifiers)
 
-Parameter guidance is given in [nf-core/ampliseq website parameter documentation](https://nf-co.re/ampliseq/parameters/#taxonomic-database). Citations are listed in [`CITATIONS.md`](CITATIONS.md).
+Parameter guidance is given in [nf-core/ampliseq website parameter documentation](https://nf-co.re/ampliseq/parameters/#taxonomic-assignment). Citations are listed in [`CITATIONS.md`](CITATIONS.md).
 
 ### Multiple region analysis with Sidle
 

--- a/modules/local/summary_report.nf
+++ b/modules/local/summary_report.nf
@@ -113,6 +113,7 @@ process SUMMARY_REPORT  {
         params.max_len_asv ? "max_len_asv=$params.max_len_asv" : "max_len_asv=0",
         filter_codons_fasta ? "filter_codons_fasta='$filter_codons_fasta',stop_codons='$params.stop_codons'" : "",
         filter_codons_stats ? "filter_codons_stats='$filter_codons_stats'" : "",
+        "dada_min_boot=$params.dada_min_boot",
         itsx_cutasv_summary ? "itsx_cutasv_summary='$itsx_cutasv_summary',cut_its='$params.cut_its'" : "",
         dada2_tax ? "dada2_taxonomy='$dada2_tax'" : "",
         dada2_tax && !params.dada_ref_tax_custom ? "dada2_ref_tax_title='${params.dada_ref_databases[params.dada_ref_taxonomy]["title"]}',dada2_ref_tax_file='${params.dada_ref_databases[params.dada_ref_taxonomy]["file"]}',dada2_ref_tax_citation='${params.dada_ref_databases[params.dada_ref_taxonomy]["citation"]}'" : "",

--- a/nextflow.config
+++ b/nextflow.config
@@ -119,10 +119,8 @@ params {
     skip_multiqc           = false
     skip_report            = false
 
-    // DADA2 assignTaxonomy options
+    // Taxonomic assignment options
     dada_min_boot = 50
-
-    // Database options
     dada_ref_taxonomy        = "silva=138.2"
     dada_assign_taxlevels    = null
     dada_ref_tax_custom      = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -119,6 +119,9 @@ params {
     skip_multiqc           = false
     skip_report            = false
 
+    // DADA2 assignTaxonomy options
+    dada_min_boot = 50
+
     // Database options
     dada_ref_taxonomy        = "silva=138.2"
     dada_assign_taxlevels    = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,11 +25,11 @@ params {
 
     // Other options
     save_intermediates                        = false
-    trunc_qmin                                = 25
-    trunc_rmin                                = 0.75
+    truncq                                    = 2
     trunclenf                                 = null
     trunclenr                                 = null
-    truncq                                    = 2
+    trunc_qmin                                = 25
+    trunc_rmin                                = 0.75
     max_ee                                    = 2
     max_len                                   = null
     ignore_failed_filtering                   = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -405,6 +405,23 @@
             },
             "fa_icon": "fas fa-filter"
         },
+        "dada2_assigntaxonomy": {
+            "title": "DADA2 assignTaxonomy",
+            "type": "object",
+            "description": "Options for the DADA2 assignTaxonomy method used to classify ASVs against a database",
+            "default": "",
+            "fa_icon": "fas fa-sitemap",
+            "properties": {
+                "dada_min_boot": {
+                    "type": "integer",
+                    "default": 50,
+                    "fa_icon": "fas fa-greater-than-equal",
+                    "description": "The minimum bootstrap confidence (out of 100 trials) for assigning a taxonomic level. Matches `minBoot` in DADA2's assignTaxonomy method.",
+                    "minimum": 0,
+                    "maximum": 100
+                }
+            }
+        },
         "taxonomic_database": {
             "title": "Taxonomic database",
             "type": "object",
@@ -1090,6 +1107,9 @@
         },
         {
             "$ref": "#/$defs/asv_post_processing"
+        },
+        {
+            "$ref": "#/$defs/dada2_assigntaxonomy"
         },
         {
             "$ref": "#/$defs/taxonomic_database"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -405,29 +405,20 @@
             },
             "fa_icon": "fas fa-filter"
         },
-        "dada2_assigntaxonomy": {
-            "title": "DADA2 assignTaxonomy",
+        "taxonomic_assignment": {
+            "title": "Taxonomic assignment",
             "type": "object",
-            "description": "Options for the DADA2 assignTaxonomy method used to classify ASVs against a database",
-            "default": "",
-            "fa_icon": "fas fa-sitemap",
+            "fa_icon": "fas fa-database",
+            "description": "Choose a method and database for taxonomic assignments to single-region amplicons",
             "properties": {
                 "dada_min_boot": {
                     "type": "integer",
                     "default": 50,
                     "fa_icon": "fas fa-greater-than-equal",
-                    "description": "The minimum bootstrap confidence (out of 100 trials) for assigning a taxonomic level. Matches `minBoot` in DADA2's assignTaxonomy method.",
+                    "description": "The minimum bootstrap confidence (out of 100 trials) for assigning a taxonomic level with DADA2. Matches `minBoot` in DADA2's assignTaxonomy method.",
                     "minimum": 0,
                     "maximum": 100
-                }
-            }
-        },
-        "taxonomic_database": {
-            "title": "Taxonomic database",
-            "type": "object",
-            "fa_icon": "fas fa-database",
-            "description": "Choose a method and database for taxonomic assignments to single-region amplicons",
-            "properties": {
+                },
                 "dada_ref_taxonomy": {
                     "type": "string",
                     "help_text": "Choose any of the supported databases, and optionally also specify the version. Database and version are separated by an equal sign (`=`, e.g. `silva=138`) . This will download the desired database, format it to produce a file that is compatible with DADA2's assignTaxonomy and another file that is compatible with DADA2's addSpecies.\n\nThe following databases are supported:\n- GTDB - Genome Taxonomy Database - 16S rRNA\n- SBDI-GTDB, a Sativa-vetted version of the GTDB 16S rRNA\n- PR2 - Protist Reference Ribosomal Database - 18S rRNA\n- RDP - Ribosomal Database Project - 16S rRNA\n- SILVA ribosomal RNA gene database project - 16S rRNA\n- UNITE - eukaryotic nuclear ribosomal ITS region - ITS\n- COIDB - eukaryotic Cytochrome Oxidase I (COI) from The Barcode of Life Data System (BOLD) - COI\n\nGenerally, using `gtdb`, `pr2`, `rdp`, `sbdi-gtdb`, `silva`, `coidb`, `unite-fungi`, or `unite-alleuk` will select the most recent supported version.\n\nPlease note that commercial/non-academic entities [require licensing](https://www.arb-silva.de/silva-license-information) for SILVA v132 database (non-default) but not from v138 on (default).",
@@ -1109,10 +1100,7 @@
             "$ref": "#/$defs/asv_post_processing"
         },
         {
-            "$ref": "#/$defs/dada2_assigntaxonomy"
-        },
-        {
-            "$ref": "#/$defs/taxonomic_database"
+            "$ref": "#/$defs/taxonomic_assignment"
         },
         {
             "$ref": "#/$defs/multiregion_taxonomic_database"


### PR DESCRIPTION
<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

This PR adds a new parameter, dada_min_boot, that corresponds exactly with minBoot in DADA2's [assignTaxonomy](https://rdrr.io/bioc/dada2/man/assignTaxonomy.html) method. This parameter specifies a minimum bootstrap confidence (out of 100 trials) needed in order to assign a taxonomic level. This can be helpful in order to filter out assignments for ASVs that are likely too specific. E.g. An ASV was assigned to the incorrect species with confidence 55 (0.55), which is quite low, but was assigned to the correct genus level with confidence 75 (0.75). By setting dada_min_boot to 60 (0.60) in this example, the reported assignment would be to the genus level. Users can adjust dada_min_boot based on their own observations concerning what threshold they begin to see inaccurate assignments.

This also contains a small commit to adjust the order of the read truncation parameters (truncq, trunc_qmin, trunc_rmin, trunclenf, trunclenr) in nextflow.config to match the order they appear in nextflow_schema.json. No functional difference.