### PR TITLE
Reviewer2 2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#909](https://github.com/nf-core/ampliseq/pull/909),[#914](https://github.com/nf-core/ampliseq/pull/914) - Parameter `--truncq` allows read truncation by quality score, where each read is truncated at the first instance of a quality score less than or equal to `truncq` (default value is 2). This quality score-based truncation occurs before read length truncation. If `--trunc_qmin` and `--trunc_rmin` are used to automatically calculate the values for `trunclenf` and `trunclenr` used for read length truncation, those calculations are based on the read metrics before quality score-based truncation (using `truncq`) is performed. `truncq` is passed directly as `truncQ` into DADA2's [filterAndTrim](https://rdrr.io/bioc/dada2/man/filterAndTrim.html) method.
 - [#913](https://github.com/nf-core/ampliseq/pull/913) - Parameter `--dada_min_boot` allows the user to specify a minimum bootstrap confidence (out of 100 trials) for assigning a taxonomic level with DADA2's [assignTaxonomy](https://rdrr.io/bioc/dada2/man/assignTaxonomy.html) method.
 
-| **Parameter**      | **Description**                                                                                         |
-| ------------------ | ---------------------------------------------------------------------- |
-| **truncq**         | New: Read quality score-based truncation                               |
-| **dada_min_boot**  | New: Minimum bootstrap confidence for taxonomic assignments with DADA2 |
+| **Parameter**     | **Description**                                                        |
+| ----------------- | ---------------------------------------------------------------------- |
+| **truncq**        | New: Read quality score-based truncation                               |
+| **dada_min_boot** | New: Minimum bootstrap confidence for taxonomic assignments with DADA2 |
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## nf-core/ampliseq version 2.15.0 - 2025-09-22
+## nf-core/ampliseq version 2.15.0 - 2025-10-07
 
 ### `Added`
 
 - [#909](https://github.com/nf-core/ampliseq/pull/909),[#914](https://github.com/nf-core/ampliseq/pull/914) - Parameter `--truncq` allows read truncation by quality score, where each read is truncated at the first instance of a quality score less than or equal to `truncq` (default value is 2). This quality score-based truncation occurs before read length truncation. If `--trunc_qmin` and `--trunc_rmin` are used to automatically calculate the values for `trunclenf` and `trunclenr` used for read length truncation, those calculations are based on the read metrics before quality score-based truncation (using `truncq`) is performed. `truncq` is passed directly as `truncQ` into DADA2's [filterAndTrim](https://rdrr.io/bioc/dada2/man/filterAndTrim.html) method.
 - [#913](https://github.com/nf-core/ampliseq/pull/913) - Parameter `--dada_min_boot` allows the user to specify a minimum bootstrap confidence (out of 100 trials) for assigning a taxonomic level with DADA2's [assignTaxonomy](https://rdrr.io/bioc/dada2/man/assignTaxonomy.html) method.
+
+| **Parameter**      | **Description**                                                                                         |
+| ------------------ | ---------------------------------------------------------------------- |
+| **truncq**         | New: Read quality score-based truncation                               |
+| **dada_min_boot**  | New: Minimum bootstrap confidence for taxonomic assignments with DADA2 |
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#899](https://github.com/nf-core/ampliseq/pull/899) - With `--dada_ref_tax_custom` all chunks defined by `--dada_assign_chunksize` are now taxonomically annotated.
 - [#904](https://github.com/nf-core/ampliseq/pull/904) - Update `untar` module.
 - [#906](https://github.com/nf-core/ampliseq/pull/906) - Fix `--mergepairs_strategy "consensus"` causing an error in dada2_stats when analysing a run composed by only one sample.
+- [#916](https://github.com/nf-core/ampliseq/pull/916) - Improved ext.args layout
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -42,10 +42,10 @@ process {
             "--minimum-length 1",
             "-O ${params.cutadapt_min_overlap}",
             "-e ${params.cutadapt_max_error_rate}",
-            params.pacbio ? "--rc -g ${meta.fw_primer}...${meta.rv_primer_revcomp}" :
+            params.pacbio         ? "--rc -g ${meta.fw_primer}...${meta.rv_primer_revcomp}" :
                 params.iontorrent ? "--rc -g ${meta.fw_primer}...${meta.rv_primer_revcomp}" :
                 params.single_end ? "-g ${meta.fw_primer}" :
-                "-g ${meta.fw_primer} -G ${meta.rv_primer}",
+                    "-g ${meta.fw_primer} -G ${meta.rv_primer}",
             params.retain_untrimmed ? '' : "--discard-untrimmed"
         ].join(' ').trim() }
         ext.prefix = { "${meta.id}.trimmed" }
@@ -76,10 +76,10 @@ process {
             "--discard-trimmed --minimum-length 1",
             "-O ${params.cutadapt_min_overlap}",
             "-e ${params.cutadapt_max_error_rate}",
-            params.pacbio ? "--rc -g ${meta.fw_primer}...${meta.rv_primer_revcomp}" :
+            params.pacbio         ? "--rc -g ${meta.fw_primer}...${meta.rv_primer_revcomp}" :
                 params.iontorrent ? "--rc -g ${meta.fw_primer}...${meta.rv_primer_revcomp}" :
                 params.single_end ? "-g ${meta.fw_primer}" :
-                "-g ${meta.fw_primer} -G ${meta.rv_primer}"
+                    "-g ${meta.fw_primer} -G ${meta.rv_primer}"
         ].join(' ').trim() }
         ext.prefix = { "${meta.id}.double-primer" }
         publishDir = [
@@ -138,16 +138,16 @@ process {
 
     max_len = params.max_len ?: "Inf"
     withName: DADA2_FILTNTRIM {
-        ext.args = [
+        ext.args = { [
             'maxN = 0, trimRight = 0, minQ = 0, rm.lowcomplex = 0, orient.fwd = NULL, matchIDs = FALSE, id.sep = "\\\\s", id.field = NULL, n = 1e+05, OMP = TRUE',
             "qualityType = \"${params.quality_type}\"",
             "truncQ = ${params.truncq}",
             params.pacbio || params.iontorrent || params.single_end ? "maxEE = ${params.max_ee}" : "maxEE = c(${params.max_ee}, ${params.max_ee})",
-            params.pacbio ? "trimLeft = 0, minLen = ${params.min_len}, maxLen = $max_len, rm.phix = FALSE" :
-                params.iontorrent ? "trimLeft = 15, minLen = ${params.min_len}, maxLen = $max_len, rm.phix = TRUE" :
-                params.illumina_pe_its ? "trimLeft = 0, minLen = ${params.min_len}, maxLen = $max_len, rm.phix = TRUE" :
-                "trimLeft = 0, minLen = ${params.min_len}, maxLen = $max_len, rm.phix = TRUE"
-        ].join(',').replaceAll('(,)*$', "")
+            params.pacbio                                           ? "trimLeft = 0, minLen = ${params.min_len}, maxLen = $max_len, rm.phix = FALSE" :
+                params.iontorrent                                   ? "trimLeft = 15, minLen = ${params.min_len}, maxLen = $max_len, rm.phix = TRUE" :
+                params.illumina_pe_its                              ? "trimLeft = 0, minLen = ${params.min_len}, maxLen = $max_len, rm.phix = TRUE" :
+                    "trimLeft = 0, minLen = ${params.min_len}, maxLen = $max_len, rm.phix = TRUE"
+        ].join(',').replaceAll('(,)*$', "") }
         publishDir = [
             path: { "${params.outdir}/dada2/args" },
             mode: params.publish_dir_mode,
@@ -180,11 +180,11 @@ process {
     withName: DADA2_ERR {
         ext.seed = "${params.seed}"
         ext.prefix = { meta.region ? "region-${meta.region}_run-${meta.run}" : "${meta.run}" }
-        ext.args = [
+        ext.args = { [
             'nbases = 1e8, nreads = NULL, randomize = TRUE, MAX_CONSIST = 10, OMEGA_C = 0',
             "qualityType = \"${params.quality_type}\"",
             params.pacbio ? "errorEstimationFunction = PacBioErrfun" : "errorEstimationFunction = loessErrfun"
-        ].join(',').replaceAll('(,)*$', "")
+        ].join(',').replaceAll('(,)*$', "") }
         publishDir = [
             [
                 path: { "${params.outdir}/dada2/QC" },
@@ -228,19 +228,20 @@ process {
         ext.prefix = { meta.region ? "region-${meta.region}_run-${meta.run}" : "${meta.run}" }
         ext.quality_type = "${params.quality_type}"
         // standard setting can be inspected with getDadaOpt(option = NULL)
-        ext.args = [
+        ext.args = { [
             'selfConsist = FALSE, priors = character(0), DETECT_SINGLETONS = FALSE, GAPLESS = TRUE, GAP_PENALTY = -8, GREEDY = TRUE, KDIST_CUTOFF = 0.42, MATCH = 5, MAX_CLUST = 0, MAX_CONSIST = 10, MIN_ABUNDANCE = 1, MIN_FOLD = 1, MIN_HAMMING = 1, MISMATCH = -4, OMEGA_A = 1e-40, OMEGA_C = 1e-40, OMEGA_P = 1e-4, PSEUDO_ABUNDANCE = Inf, PSEUDO_PREVALENCE = 2, SSE = 2, USE_KMERS = TRUE, USE_QUALS = TRUE, VECTORIZED_ALIGNMENT = TRUE',
             params.iontorrent ? "BAND_SIZE = 32, HOMOPOLYMER_GAP_PENALTY = -1" : "BAND_SIZE = 16, HOMOPOLYMER_GAP_PENALTY = NULL",
             params.sample_inference == "pseudo" ? "pool = \"pseudo\"" :
-                params.sample_inference == "pooled" ? "pool = TRUE" : "pool = FALSE"
-        ].join(',').replaceAll('(,)*$', "")
+                params.sample_inference == "pooled" ? "pool = TRUE" :
+                    "pool = FALSE"
+        ].join(',').replaceAll('(,)*$', "") }
         // setting from https://rdrr.io/bioc/dada2/man/mergePairs.html & https://rdrr.io/bioc/dada2/man/nwalign.html & match = getDadaOpt("MATCH"), mismatch = getDadaOpt("MISMATCH"), gap = getDadaOpt("GAP_PENALTY"), missing from the list below is: 'band = -1'
-        ext.args2 = [
+        ext.args2 = { [
             "homo_gap = NULL, endsfree = TRUE, vec = FALSE, propagateCol = character(0), trimOverhang = FALSE",
             params.mergepairs_strategy == "consensus" ?
                 "returnRejects = TRUE, match = ${params.mergepairs_consensus_match}, mismatch = ${params.mergepairs_consensus_mismatch}, minOverlap = ${params.mergepairs_consensus_minoverlap}, maxMismatch = ${params.mergepairs_consensus_maxmismatch}, gap = ${params.mergepairs_consensus_gap}" :
                 "justConcatenate = ${params.mergepairs_strategy == 'concatenate' ? 'TRUE' : 'FALSE'}, returnRejects = FALSE, match = 1, mismatch = -64, gap = -64, minOverlap = 12, maxMismatch = 0"
-        ].join(',').replaceAll('(,)*$', "")
+        ].join(',').replaceAll('(,)*$', "") }
         ext.quantile = "${params.mergepairs_consensus_percentile_cutoff}"
         publishDir = [
             [
@@ -465,10 +466,11 @@ process {
     }
 
     withName: FILTER_CODONS {
-        ext.args = [params.orf_start ? "-s ${params.orf_start}" : '',
-            params.orf_end ? "-e ${params.orf_end}" : '',
+        ext.args = { [
+            params.orf_start   ? "-s ${params.orf_start}" : '',
+            params.orf_end     ? "-e ${params.orf_end}" : '',
             params.stop_codons ? "-x ${params.stop_codons}" : ''
-        ].join(' ')
+        ].join(' ') }
         publishDir = [
             path: { "${params.outdir}/codon_filter" },
             mode: params.publish_dir_mode,
@@ -485,12 +487,12 @@ process {
     }
 
     withName: ITSX_CUTASV {
-        ext.args = [
+        ext.args = { [
             '-t all --preserve T --date F --positions F --graphical F',
-            params.cut_its == "its1" ? "--save_regions ITS1" :
+            params.cut_its == "its1"     ? "--save_regions ITS1" :
                 params.cut_its == "its2" ? "--save_regions ITS2" : "--save_regions none",
-            params.its_partial != 0 ? "--partial ${params.its_partial}" : ""
-        ].join(' ').trim()
+            params.its_partial != 0      ? "--partial ${params.its_partial}" : ""
+        ].join(' ').trim() }
         publishDir = [
             path: { "${params.outdir}/itsx" },
             mode: params.publish_dir_mode,
@@ -517,10 +519,10 @@ process {
 
     withName: DADA2_TAXONOMY {
         ext.seed = "${params.seed}"
-        ext.args = [
+        ext.args = { [
             "minBoot = ${params.dada_min_boot}",
             params.dada_taxonomy_rc || params.pacbio || params.iontorrent ? "tryRC = TRUE" : "tryRC = FALSE"
-        ].join(',').replaceAll('(,)*$', "")
+        ].join(',').replaceAll('(,)*$', "") }
         publishDir = [
             [
                 path: { "${params.outdir}/dada2/args" },
@@ -537,11 +539,11 @@ process {
 
     withName: DADA2_ADDSPECIES {
         ext.seed = "${params.seed}"
-        ext.args = [
+        ext.args = { [
             'n = 1e5',
-            params.dada_addspecies_allowmultiple ? "allowMultiple = TRUE" : "",
+            params.dada_addspecies_allowmultiple                          ? "allowMultiple = TRUE" : "",
             params.dada_taxonomy_rc || params.pacbio || params.iontorrent ? "tryRC = TRUE" : "tryRC = FALSE"
-        ].join(',').replaceAll('(,)*$', "")
+        ].join(',').replaceAll('(,)*$', "") }
         publishDir = [
             [
                 path: { "${params.outdir}/dada2/args" },
@@ -565,7 +567,7 @@ process {
     }
 
     withName: VSEARCH_SINTAX {
-        ext.args = "--sintax_cutoff 0.8 --randseed ${params.seed}"
+        ext.args = { "--sintax_cutoff 0.8 --randseed ${params.seed}" }
         cpus = 1
         publishDir = [
             [
@@ -586,7 +588,7 @@ process {
 
     withName: KRAKEN2_KRAKEN2 {
         // "--use-names" is required for downstream processes!
-        ext.args = "--use-names --confidence ${params.kraken2_confidence}"
+        ext.args = { "--use-names --confidence ${params.kraken2_confidence}" }
         publishDir = [
             path: { "${params.outdir}/kraken2" },
             mode: params.publish_dir_mode,
@@ -614,7 +616,7 @@ process {
     }
 
     withName: VSEARCH_CLUSTER {
-        ext.args = "--id ${params.vsearch_cluster_id} --usersort --qmask 'none'"
+        ext.args  = { "--id ${params.vsearch_cluster_id} --usersort --qmask 'none'" }
         ext.args2 = '--cluster_smallmem'
         ext.args3 = '--clusters'
     }
@@ -987,7 +989,7 @@ process {
         ext.args = '--p-prv-cut 0.1 --p-lib-cut 500 --p-alpha 0.05 --p-conserve'
         // additional arguments for "qiime composition da-barplot"
         ext.args2 = { [
-            params.ancombc_effect_size ? "--p-effect-size-threshold ${params.ancombc_effect_size}" : '',
+            params.ancombc_effect_size  ? "--p-effect-size-threshold ${params.ancombc_effect_size}"   : '',
             params.ancombc_significance ? "--p-significance-threshold ${params.ancombc_significance}" : '',
             '--p-label-limit 1000'
         ].join(' ') }
@@ -1014,7 +1016,7 @@ process {
         ].join(' ') }
         // additional arguments for "qiime composition da-barplot"
         ext.args2 = { [
-            params.ancombc_effect_size ? "--p-effect-size-threshold ${params.ancombc_effect_size}" : '',
+            params.ancombc_effect_size  ? "--p-effect-size-threshold ${params.ancombc_effect_size}"   : '',
             params.ancombc_significance ? "--p-significance-threshold ${params.ancombc_significance}" : '',
             '--p-label-limit 1000'
         ].join(' ') }
@@ -1043,11 +1045,11 @@ process {
     }
 
     withName: SBDIEXPORT {
-        ext.args = [
+        ext.args = { [
             params.single_end ? 'single' : 'paired',
             "${params.FW_primer}",
             "${params.RV_primer}"
-        ].join(' ').trim()
+        ].join(' ').trim() }
         publishDir = [
             path: { "${params.outdir}/SBDI" },
             mode: params.publish_dir_mode,


### PR DESCRIPTION
Implement reviewer suggestions for [release 2.15.0](https://github.com/nf-core/ampliseq/pull/911).
Added `{}` where missing for `ext.args` that include params.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
