### PR TITLE
Fix multiregion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#942](https://github.com/nf-core/ampliseq/pull/942) - Nextflow strict syntax for non-nf-core-modules/workflows
+- [#944](https://github.com/nf-core/ampliseq/pull/944) - Regions in multiple region analysis are now always properly sorted.
 
 ### `Dependencies`
 

--- a/modules/local/sidle_dbextract.nf
+++ b/modules/local/sidle_dbextract.nf
@@ -11,7 +11,7 @@ process SIDLE_DBEXTRACT {
 
     output:
     tuple val(meta), path("db_*_kmers.qza"), emit: kmers
-    tuple val(meta), path("db_*_map.qza")  , emit: map
+    tuple val(meta), path("db_*_map.qza")  , emit: kmer_map
     path "versions.yml"                    , emit: versions
 
     script:

--- a/modules/local/sidle_dbrecon.nf
+++ b/modules/local/sidle_dbrecon.nf
@@ -18,8 +18,8 @@ process SIDLE_DBRECON {
     script:
     def args = task.ext.args ?: ''
     def db_input = ""
-    // sort the input so that the regions are sorted by sequence
-    def df = [region, kmer_map, aligned_map].transpose().sort()
+    // input must be sorted already by regions
+    def df = [region, kmer_map, aligned_map].transpose()
     df.each { i ->
         db_input += " --p-region "+i[0]+" --i-kmer-map "+i[1]+" --i-regional-alignment "+i[2]
     }

--- a/modules/local/sidle_dbrecon.nf
+++ b/modules/local/sidle_dbrecon.nf
@@ -6,7 +6,7 @@ process SIDLE_DBRECON {
 
     input:
     val(metaid)
-    path(map)
+    path(kmer_map)
     path(aligned_map)
 
     output:
@@ -19,7 +19,7 @@ process SIDLE_DBRECON {
     def args = task.ext.args ?: ''
     def db_input = ""
     // sort the input so that the regions are sorted by sequence
-    def df = [metaid, map, aligned_map].transpose().sort{ it[0] }
+    def df = [metaid, kmer_map, aligned_map].transpose().sort{ it[0] }
     df.each { i ->
         db_input += " --p-region "+i[0]+" --i-kmer-map "+i[1]+" --i-regional-alignment "+i[2]
     }

--- a/modules/local/sidle_tablerecon.nf
+++ b/modules/local/sidle_tablerecon.nf
@@ -5,7 +5,7 @@ process SIDLE_TABLERECON {
     container 'nf-core/pipesidle:0.1.0-beta'
 
     input:
-    val(metaid)
+    val(region)
     path(table)
     path(aligned_map)
     path(reconstruction_map)
@@ -22,7 +22,7 @@ process SIDLE_TABLERECON {
     def args = task.ext.args ?: ''
     def region_input = ""
     // sort the input so that the regions are sorted by sequence
-    def df = [metaid, aligned_map, table].transpose().sort{ it[0] }
+    def df = [region, aligned_map, table].transpose().sort{ it[0] }
     df.each { i ->
         region_input += " --p-region "+i[0]+" --i-regional-alignment "+i[1]+" --i-regional-table "+i[2]
     }

--- a/modules/local/sidle_tablerecon.nf
+++ b/modules/local/sidle_tablerecon.nf
@@ -21,8 +21,8 @@ process SIDLE_TABLERECON {
     script:
     def args = task.ext.args ?: ''
     def region_input = ""
-    // sort the input so that the regions are sorted by sequence
-    def df = [region, aligned_map, table].transpose().sort()
+    // input must be sorted already by regions
+    def df = [region, aligned_map, table].transpose()
     df.each { i ->
         region_input += " --p-region "+i[0]+" --i-regional-alignment "+i[1]+" --i-regional-table "+i[2]
     }

--- a/subworkflows/local/sidle_wf.nf
+++ b/subworkflows/local/sidle_wf.nf
@@ -66,6 +66,8 @@ workflow SIDLE_WF {
 
     SIDLE_DBEXTRACT.out.kmer_map
         .join(SIDLE_ALIGN.out.aligned_map)
+        .toSortedList( { a, b -> a[0].region <=> b[0].region } )
+        .flatMap()
         .multiMap { meta, kmer_map, aligned_map ->
             region: meta.region
             kmer_map: kmer_map
@@ -81,6 +83,8 @@ workflow SIDLE_WF {
 
     SIDLE_TRIM.out.table
         .join(SIDLE_ALIGN.out.aligned_map)
+        .toSortedList( { a, b -> a[0].region <=> b[0].region } )
+        .flatMap()
         .multiMap { meta, table, aligned_map ->
             region: meta.region
             table: table

--- a/subworkflows/local/sidle_wf.nf
+++ b/subworkflows/local/sidle_wf.nf
@@ -64,25 +64,25 @@ workflow SIDLE_WF {
     SIDLE_ALIGN ( SIDLE_DBEXTRACT.out.kmers.join(SIDLE_TRIM.out.seq).dump(tag: 'into_SIDLE_ALIGN') )
     ch_sidle_versions = ch_sidle_versions.mix(SIDLE_ALIGN.out.versions)
 
-    SIDLE_DBEXTRACT.out.map
+    SIDLE_DBEXTRACT.out.kmer_map
         .join(SIDLE_ALIGN.out.aligned_map)
-        .multiMap { meta, map, aligned_map ->
-            sampleid: meta.id
-            map: map
+        .multiMap { meta, kmer_map, aligned_map ->
+            region: meta.region
+            kmer_map: kmer_map
             aligned_map: aligned_map
         }
         .set { ch_db_reconstruction }
 
     SIDLE_DBRECON (
-        ch_db_reconstruction.sampleid.collect(),
-        ch_db_reconstruction.map.collect(),
+        ch_db_reconstruction.region.collect(),
+        ch_db_reconstruction.kmer_map.collect(),
         ch_db_reconstruction.aligned_map.collect() )
     ch_sidle_versions = ch_sidle_versions.mix(SIDLE_DBRECON.out.versions)
 
     SIDLE_TRIM.out.table
         .join(SIDLE_ALIGN.out.aligned_map)
         .multiMap { meta, table, aligned_map ->
-            sampleid: meta.id
+            region: meta.region
             table: table
             aligned_map: aligned_map
         }
@@ -90,7 +90,7 @@ workflow SIDLE_WF {
 
     // Abundance table
     SIDLE_TABLERECON (
-        ch_table_reconstruction.sampleid.collect(),
+        ch_table_reconstruction.region.collect(),
         ch_table_reconstruction.table.collect(),
         ch_table_reconstruction.aligned_map.collect(),
         SIDLE_DBRECON.out.reconstruction_map,

--- a/tests/multiregion.nf.test
+++ b/tests/multiregion.nf.test
@@ -35,6 +35,8 @@ nextflow_pipeline {
                     path("$outputDir/dada2/DADA2_stats.tsv"),
                     path("$outputDir/dada2/DADA2_table.rds"),
                     path("$outputDir/dada2/DADA2_table.tsv"),
+                    path("$outputDir/sidle/DB/3_reconstructed/reconstruction_summary/metadata.tsv"),
+                    path("$outputDir/sidle/reconstructed/reconstructed_merged.tsv"),
                     path("$outputDir/multiqc/multiqc_data/multiqc_fastqc.txt"),
                     path("$outputDir/multiqc/multiqc_data/multiqc_general_stats.txt"),
                     path("$outputDir/multiqc/multiqc_data/multiqc_cutadapt.txt")

--- a/tests/multiregion.nf.test
+++ b/tests/multiregion.nf.test
@@ -35,7 +35,6 @@ nextflow_pipeline {
                     path("$outputDir/dada2/DADA2_stats.tsv"),
                     path("$outputDir/dada2/DADA2_table.rds"),
                     path("$outputDir/dada2/DADA2_table.tsv"),
-                    path("$outputDir/sidle/DB/3_reconstructed/reconstruction_summary/metadata.tsv"),
                     path("$outputDir/sidle/reconstructed/reconstructed_merged.tsv"),
                     path("$outputDir/multiqc/multiqc_data/multiqc_fastqc.txt"),
                     path("$outputDir/multiqc/multiqc_data/multiqc_general_stats.txt"),

--- a/tests/multiregion.nf.test.snap
+++ b/tests/multiregion.nf.test.snap
@@ -603,6 +603,8 @@
             "DADA2_stats.tsv:md5,e56236955a435abbfdc92d514c9c5443",
             "DADA2_table.rds:md5,6358376bb6f42ed782cda2be1564d3d8",
             "DADA2_table.tsv:md5,f14f4e62f9898e6a0755e2d1621bcc3b",
+            "sidle/DB/3_reconstructed/reconstruction_summary/metadata.tsv:md5,2393de9d0e8ed317e14f6a6e79af99e6",
+            "sidle/reconstructed/reconstructed_merged.tsv:md5,984b750dce7c876f3d4a780708f87848",
             "multiqc_fastqc.txt:md5,9468ae91af1a841c5e1369f11f704604",
             "multiqc_general_stats.txt:md5,68f2972dd2d44e499d5afac6cf8624c8",
             "multiqc_cutadapt.txt:md5,d845cb0bde470ed3b7ba32edb2e76f83"

--- a/tests/multiregion.nf.test.snap
+++ b/tests/multiregion.nf.test.snap
@@ -603,8 +603,7 @@
             "DADA2_stats.tsv:md5,e56236955a435abbfdc92d514c9c5443",
             "DADA2_table.rds:md5,6358376bb6f42ed782cda2be1564d3d8",
             "DADA2_table.tsv:md5,f14f4e62f9898e6a0755e2d1621bcc3b",
-            "sidle/DB/3_reconstructed/reconstruction_summary/metadata.tsv:md5,2393de9d0e8ed317e14f6a6e79af99e6",
-            "sidle/reconstructed/reconstructed_merged.tsv:md5,984b750dce7c876f3d4a780708f87848",
+            "reconstructed_merged.tsv:md5,984b750dce7c876f3d4a780708f87848",
             "multiqc_fastqc.txt:md5,9468ae91af1a841c5e1369f11f704604",
             "multiqc_general_stats.txt:md5,68f2972dd2d44e499d5afac6cf8624c8",
             "multiqc_cutadapt.txt:md5,d845cb0bde470ed3b7ba32edb2e76f83"


### PR DESCRIPTION
Multiple region analysis was not always optimal because the regions were not always properly sorted. This PR aims to guarantee that the sorting is always proper.

For CI tests, '-profile test_multiregion' is 7/14.
Intentionally initially against `master` branch to also run conda tests.

I checked whether strict syntax is still fine with `NXF_VER=25.10.2 nextflow lint ampliseq -exclude ".git,.nf-test,nf-test.config"` (hope that will be soon in the template...)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
