### PR TITLE
Gracefully handle missing MultiQC plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 [#926](https://github.com/nf-core/ampliseq/pull/926) - Template update for nf-core/tools version 3.4.1
+[#929](https://github.com/nf-core/ampliseq/pull/929) - A bug in a dependency of MultiQC can lead (rarely) to plot generation being omitted, without warning. In that case, the subsequent pipeline summary report failed previously, now it gracefully handles that issue.
 
 ### `Dependencies`
 

--- a/assets/report_template.Rmd
+++ b/assets/report_template.Rmd
@@ -245,8 +245,20 @@ MultiQC report, which can be found in [multiqc/multiqc_report.html](../multiqc/m
 "))
 ```
 
+<!-- TODO: MultiQC occasionally doesnt produce plots. This seems to be a consequence of an issue in Kaleido, should be fixed with Kaleido2 -->
+
 ```{r, eval = !isFALSE(params$mqc_plot), out.width='100%', dpi=1200, fig.align='center'}
-knitr::include_graphics(params$mqc_plot)
+if ( file.exists(params$mqc_plot) ) {
+    knitr::include_graphics(params$mqc_plot)
+}
+```
+```{r, !isFALSE(params$mqc_plot), results='asis'}
+if ( !file.exists(params$mqc_plot) ) {
+    cat(paste0("
+_This plot is missing. That is only a visual mishap, all data can be found in the MultiQC report._
+_The cause is likely a bug in Kaleido, a dependency of MultiQC. There is no need to take action._
+    "))
+}
 ```
 
 <!-- Subsection on Cutadapt -->


### PR DESCRIPTION
Solves https://github.com/nf-core/ampliseq/issues/925.

MultiQC occasionally fails due to a bug in a dependency. Previously the subsequent pipeline summary report failed, now the report is generated regardless.
Instead of the plot, a small message (not a large big warning) says that a plot is missing:
<img width="832" height="176" alt="image" src="https://github.com/user-attachments/assets/0b79bb7b-7796-4796-b1ea-61f12f039a83" />

Alternatively the warning in the report could be omitted. Possibly (dont know yet how) a warning could go into the console/log (but thats currently not the case!).

The CI tests would fail (missing output files that are expected), that makes sure that we do not miss that in case MultiQC also fails to produce plot in the CI tests.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
