### PR TITLE
Enable local reference storage directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#948](https://github.com/nf-core/ampliseq/pull/948) - Decontam as optional decontamination tool.
 - [#949](https://github.com/nf-core/ampliseq/pull/949) - The dataset can be filtered for downstream analysis with the metadata sheet, for example to remove negative control samples meant for Decontam.
+- [#964](https://github.com/nf-core/ampliseq/pull/964) - Enabled local reference storage directory with `--ref_taxonomy_storage`.
 
 ### `Changed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -18,6 +18,10 @@ process {
         enabled: false
     ]
 
+    withName: DOWNLOAD_REFERENCE {
+        storeDir = params.ref_taxonomy_storage ?: false
+    }
+
     withName: RENAME_RAW_DATA_FILES {
         // copy in case cutadapt is skipped, because the next step (DADA2's filterAndTrim) follows soft links and ignores renamed file names
         ext.args = params.skip_cutadapt ? 'cp' : 'ln -s'

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -439,6 +439,7 @@ params {
             citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
             fmtscript = "taxref_reformat_qiime_greengenes85.sh"
         }
+        // Index in https://ftp.microbio.me/greengenes_release/
         'greengenes2' {
             title = "Greengenes2 16S - Version 2024.09"
             file = [ "http://ftp.microbio.me/greengenes_release/2024.09/2024.09.seqs.fna.gz", "http://ftp.microbio.me/greengenes_release/2024.09/2024.09.taxonomy.md5.tsv.gz" ]
@@ -644,6 +645,7 @@ params {
             fmtscript = "taxref_reformat_sidle.sh"
             taxlevels = "D,P,C,O,F,G"
         }
+        // Index in https://ftp.microbio.me/greengenes_release/
         'greengenes' {
             title = "Greengenes - Version 13_8"
             file = [ "ftp://greengenes.microbio.me/greengenes_release/gg_13_5/gg_13_8_otus.tar.gz" ]
@@ -660,9 +662,9 @@ params {
             fmtscript = "taxref_reformat_sidle.sh"
             taxlevels = "D,P,C,O,F,G,S"
         }
-        'greengenes88' {
-            title = "Greengenes - Version 13_8 - clustered at 88% similarity - for testing purposes only"
-            file = [ "ftp://greengenes.microbio.me/greengenes_release/gg_13_5/gg_13_8_otus.tar.gz" ]
+        'greengenes=12_8_88' {
+            title = "Greengenes - Version 12_8 - clustered at 88% similarity - for testing purposes only"
+            file = [ "ftp://greengenes.microbio.me/greengenes_release/gg_12_8/gg_12_8.fasta.gz" ]
             citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
             fmtscript = "taxref_reformat_sidle.sh"
             taxlevels = "D,P,C,O,F,G,S"

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -662,13 +662,5 @@ params {
             fmtscript = "taxref_reformat_sidle.sh"
             taxlevels = "D,P,C,O,F,G,S"
         }
-        'greengenes=12_8_88' {
-            title = "Greengenes - Version 12_8 - clustered at 88% similarity - for testing purposes only"
-            file = [ "ftp://greengenes.microbio.me/greengenes_release/gg_12_8/gg_12_8_otus.tar.gz" ]
-            citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
-            fmtscript = "taxref_reformat_sidle.sh"
-            taxlevels = "D,P,C,O,F,G,S"
-            derep = "88"
-        }
     }
 }

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -4,7 +4,7 @@
  * -----------------------------------------------------------
  * Defines sources and files for reference databases
  * Please also reflect all changes in 'nextflow_schema.json'
- * Each entry requires as a minimum: title, file, citation, fmtscript
+ * Each entry requires as a minimum: title, file, citation, fmtscript, dbversion
  * Optional entries are: taxlevels, shfile
  * taxlevels default in "dada2_taxonomy.nf" and "dada2_addspecies.nf": "Kingdom,Phylum,Class,Order,Family,Genus,Species"
  */
@@ -356,6 +356,7 @@ params {
             file = [ "https://data.qiime2.org/2023.7/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2023.7/common/silva-138-99-tax.qza" ]
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
+            dbversion = "SILVA v138 (https://docs.qiime2.org/2023.7/data-resources/#silva-16s-18s-rrna)"
             fmtscript = "taxref_reformat_qiime_silva138.sh"
         }
         'silva' {
@@ -363,6 +364,7 @@ params {
             file = [ "https://data.qiime2.org/2023.7/common/silva-138-99-seqs.qza", "https://data.qiime2.org/2023.7/common/silva-138-99-tax.qza" ]
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
+            dbversion = "SILVA v138 (https://docs.qiime2.org/2023.7/data-resources/#silva-16s-18s-rrna)"
             fmtscript = "taxref_reformat_qiime_silva138.sh"
         }
 
@@ -438,6 +440,7 @@ params {
             file = [ "https://data.qiime2.org/2023.7/tutorials/training-feature-classifiers/85_otus.fasta", "https://data.qiime2.org/2023.7/tutorials/training-feature-classifiers/85_otu_taxonomy.txt" ]
             citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
             fmtscript = "taxref_reformat_qiime_greengenes85.sh"
+            dbversion = "Greengenes 13_8 (https://docs.qiime2.org/2023.7/tutorials/feature-classifier/#obtaining-and-importing-reference-data-sets)"
         }
         // Index in https://ftp.microbio.me/greengenes_release/
         'greengenes2' {
@@ -445,18 +448,21 @@ params {
             file = [ "http://ftp.microbio.me/greengenes_release/2024.09/2024.09.seqs.fna.gz", "http://ftp.microbio.me/greengenes_release/2024.09/2024.09.taxonomy.md5.tsv.gz" ]
             citation = "McDonald, D., Jiang, Y., Balaban, M. et al. Greengenes2 unifies microbial data in a single reference tree. Nat Biotechnol (2023). https://doi.org/10.1038/s41587-023-01845-1"
             fmtscript = "taxref_reformat_qiime_greengenes2022.sh"
+            dbversion = "Greengenes2 2024.09 (https://ftp.microbio.me/greengenes_release/2024.09/)"
         }
         'greengenes2=2024.09' {
             title = "Greengenes2 16S - Version 2024.09"
             file = [ "http://ftp.microbio.me/greengenes_release/2024.09/2024.09.seqs.fna.gz", "http://ftp.microbio.me/greengenes_release/2024.09/2024.09.taxonomy.md5.tsv.gz" ]
             citation = "McDonald, D., Jiang, Y., Balaban, M. et al. Greengenes2 unifies microbial data in a single reference tree. Nat Biotechnol (2023). https://doi.org/10.1038/s41587-023-01845-1"
             fmtscript = "taxref_reformat_qiime_greengenes2022.sh"
+            dbversion = "Greengenes2 2024.09 (https://ftp.microbio.me/greengenes_release/2024.09/)"
         }
         'greengenes2=2022.10' {
             title = "Greengenes2 16S - Version 2022.10"
             file = [ "http://ftp.microbio.me/greengenes_release/2022.10/2022.10.seqs.fna.gz", "http://ftp.microbio.me/greengenes_release/2022.10/2022.10.taxonomy.md5.tsv.gz" ]
             citation = "McDonald, D., Jiang, Y., Balaban, M. et al. Greengenes2 unifies microbial data in a single reference tree. Nat Biotechnol (2023). https://doi.org/10.1038/s41587-023-01845-1"
             fmtscript = "taxref_reformat_qiime_greengenes2022.sh"
+            dbversion = "Greengenes2 2022.10 (https://ftp.microbio.me/greengenes_release/2022.10/)"
         }
     }
     //Sintax taxonomic reference databases
@@ -557,6 +563,7 @@ params {
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = ""
+            dbversion = "SILVA v138 (https://benlangmead.github.io/aws-indexes/k2)"
             taxlevels = "D,P,C,O,F,G"
         }
         'silva=138' {
@@ -565,6 +572,7 @@ params {
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = ""
+            dbversion = "SILVA v138 (https://benlangmead.github.io/aws-indexes/k2)"
             taxlevels = "D,P,C,O,F,G"
         }
         'silva=132' {
@@ -573,6 +581,7 @@ params {
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = ""
+            dbversion = "SILVA v132 (https://benlangmead.github.io/aws-indexes/k2)"
             taxlevels = "D,P,C,O,F,G"
         }
         'rdp' {
@@ -580,6 +589,7 @@ params {
             file = [ "https://genome-idx.s3.amazonaws.com/kraken/16S_RDP11.5_20200326.tgz" ]
             citation = "Cole JR, Wang Q, Fish JA, Chai B, McGarrell DM, Sun Y, Brown CT, Porras-Alfaro A, Kuske CR, Tiedje JM. Ribosomal Database Project: data and tools for high throughput rRNA analysis. Nucleic Acids Res. 2014 Jan;42(Database issue):D633-42. doi: 10.1093/nar/gkt1244. Epub 2013 Nov 27. PMID: 24288368; PMCID: PMC3965039."
             fmtscript = ""
+            dbversion = "RDP 18/11.5 (https://benlangmead.github.io/aws-indexes/k2)"
             taxlevels = "D,P,C,O,F,G"
         }
         'rdp=18' {
@@ -587,6 +597,7 @@ params {
             file = [ "https://genome-idx.s3.amazonaws.com/kraken/16S_RDP11.5_20200326.tgz" ]
             citation = "Cole JR, Wang Q, Fish JA, Chai B, McGarrell DM, Sun Y, Brown CT, Porras-Alfaro A, Kuske CR, Tiedje JM. Ribosomal Database Project: data and tools for high throughput rRNA analysis. Nucleic Acids Res. 2014 Jan;42(Database issue):D633-42. doi: 10.1093/nar/gkt1244. Epub 2013 Nov 27. PMID: 24288368; PMCID: PMC3965039."
             fmtscript = ""
+            dbversion = "RDP 18/11.5 (https://benlangmead.github.io/aws-indexes/k2)"
             taxlevels = "D,P,C,O,F,G"
         }
         'greengenes' {
@@ -594,6 +605,7 @@ params {
             file = [ "https://genome-idx.s3.amazonaws.com/kraken/16S_Greengenes13.5_20200326.tgz" ]
             citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
             fmtscript = ""
+            dbversion = "Greengenes 13.5 (https://benlangmead.github.io/aws-indexes/k2)"
             taxlevels = "D,P,C,O,F,G,S"
         }
         'greengenes=13.5' {
@@ -601,6 +613,7 @@ params {
             file = [ "https://genome-idx.s3.amazonaws.com/kraken/16S_Greengenes13.5_20200326.tgz" ]
             citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
             fmtscript = ""
+            dbversion = "Greengenes 13.5 (https://benlangmead.github.io/aws-indexes/k2)"
             taxlevels = "D,P,C,O,F,G,S"
         }
         'standard' {
@@ -608,6 +621,7 @@ params {
             file = [ "https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20240904.tar.gz" ]
             citation = "Wood, D. E., Lu, J., & Langmead, B. (2019). Improved metagenomic analysis with Kraken 2. Genome biology, 20(1), 257. https://doi.org/10.1186/s13059-019-1891-0"
             fmtscript = ""
+            dbversion = "Standard 20240904 (https://benlangmead.github.io/aws-indexes/k2)"
             taxlevels = "D,P,C,O,F,G,S"
         }
         'standard=20240904' {
@@ -615,6 +629,7 @@ params {
             file = [ "https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20240904.tar.gz" ]
             citation = "Wood, D. E., Lu, J., & Langmead, B. (2019). Improved metagenomic analysis with Kraken 2. Genome biology, 20(1), 257. https://doi.org/10.1186/s13059-019-1891-0"
             fmtscript = ""
+            dbversion = "Standard 20240904 (https://benlangmead.github.io/aws-indexes/k2)"
             taxlevels = "D,P,C,O,F,G,S"
         }
         'standard=20230605' {
@@ -622,6 +637,7 @@ params {
             file = [ "https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20230605.tar.gz" ]
             citation = "Wood, D. E., Lu, J., & Langmead, B. (2019). Improved metagenomic analysis with Kraken 2. Genome biology, 20(1), 257. https://doi.org/10.1186/s13059-019-1891-0"
             fmtscript = ""
+            dbversion = "Standard 20230605 (https://benlangmead.github.io/aws-indexes/k2)"
             taxlevels = "D,P,C,O,F,G,S"
         }
     }
@@ -634,6 +650,7 @@ params {
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = "taxref_reformat_sidle.sh"
+            dbversion = "SILVA v128 (https://www.arb-silva.de/)"
             taxlevels = "D,P,C,O,F,G"
         }
         'silva=128' {
@@ -643,6 +660,7 @@ params {
             citation = "https://www.arb-silva.de/; Bokulich, N.A., Robeson, M., Dillon, M.R. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931"
             license = "https://www.arb-silva.de/silva-license-information/"
             fmtscript = "taxref_reformat_sidle.sh"
+            dbversion = "SILVA v128 (https://www.arb-silva.de/)"
             taxlevels = "D,P,C,O,F,G"
         }
         // Index in https://ftp.microbio.me/greengenes_release/
@@ -652,6 +670,7 @@ params {
             tree_qza = [ "https://data.qiime2.org/2021.4/common/sepp-refs-gg-13-8.qza" ]
             citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
             fmtscript = "taxref_reformat_sidle.sh"
+            dbversion = "Greengenes 13.8 (https://ftp.microbio.me/greengenes_release/gg_13_5/)"
             taxlevels = "D,P,C,O,F,G,S"
         }
         'greengenes=13_8' {
@@ -660,7 +679,17 @@ params {
             tree_qza = [ "https://data.qiime2.org/2021.4/common/sepp-refs-gg-13-8.qza" ]
             citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
             fmtscript = "taxref_reformat_sidle.sh"
+            dbversion = "Greengenes 13.8 (https://ftp.microbio.me/greengenes_release/gg_13_5/)"
             taxlevels = "D,P,C,O,F,G,S"
+        }
+        'greengenes88' {
+            title = "Greengenes - Version 13_8 - clustered at 88% similarity - for testing purposes only"
+            file = [ "ftp://greengenes.microbio.me/greengenes_release/gg_13_5/gg_13_8_otus.tar.gz" ]
+            citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
+            fmtscript = "taxref_reformat_sidle.sh"
+            dbversion = "Greengenes 13.8 (https://ftp.microbio.me/greengenes_release/gg_13_5/)"
+            taxlevels = "D,P,C,O,F,G,S"
+            derep = "88"
         }
     }
 }

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -664,7 +664,7 @@ params {
         }
         'greengenes=12_8_88' {
             title = "Greengenes - Version 12_8 - clustered at 88% similarity - for testing purposes only"
-            file = [ "ftp://greengenes.microbio.me/greengenes_release/gg_12_8/gg_12_8.fasta.gz" ]
+            file = [ "ftp://greengenes.microbio.me/greengenes_release/gg_12_8/gg_12_8_otus.tar.gz" ]
             citation = "McDonald, D., Price, M., Goodrich, J. et al. An improved Greengenes taxonomy with explicit ranks for ecological and evolutionary analyses of bacteria and archaea. ISME J 6, 610–618 (2012). https://doi.org/10.1038/ismej.2011.139"
             fmtscript = "taxref_reformat_sidle.sh"
             taxlevels = "D,P,C,O,F,G,S"

--- a/conf/test_multiregion.config
+++ b/conf/test_multiregion.config
@@ -26,7 +26,7 @@ params {
     input = params.pipelines_testdata_base_path + "ampliseq/samplesheets/samplesheet_multiregion.tsv"
     metadata = params.pipelines_testdata_base_path + "ampliseq/samplesheets/metadata_multiregion.tsv"
     multiregion = params.pipelines_testdata_base_path + "ampliseq/samplesheets/regions_multiregion.tsv"
-    sidle_ref_taxonomy = "greengenes=13_8"
+    sidle_ref_taxonomy = "greengenes88"
 
     // Prevent default taxonomic classification
     skip_dada_taxonomy = true

--- a/conf/test_multiregion.config
+++ b/conf/test_multiregion.config
@@ -26,7 +26,7 @@ params {
     input = params.pipelines_testdata_base_path + "ampliseq/samplesheets/samplesheet_multiregion.tsv"
     metadata = params.pipelines_testdata_base_path + "ampliseq/samplesheets/metadata_multiregion.tsv"
     multiregion = params.pipelines_testdata_base_path + "ampliseq/samplesheets/regions_multiregion.tsv"
-    sidle_ref_taxonomy = "greengenes=12_8_88"
+    sidle_ref_taxonomy = "greengenes=13_8"
 
     // Prevent default taxonomic classification
     skip_dada_taxonomy = true

--- a/conf/test_multiregion.config
+++ b/conf/test_multiregion.config
@@ -26,7 +26,7 @@ params {
     input = params.pipelines_testdata_base_path + "ampliseq/samplesheets/samplesheet_multiregion.tsv"
     metadata = params.pipelines_testdata_base_path + "ampliseq/samplesheets/metadata_multiregion.tsv"
     multiregion = params.pipelines_testdata_base_path + "ampliseq/samplesheets/regions_multiregion.tsv"
-    sidle_ref_taxonomy = "greengenes88"
+    sidle_ref_taxonomy = "greengenes=12_8_88"
 
     // Prevent default taxonomic classification
     skip_dada_taxonomy = true

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -267,6 +267,10 @@ Special features of taxonomic classification tools:
 
 Parameter guidance is given in [nf-core/ampliseq website parameter documentation](https://nf-co.re/ampliseq/parameters/#taxonomic-assignment). Citations are listed in [`CITATIONS.md`](CITATIONS.md).
 
+> [!TIP]
+> Taxonomic reference databases can be stored and shared locally with [--ref_taxonomy_storage](https://nf-co.re/ampliseq/parameters/#ref_taxonomy_storage).
+> That way, remote files will be downloaded only if they are not available in the storage directory.
+
 ### Multiple region analysis with Sidle
 
 Instead of relying on one short amplicon, scaffolding multiple regions along a reference can improve resolution over a single region. This method applies [Sidle (SMURF Implementation Done to acceLerate Efficiency)](https://github.com/jwdebelius/q2-sidle) within [QIIME2](https://qiime2.org/) with [Silva](https://www.arb-silva.de/) (see [licence](https://www.arb-silva.de/silva-license-information/)) or [Greengenes](http://greengenes.microbio.me/greengenes_release/) database.

--- a/modules/local/download_reference.nf
+++ b/modules/local/download_reference.nf
@@ -1,0 +1,22 @@
+process DOWNLOAD_REFERENCE {
+    tag "${local_filename}"
+    label 'process_single'
+
+    conda "conda-forge::wget=1.21.4"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3b/3b54fa9135194c72a18d00db6b399c03248103f87e43ca75e4b50d61179994b3/data':
+        'community.wave.seqera.io/library/wget:1.21.4--8b0fcde81c17be5e' }"
+    
+    input:
+    val ref_url
+    
+    output:
+    path "${local_filename}", emit: db
+    // version output file is not wanted because of overwriting issues when storeDir is used
+    
+    script:
+    local_filename = file(ref_url).name
+    """
+    wget -O "${local_filename}" "${ref_url}"
+    """
+}

--- a/modules/local/download_reference.nf
+++ b/modules/local/download_reference.nf
@@ -6,14 +6,14 @@ process DOWNLOAD_REFERENCE {
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3b/3b54fa9135194c72a18d00db6b399c03248103f87e43ca75e4b50d61179994b3/data':
         'community.wave.seqera.io/library/wget:1.21.4--8b0fcde81c17be5e' }"
-    
+
     input:
     val ref_url
-    
+
     output:
     path "${local_filename}", emit: db
     // version output file is not wanted because of overwriting issues when storeDir is used
-    
+
     script:
     local_filename = file(ref_url).name
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -124,7 +124,8 @@ params {
     skip_report            = false
 
     // Taxonomic assignment options
-    dada_min_boot = 50
+    ref_taxonomy_storage     = null
+    dada_min_boot            = 50
     dada_ref_taxonomy        = "silva=138.2"
     dada_assign_taxlevels    = null
     dada_ref_tax_custom      = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -676,7 +676,7 @@
                     "type": "string",
                     "help_text": "",
                     "description": "Name of supported database, and optionally also version number",
-                    "enum": ["silva", "silva=128", "greengenes", "greengenes=13_8", "greengenes=12_8_88"]
+                    "enum": ["silva", "silva=128", "greengenes", "greengenes=13_8"]
                 },
                 "sidle_ref_tax_custom": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -72,6 +72,12 @@
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
                 },
+                "ref_taxonomy_storage": {
+                    "type": "string",
+                    "format": "directory-path",
+                    "description": "The directory where the reference taxonomy databases will be saved for re-use. Absolute paths to storage on Cloud infrastructure.",
+                    "fa_icon": "fas fa-folder-open"
+                },
                 "save_intermediates": {
                     "type": "boolean",
                     "description": "Save intermediate results such as QIIME2's qza and qzv files",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -676,7 +676,7 @@
                     "type": "string",
                     "help_text": "",
                     "description": "Name of supported database, and optionally also version number",
-                    "enum": ["silva", "silva=128", "greengenes", "greengenes=13_8", "greengenes88"]
+                    "enum": ["silva", "silva=128", "greengenes", "greengenes=13_8", "greengenes=12_8_88"]
                 },
                 "sidle_ref_tax_custom": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -676,7 +676,7 @@
                     "type": "string",
                     "help_text": "",
                     "description": "Name of supported database, and optionally also version number",
-                    "enum": ["silva", "silva=128", "greengenes", "greengenes=13_8"]
+                    "enum": ["silva", "silva=128", "greengenes", "greengenes=13_8", "greengenes88"]
                 },
                 "sidle_ref_tax_custom": {
                     "type": "string",

--- a/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
@@ -319,6 +319,58 @@ def validateInputParameters() {
             log.warn "Incompatible parameters: Multiple region analysis with `--multiregion` ignores any of `--vsearch_cluster`, `--filter_ssu`, `--min_len_asv`, `--max_len_asv`, `--filter_codons`, `--cut_its`"
         }
     }
+
+    //
+    // Verify that all database files with identical titels are unique
+    //
+
+    // Collect all files from all database sections
+    def allFiles = [:]
+    params.each { sectionName, sectionValue ->
+        // Check if this section contains database configurations (nested maps with 'file' key)
+        if (sectionValue instanceof Map && sectionValue.any { it.value instanceof Map && it.value.containsKey('file') }) {
+            sectionValue.each { dbKey, dbConfig ->
+                if (dbConfig.containsKey('file')) {
+                    dbConfig.file.each { fileUrl ->
+                        def fileName = fileUrl.split('/')[-1]
+                        if (!allFiles.containsKey(fileName)) {
+                            allFiles[fileName] = []
+                        }
+                        allFiles[fileName] << [
+                            "section": sectionName,
+                            "key": dbKey,
+                            "title": dbConfig.title
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    // Validate: files should be unique, unless they belong to the same database 'file'
+    def validationPassed = true
+    def failed_duplication = []
+    def passed_duplication = []
+    allFiles.each { fileName, occurrences ->
+        if (occurrences.size() > 1) {
+            // Check if all occurrences have the same title
+            def uniqueCateggory = occurrences.collect { it -> it.title }.unique()
+            
+            if (uniqueCateggory.size() > 1) {
+                validationPassed = false
+                failed_duplication << "File '${fileName}' is used by different databases:\n" +
+                    occurrences.collect { it -> "  - ${it.section}['${it.key}']: ${it.title}" }.join("\n")
+            } else {
+                // This is allowed: same database 'file' under different keys
+                passed_duplication << "  - File '${fileName}' with multiple keys: " +
+                    occurrences.collect { "${it.section}['${it.key}']" }.join(", ")
+            }
+        }
+    }
+    // Report in case the validation failed
+    if (!validationPassed) {
+        log.error( "Validation failed!\nDuplicated database files with same database title:\n" + passed_duplication.join("\n") + "\nDuplicate database files across different database titles detected:\n" + failed_duplication.join("\n\n") )
+        error("Duplicate files across different databases detected")
+    }
 }
 
 //

--- a/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
@@ -354,7 +354,7 @@ def validateInputParameters() {
         if (occurrences.size() > 1) {
             // Check if all occurrences have the same title
             def uniqueCateggory = occurrences.collect { it -> it.title }.unique()
-            
+
             if (uniqueCateggory.size() > 1) {
                 validationPassed = false
                 failed_duplication << "File '${fileName}' is used by different databases:\n" +

--- a/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
@@ -327,7 +327,7 @@ def validateInputParameters() {
     // Verify that all database entries have "dbversion" fields
     def requiredFields = ['title', 'file', 'citation', 'fmtscript', 'dbversion']
     def errors = []
-    
+
     // Iterate through all params entries
     params.each { key, value ->
         if (value instanceof Map) {

--- a/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
@@ -321,8 +321,35 @@ def validateInputParameters() {
     }
 
     //
-    // Verify that all database files with identical titels are unique
+    // Verify that all database files with identical dbversions are unique
     //
+
+    // Verify that all database entries have "dbversion" fields
+    def requiredFields = ['title', 'file', 'citation', 'fmtscript', 'dbversion']
+    def errors = []
+    
+    // Iterate through all params entries
+    params.each { key, value ->
+        if (value instanceof Map) {
+            // Iterate through each entry in the map
+            value.each { dbKey, dbEntry ->
+                if (dbEntry instanceof Map) {
+                    // Check for missing required fields
+                    def missingFields = requiredFields.findAll { field ->
+                        !dbEntry.containsKey(field) || dbEntry[field] == null
+                    }
+                    if (missingFields) {
+                        errors.add("   - params.${key}[${dbKey}]: Missing required fields: ${missingFields.join(', ')}")
+                    }
+                }
+            }
+        }
+    }
+    // Report errors
+    if (errors) {
+        log.error("Reference database validation failed:\n" + errors.join("\n"))
+        error("Missing fields in reference database definitions.")
+    }
 
     // Collect all files from all database sections
     def allFiles = [:]
@@ -339,7 +366,7 @@ def validateInputParameters() {
                         allFiles[fileName] << [
                             "section": sectionName,
                             "key": dbKey,
-                            "title": dbConfig.title
+                            "dbversion": dbConfig.dbversion
                         ]
                     }
                 }
@@ -352,13 +379,13 @@ def validateInputParameters() {
     def passed_duplication = []
     allFiles.each { fileName, occurrences ->
         if (occurrences.size() > 1) {
-            // Check if all occurrences have the same title
-            def uniqueCateggory = occurrences.collect { it -> it.title }.unique()
+            // Check if all occurrences have the same dbversion
+            def uniqueCateggory = occurrences.collect { it -> it.dbversion }.unique()
 
             if (uniqueCateggory.size() > 1) {
                 validationPassed = false
                 failed_duplication << "File '${fileName}' is used by different databases:\n" +
-                    occurrences.collect { it -> "  - ${it.section}['${it.key}']: ${it.title}" }.join("\n")
+                    occurrences.collect { it -> "  - ${it.section}['${it.key}']: ${it.dbversion}" }.join("\n")
             } else {
                 // This is allowed: same database 'file' under different keys
                 passed_duplication << "  - File '${fileName}' with multiple keys: " +
@@ -368,7 +395,7 @@ def validateInputParameters() {
     }
     // Report in case the validation failed
     if (!validationPassed) {
-        log.error( "Validation failed!\nDuplicated database files with same database title:\n" + passed_duplication.join("\n") + "\nDuplicate database files across different database titles detected:\n" + failed_duplication.join("\n\n") )
+        log.error( "Validation failed!\nDuplicated database files with same database dbversion:\n" + passed_duplication.join("\n") + "\nDuplicate database files across different database dbversions detected:\n" + failed_duplication.join("\n\n") )
         error("Duplicate files across different databases detected")
     }
 }

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -372,7 +372,7 @@ workflow AMPLISEQ {
         // database files
         ch_kraken2_ref_taxonomy_url = params.kraken2_ref_databases.containsKey(params.kraken2_ref_taxonomy) ?
             channel.fromList(params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["file"]) : channel.empty()
-        ch_kraken2_ref_taxonomy = DOWNLOAD_REFERENCE_KRAKEN( ch_kraken2_ref_taxonomy_url ).db.collect()
+        ch_kraken2_ref_taxonomy = DOWNLOAD_REFERENCE_KRAKEN( ch_kraken2_ref_taxonomy_url ).db
         // name
         val_kraken2_ref_taxonomy = params.kraken2_ref_taxonomy.replace('=','_').replace('.','_')
         // taxlevels

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -17,6 +17,12 @@ include { FASTA_NEWICK_EPANG_GAPPA          } from '../subworkflows/nf-core/fast
 // MODULE: Installed directly from nf-core/modules
 //
 
+include { DOWNLOAD_REFERENCE as DOWNLOAD_REFERENCE_DADA       } from '../modules/local/download_reference'
+include { DOWNLOAD_REFERENCE as DOWNLOAD_REFERENCE_SINTAX     } from '../modules/local/download_reference'
+include { DOWNLOAD_REFERENCE as DOWNLOAD_REFERENCE_KRAKEN     } from '../modules/local/download_reference'
+include { DOWNLOAD_REFERENCE as DOWNLOAD_REFERENCE_QIIME      } from '../modules/local/download_reference'
+include { DOWNLOAD_REFERENCE as DOWNLOAD_REFERENCE_SIDLE      } from '../modules/local/download_reference'
+include { DOWNLOAD_REFERENCE as DOWNLOAD_REFERENCE_SIDLE_TREE } from '../modules/local/download_reference'
 include { RENAME_RAW_DATA_FILES         } from '../modules/local/rename_raw_data_files'
 include { DADA2_ERR                     } from '../modules/local/dada2_err'
 include { NOVASEQ_ERR                   } from '../modules/local/novaseq_err'
@@ -79,7 +85,7 @@ include { QIIME2_EXPORT                 } from '../subworkflows/local/qiime2_exp
 include { QIIME2_BARPLOTAVG             } from '../subworkflows/local/qiime2_barplotavg'
 include { QIIME2_DIVERSITY              } from '../subworkflows/local/qiime2_diversity'
 include { QIIME2_ANCOM                  } from '../subworkflows/local/qiime2_ancom'
-include { ROBJECT_WORKFLOW             } from '../subworkflows/local/robject_workflow'
+include { ROBJECT_WORKFLOW              } from '../subworkflows/local/robject_workflow'
 
 //
 // FUNCTIONS
@@ -100,94 +106,17 @@ include { makeComplement         } from '../subworkflows/local/utils_nfcore_ampl
 workflow AMPLISEQ {
 
     main:
+    // set empty channels
+    ch_tax_for_robject = channel.empty()
+    ch_versions        = channel.empty()
+    ch_multiqc_files   = channel.empty()
+
     //
     // INPUT AND VARIABLES
     //
     if (params.metadata) {
         ch_metadata = channel.fromPath("${params.metadata}", checkIfExists: true)
     } else { ch_metadata = channel.empty() }
-
-    if (params.classifier) {
-        ch_qiime_classifier = channel.fromPath("${params.classifier}", checkIfExists: true)
-    } else { ch_qiime_classifier = channel.empty() }
-
-    if (params.sidle_ref_tax_custom) {
-        //custom ref taxonomy input from params.sidle_ref_tax_custom & params.sidle_ref_seq_custom & [optionallly] params.sidle_ref_aln_custom
-        channel.fromPath("${params.sidle_ref_tax_custom}", checkIfExists: true)
-            .combine( channel.fromPath("${params.sidle_ref_seq_custom}", checkIfExists: true) )
-            .combine( params.sidle_ref_aln_custom ? channel.fromPath("${params.sidle_ref_aln_custom}", checkIfExists: true) : channel.of("EMPTY") )
-            .set{ ch_sidle_ref_taxonomy }
-        ch_sidle_ref_taxonomy_tree = params.sidle_ref_tree_custom ? channel.fromPath("${params.sidle_ref_tree_custom}", checkIfExists: true) : channel.empty()
-        val_sidle_ref_taxonomy = "user"
-    } else if (params.sidle_ref_taxonomy) {
-        //standard ref taxonomy input from params.sidle_ref_taxonomy & conf/ref_databases.config
-        ch_sidle_ref_taxonomy = channel.fromList( params.sidle_ref_databases[params.sidle_ref_taxonomy]["file"] ).map { it -> file(it) }
-        ch_sidle_ref_taxonomy_tree = params.sidle_ref_tree_custom ? channel.fromPath("${params.sidle_ref_tree_custom}", checkIfExists: true) :
-            params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ? channel.fromList( params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ).map { it -> file(it) } : channel.empty()
-        val_sidle_ref_taxonomy = params.sidle_ref_taxonomy.replace('=','_').replace('.','_')
-    } else {
-        ch_sidle_ref_taxonomy = channel.empty()
-        ch_sidle_ref_taxonomy_tree = channel.empty()
-        val_sidle_ref_taxonomy = "none"
-    }
-
-    if (params.dada_ref_tax_custom) {
-        //custom ref taxonomy input from params.dada_ref_tax_custom & params.dada_ref_tax_custom_sp
-        ch_assigntax = channel.fromPath("${params.dada_ref_tax_custom}", checkIfExists: true)
-        if (params.dada_ref_tax_custom_sp) {
-            ch_addspecies = channel.fromPath("${params.dada_ref_tax_custom_sp}", checkIfExists: true)
-        } else { ch_addspecies = channel.empty() }
-        ch_dada_ref_taxonomy = channel.empty()
-        val_dada_ref_taxonomy = "user"
-    } else if (params.dada_ref_taxonomy && !params.skip_dada_taxonomy && !params.skip_taxonomy) {
-        //standard ref taxonomy input from params.dada_ref_taxonomy & conf/ref_databases.config
-        ch_dada_ref_taxonomy = params.dada_ref_databases.containsKey(params.dada_ref_taxonomy) ? channel.fromList(params.dada_ref_databases[params.dada_ref_taxonomy]["file"]).map { it -> file(it) } : channel.empty()
-        val_dada_ref_taxonomy = params.dada_ref_taxonomy.replace('=','_').replace('.','_')
-    } else {
-        ch_dada_ref_taxonomy = channel.empty()
-        val_dada_ref_taxonomy = "none"
-    }
-
-    if (params.qiime_ref_tax_custom) {
-        if ("${params.qiime_ref_tax_custom}".contains(",")) {
-            qiime_ref_paths = "${params.qiime_ref_tax_custom}".split(",")
-            if (qiime_ref_paths.length != 2) {
-                error "--qiime_ref_tax_custom accepts a single filepath to a directory or tarball, or two filepaths separated by a comma. Please review input."
-            }
-
-            ch_qiime_ref_taxonomy = channel.fromPath(Arrays.asList(qiime_ref_paths), checkIfExists: true)
-        } else {
-            ch_qiime_ref_taxonomy = channel.fromPath("${params.qiime_ref_tax_custom}", checkIfExists: true)
-        }
-        val_qiime_ref_taxonomy = "user"
-    } else if (params.qiime_ref_taxonomy && !params.skip_taxonomy && !params.classifier) {
-        ch_qiime_ref_taxonomy = params.qiime_ref_databases.containsKey(params.qiime_ref_taxonomy) ? channel.fromList(params.qiime_ref_databases[params.qiime_ref_taxonomy]["file"]).map { it -> file(it) } : channel.empty()
-        val_qiime_ref_taxonomy = params.qiime_ref_taxonomy.replace('=','_').replace('.','_')
-    } else {
-        ch_qiime_ref_taxonomy = channel.empty()
-        val_qiime_ref_taxonomy = "none"
-    }
-
-    if (params.sintax_ref_taxonomy && !params.skip_taxonomy) {
-        ch_sintax_ref_taxonomy = params.sintax_ref_databases.containsKey(params.sintax_ref_taxonomy) ? channel.fromList(params.sintax_ref_databases[params.sintax_ref_taxonomy]["file"]).map { it -> file(it) } : channel.empty()
-        val_sintax_ref_taxonomy = params.sintax_ref_taxonomy.replace('=','_').replace('.','_')
-    } else {
-        ch_sintax_ref_taxonomy = channel.empty()
-        val_sintax_ref_taxonomy = "none"
-    }
-
-    if (params.kraken2_ref_tax_custom) {
-        //custom ref taxonomy input from params.kraken2_ref_tax_custom
-        ch_kraken2_ref_taxonomy = channel.fromPath("${params.kraken2_ref_tax_custom}", checkIfExists: true)
-        val_kraken2_ref_taxonomy = "user"
-    } else if (params.kraken2_ref_taxonomy && !params.skip_taxonomy) {
-        //standard ref taxonomy input from params.dada_ref_taxonomy & conf/ref_databases.config
-        ch_kraken2_ref_taxonomy = params.kraken2_ref_databases.containsKey(params.kraken2_ref_taxonomy) ? channel.fromList(params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["file"]).map { it -> file(it) } : channel.empty()
-        val_kraken2_ref_taxonomy = params.kraken2_ref_taxonomy.replace('=','_').replace('.','_')
-    } else {
-        ch_kraken2_ref_taxonomy = channel.empty()
-        val_kraken2_ref_taxonomy = "none"
-    }
 
     // report sources
     ch_report_template = channel.fromPath("${params.report_template}", checkIfExists: true)
@@ -213,28 +142,6 @@ workflow AMPLISEQ {
     tax_agglom_min = params.tax_agglom_min
     tax_agglom_max = params.tax_agglom_max
 
-    //use custom taxlevels from --dada_assign_taxlevels or database specific taxlevels if specified in conf/ref_databases.config
-    if ( params.dada_ref_taxonomy ) {
-        taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" :
-            params.dada_ref_databases.containsKey(params.dada_ref_taxonomy) && params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] ? params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] : ""
-    } else { taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" : "" }
-    if ( params.sintax_ref_taxonomy ) {
-        sintax_taxlevels = params.sintax_ref_databases.containsKey(params.sintax_ref_taxonomy) && params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] ? params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] : ""
-    } else {
-        sintax_taxlevels = ""
-    }
-    if ( params.kraken2_ref_taxonomy ) {
-        kraken2_taxlevels = params.kraken2_assign_taxlevels ? "${params.kraken2_assign_taxlevels}" :
-            params.kraken2_ref_databases.containsKey(params.kraken2_ref_taxonomy) && params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] ? params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] : ""
-    } else { kraken2_taxlevels = params.kraken2_assign_taxlevels ? "${params.kraken2_assign_taxlevels}" : "" }
-
-    //make sure that taxlevels adheres to requirements when mixed with addSpecies
-    if ( params.dada_ref_taxonomy && !params.skip_dada_addspecies && !params.skip_dada_taxonomy && !params.skip_taxonomy && taxlevels ) {
-        if ( !taxlevels.endsWith(",Genus,Species") && !taxlevels.endsWith(",Genus") ) {
-            error("Incompatible settings: To use exact species annotations, taxonomic levels must end with `,Genus,Species` or `,Genus` but are currently `${taxlevels}`. Taxonomic levels can be set with `--dada_assign_taxlevels`. Skip exact species annotations with `--skip_dada_addspecies`.\n")
-        }
-    }
-
     // Only run QIIME2 taxonomy classification if needed parameters are passed and we are not skipping taxonomy or qiime steps.
     if ( !params.skip_taxonomy && !params.skip_qiime && (params.qiime_ref_taxonomy || params.qiime_ref_tax_custom || params.classifier) ) {
         run_qiime2_taxonomy = true
@@ -248,10 +155,6 @@ workflow AMPLISEQ {
     } else {
         run_qiime2 = false
     }
-
-    ch_tax_for_robject = channel.empty()
-    ch_versions = channel.empty()
-    ch_multiqc_files = channel.empty()
 
     //
     // Create input channels
@@ -344,6 +247,139 @@ workflow AMPLISEQ {
             def meta = info.subMap( info.keySet() - 'control' - 'quant_reading' ) // remove decontam metadata because it isnt needed any more
             return [ meta, reads ] }
         .set { ch_reads }
+
+    //
+    // REFERENCE TAXONOMY DATABASES
+    //
+
+    // SIDLE
+    ch_sidle_ref_taxonomy      = channel.empty()
+    ch_sidle_ref_taxonomy_tree = channel.empty()
+    val_sidle_ref_taxonomy     = "none"
+
+    if (params.sidle_ref_tax_custom) {
+        //custom ref taxonomy input from params.sidle_ref_tax_custom & params.sidle_ref_seq_custom & [optionally] params.sidle_ref_aln_custom
+        channel.fromPath("${params.sidle_ref_tax_custom}", checkIfExists: true)
+            .combine( channel.fromPath("${params.sidle_ref_seq_custom}", checkIfExists: true) )
+            .combine( params.sidle_ref_aln_custom ? channel.fromPath("${params.sidle_ref_aln_custom}", checkIfExists: true) : channel.of("EMPTY") )
+            .set{ ch_sidle_ref_taxonomy }
+        ch_sidle_ref_taxonomy_tree = params.sidle_ref_tree_custom ? channel.fromPath("${params.sidle_ref_tree_custom}", checkIfExists: true) : channel.empty()
+        val_sidle_ref_taxonomy = "user"
+    } else if (params.sidle_ref_taxonomy) {
+        //standard ref taxonomy input from params.sidle_ref_taxonomy & conf/ref_databases.config
+        ch_sidle_ref_taxonomy_url = channel.fromList(params.sidle_ref_databases[params.sidle_ref_taxonomy]["file"])
+        ch_sidle_ref_taxonomy = DOWNLOAD_REFERENCE_SIDLE( ch_sidle_ref_taxonomy_url ).db.collect()
+        ch_sidle_ref_taxonomy_tree = 
+            params.sidle_ref_tree_custom ? channel.fromPath("${params.sidle_ref_tree_custom}", checkIfExists: true) :
+                params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ? 
+                    DOWNLOAD_REFERENCE_SIDLE_TREE( channel.fromList( params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ) ).db :
+                        channel.empty()
+        val_sidle_ref_taxonomy = params.sidle_ref_taxonomy.replace('=','_').replace('.','_')
+    }
+
+    // DADA2
+    ch_dada_assigntax     = channel.empty()
+    ch_dada_addspecies    = channel.empty()
+    ch_dada_ref_taxonomy  = channel.empty()
+    val_dada_ref_taxonomy = "none"
+    val_dada_taxlevels    = ""
+
+    if (params.dada_ref_tax_custom) {
+        //custom ref taxonomy input from params.dada_ref_tax_custom & params.dada_ref_tax_custom_sp
+        ch_dada_assigntax = channel.fromPath("${params.dada_ref_tax_custom}", checkIfExists: true)
+        if (params.dada_ref_tax_custom_sp) {
+            ch_dada_addspecies = channel.fromPath("${params.dada_ref_tax_custom_sp}", checkIfExists: true)
+        }
+        ch_dada_ref_taxonomy = channel.empty()
+        val_dada_ref_taxonomy = "user"
+        val_dada_taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" : ""
+    } else if (params.dada_ref_taxonomy && !params.skip_dada_taxonomy && !params.skip_taxonomy) {
+        //standard ref taxonomy input from params.dada_ref_taxonomy & conf/ref_databases.config
+        // database files
+        ch_dada_ref_taxonomy_url = params.dada_ref_databases.containsKey(params.dada_ref_taxonomy) ?
+            channel.fromList(params.dada_ref_databases[params.dada_ref_taxonomy]["file"]) :
+                channel.empty()
+        ch_dada_ref_taxonomy = DOWNLOAD_REFERENCE_DADA( ch_dada_ref_taxonomy_url ).db.collect()
+        // name
+        val_dada_ref_taxonomy = params.dada_ref_taxonomy.replace('=','_').replace('.','_')
+        // taxlevels
+        val_dada_taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" :
+            params.dada_ref_databases.containsKey(params.dada_ref_taxonomy) && params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] ?
+                params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] : ""
+    }
+
+    //make sure that taxlevels adheres to requirements when mixed with addSpecies
+    if ( params.dada_ref_taxonomy && !params.skip_dada_addspecies && !params.skip_dada_taxonomy && !params.skip_taxonomy && val_dada_taxlevels ) {
+        if ( !val_dada_taxlevels.endsWith(",Genus,Species") && !val_dada_taxlevels.endsWith(",Genus") ) {
+            error("Incompatible settings: To use exact species annotations, taxonomic levels must end with `,Genus,Species` or `,Genus` but are currently `${val_dada_taxlevels}`. Taxonomic levels can be set with `--dada_assign_taxlevels`. Skip exact species annotations with `--skip_dada_addspecies`.\n")
+        }
+    }
+
+    // QIIME2
+    ch_qiime_ref_taxonomy  = channel.empty()
+    val_qiime_ref_taxonomy = "none"
+    ch_qiime_classifier    = channel.empty()
+
+    if (params.classifier) {
+        ch_qiime_classifier = channel.fromPath("${params.classifier}", checkIfExists: true)
+    } else if (params.qiime_ref_tax_custom) {
+        if ("${params.qiime_ref_tax_custom}".contains(",")) {
+            qiime_ref_paths = "${params.qiime_ref_tax_custom}".split(",")
+            if (qiime_ref_paths.length != 2) {
+                error "--qiime_ref_tax_custom accepts a single filepath to a directory or tarball, or two filepaths separated by a comma. Please review input."
+            }
+            ch_qiime_ref_taxonomy = channel.fromPath(Arrays.asList(qiime_ref_paths), checkIfExists: true)
+        } else {
+            ch_qiime_ref_taxonomy = channel.fromPath("${params.qiime_ref_tax_custom}", checkIfExists: true)
+        }
+        val_qiime_ref_taxonomy = "user"
+    } else if (params.qiime_ref_taxonomy && run_qiime2_taxonomy) {
+        ch_qiime_ref_taxonomy_url = params.qiime_ref_databases.containsKey(params.qiime_ref_taxonomy) ?
+            channel.fromList(params.qiime_ref_databases[params.qiime_ref_taxonomy]["file"]) : channel.empty()
+        ch_qiime_ref_taxonomy = DOWNLOAD_REFERENCE_QIIME( ch_qiime_ref_taxonomy_url ).db.collect()
+        val_qiime_ref_taxonomy = params.qiime_ref_taxonomy.replace('=','_').replace('.','_')
+    }
+
+    // SINTAX
+    ch_sintax_ref_taxonomy  = channel.empty()
+    val_sintax_ref_taxonomy = "none"
+    val_sintax_taxlevels    = ""
+
+    if (params.sintax_ref_taxonomy && !params.skip_taxonomy) {
+        // database files
+        ch_sintax_ref_taxonomy_url = params.sintax_ref_databases.containsKey(params.sintax_ref_taxonomy) ?
+            channel.fromList(params.sintax_ref_databases[params.sintax_ref_taxonomy]["file"]) : channel.empty()
+        ch_sintax_ref_taxonomy = DOWNLOAD_REFERENCE_SINTAX( ch_sintax_ref_taxonomy_url ).db.collect()
+        // name
+        val_sintax_ref_taxonomy = params.sintax_ref_taxonomy.replace('=','_').replace('.','_')
+        // taxlevels
+        val_sintax_taxlevels = params.sintax_ref_databases.containsKey(params.sintax_ref_taxonomy) && params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] ?
+            params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] : ""
+    }
+
+    // KRAKEN2
+    ch_kraken2_ref_taxonomy  = channel.empty()
+    val_kraken2_ref_taxonomy = "none"
+    val_kraken2_taxlevels    = ""
+
+    if (params.kraken2_ref_tax_custom) {
+        //custom ref taxonomy input from params.kraken2_ref_tax_custom
+        ch_kraken2_ref_taxonomy = channel.fromPath("${params.kraken2_ref_tax_custom}", checkIfExists: true)
+        val_kraken2_ref_taxonomy = "user"
+        val_kraken2_taxlevels = params.kraken2_assign_taxlevels ? "${params.kraken2_assign_taxlevels}" : ""
+    } else if (params.kraken2_ref_taxonomy && !params.skip_taxonomy) {
+        //standard ref taxonomy input from params.dada_ref_taxonomy & conf/ref_databases.config
+        // database files
+        ch_kraken2_ref_taxonomy_url = params.kraken2_ref_databases.containsKey(params.kraken2_ref_taxonomy) ?
+            channel.fromList(params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["file"]) : channel.empty()
+        ch_kraken2_ref_taxonomy = DOWNLOAD_REFERENCE_KRAKEN( ch_kraken2_ref_taxonomy_url ).db.collect()
+        // name
+        val_kraken2_ref_taxonomy = params.kraken2_ref_taxonomy.replace('=','_').replace('.','_')
+        // taxlevels
+        val_kraken2_taxlevels = params.kraken2_assign_taxlevels ? "${params.kraken2_assign_taxlevels}" :
+            params.kraken2_ref_databases.containsKey(params.kraken2_ref_taxonomy) && params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] ?
+                params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] : ""
+    }
 
     //
     // MODULE: Rename files
@@ -632,16 +668,16 @@ workflow AMPLISEQ {
             //standard ref taxonomy input from conf/ref_databases.config
             FORMAT_TAXONOMY ( ch_dada_ref_taxonomy.collect(), val_dada_ref_taxonomy )
             ch_versions = ch_versions.mix(FORMAT_TAXONOMY.out.versions)
-            ch_assigntax = FORMAT_TAXONOMY.out.assigntax
-            ch_addspecies = FORMAT_TAXONOMY.out.addspecies
+            ch_dada_assigntax = FORMAT_TAXONOMY.out.assigntax
+            ch_dada_addspecies = FORMAT_TAXONOMY.out.addspecies
         }
         DADA2_TAXONOMY_WF (
-            ch_assigntax,
-            ch_addspecies,
+            ch_dada_assigntax,
+            ch_dada_addspecies,
             val_dada_ref_taxonomy,
             ch_fasta,
             ch_full_fasta,
-            taxlevels,
+            val_dada_taxlevels,
             params.dada_assign_chunksize
         ).tax.set { ch_dada2_tax }
         ch_versions = ch_versions.mix(DADA2_TAXONOMY_WF.out.versions)
@@ -656,7 +692,7 @@ workflow AMPLISEQ {
             ch_kraken2_ref_taxonomy,
             val_kraken2_ref_taxonomy,
             ch_fasta,
-            kraken2_taxlevels
+            val_kraken2_taxlevels
         ).qiime2_tsv.set { ch_kraken2_tax }
         ch_versions = ch_versions.mix(KRAKEN2_TAXONOMY_WF.out.versions)
         ch_tax_for_robject = ch_tax_for_robject.mix ( ch_kraken2_tax.map { it -> [ "kraken2", file(it) ] } )
@@ -671,7 +707,7 @@ workflow AMPLISEQ {
             val_sintax_ref_taxonomy,
             ch_fasta,
             ch_full_fasta,
-            sintax_taxlevels
+            val_sintax_taxlevels
         ).tax.set { ch_sintax_tax }
         ch_versions = ch_versions.mix(SINTAX_TAXONOMY_WF.out.versions)
         ch_tax_for_robject = ch_tax_for_robject.mix ( ch_sintax_tax.map { it -> [ "sintax", file(it) ] } )

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -269,9 +269,9 @@ workflow AMPLISEQ {
         //standard ref taxonomy input from params.sidle_ref_taxonomy & conf/ref_databases.config
         ch_sidle_ref_taxonomy_url = channel.fromList(params.sidle_ref_databases[params.sidle_ref_taxonomy]["file"])
         ch_sidle_ref_taxonomy = DOWNLOAD_REFERENCE_SIDLE( ch_sidle_ref_taxonomy_url ).db.collect()
-        ch_sidle_ref_taxonomy_tree = 
+        ch_sidle_ref_taxonomy_tree =
             params.sidle_ref_tree_custom ? channel.fromPath("${params.sidle_ref_tree_custom}", checkIfExists: true) :
-                params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ? 
+                params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ?
                     DOWNLOAD_REFERENCE_SIDLE_TREE( channel.fromList( params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ) ).db :
                         channel.empty()
         val_sidle_ref_taxonomy = params.sidle_ref_taxonomy.replace('=','_').replace('.','_')


### PR DESCRIPTION
Closes https://github.com/nf-core/ampliseq/issues/963.

When using the newly added parameter `--ref_taxonomy_storage`, remote taxonomic reference databases will be re-used from a local reference storage directory. That avoids downloading remote reference databases multiple times when working on the same compute resource but in a different working directory.

The changes appear here larger than they are, because database retrieval was a bit scattered in the ampliseq.nf script and I wanted to standardize it. I also considered (and tested) to use a subworkflow, but that complicated the matter because values (val_*) were emitted instead as channels.

To not accidentely use a wrong file when using the reference storage directory, each reference database file must have a unique file name in `conf/ref_databases.config`, and I added a verification step into `subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf`.

Potential issues:
- The added module is local, the nf-core wget module could be used, but would require modifications and/or extensive config & channel operations

I verified strict syntax compliance with
```
NXF_VER=25.10.2 nextflow lint ampliseq -exclude ".git,.nf-test,nf-test.config"
NXF_VER=26.02.0-edge nextflow lint ampliseq -exclude ".git,.nf-test,nf-test.config"
NXF_VER=26.02.0-edge NXF_SYNTAX_PARSER=v2 nextflow run ampliseq --help
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
