### PR TITLE
Using nextflow download over wget where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#959](https://github.com/nf-core/ampliseq/pull/959) - Add the possibility to place ASVs in the best matching tree through a spreadsheet with HMM profiles and corresponding reference trees (see [usage doc](https://github.com/nf-core/ampliseq/docs/usage.md#multiple-reference-phylogenetic-placement)).
 - [#959](https://github.com/nf-core/ampliseq/pull/959) - Add archaeal and bacterial reference trees for phylogenetic placement to `sbdi-gtdb` reference database (see [usage doc](https://github.com/nf-core/ampliseq/docs/usage.md#placement-in-database-provided-phylogenies); only for the current release, i.e. R10-RS226-2).
 - [#957](https://github.com/nf-core/ampliseq/pull/957) - Added ITSxRust as an optional alternative to ITSx for ITS region extraction via `--its_extractor itsxrust`.
-- [#964](https://github.com/nf-core/ampliseq/pull/964) - Enabled local reference storage directory with `--ref_taxonomy_storage`.
+- [#964](https://github.com/nf-core/ampliseq/pull/964),[#968](https://github.com/nf-core/ampliseq/pull/968) - Enabled local reference storage directory with `--ref_taxonomy_storage`.
 
 ### `Changed`
 

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -297,12 +297,16 @@ workflow AMPLISEQ {
     } else if (params.sidle_ref_taxonomy) {
         //standard ref taxonomy input from params.sidle_ref_taxonomy & conf/ref_databases.config
         ch_sidle_ref_taxonomy_url = channel.fromList(params.sidle_ref_databases[params.sidle_ref_taxonomy]["file"])
-        ch_sidle_ref_taxonomy = DOWNLOAD_REFERENCE_SIDLE( ch_sidle_ref_taxonomy_url ).db.collect()
+        ch_sidle_ref_taxonomy = 
+            params.ref_taxonomy_storage ? DOWNLOAD_REFERENCE_SIDLE( ch_sidle_ref_taxonomy_url ).db.collect() :
+                ch_sidle_ref_taxonomy_url.map { it -> file(it) }
         ch_sidle_ref_taxonomy_tree =
             params.sidle_ref_tree_custom ? channel.fromPath("${params.sidle_ref_tree_custom}", checkIfExists: true) :
-                params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ?
+                params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] && params.ref_taxonomy_storage ?
                     DOWNLOAD_REFERENCE_SIDLE_TREE( channel.fromList( params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ) ).db :
-                        channel.empty()
+                        params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] && !params.ref_taxonomy_storage ?
+                            channel.fromList( params.sidle_ref_databases[params.sidle_ref_taxonomy]["tree_qza"] ).map { it -> file(it) } :
+                                channel.empty()
         val_sidle_ref_taxonomy = params.sidle_ref_taxonomy.replace('=','_').replace('.','_')
     }
 
@@ -325,15 +329,15 @@ workflow AMPLISEQ {
     } else if (params.dada_ref_taxonomy && !params.skip_dada_taxonomy && !params.skip_taxonomy) {
         //standard ref taxonomy input from params.dada_ref_taxonomy & conf/ref_databases.config
         // database files
-        ch_dada_ref_taxonomy_url = params.dada_ref_databases.containsKey(params.dada_ref_taxonomy) ?
-            channel.fromList(params.dada_ref_databases[params.dada_ref_taxonomy]["file"]) :
-                channel.empty()
-        ch_dada_ref_taxonomy = DOWNLOAD_REFERENCE_DADA( ch_dada_ref_taxonomy_url ).db.collect()
+        ch_dada_ref_taxonomy_url = channel.fromList(params.dada_ref_databases[params.dada_ref_taxonomy]["file"])
+        ch_dada_ref_taxonomy = 
+            params.ref_taxonomy_storage ? DOWNLOAD_REFERENCE_DADA( ch_dada_ref_taxonomy_url ).db.collect() :
+                ch_dada_ref_taxonomy_url.map { it -> file(it) }
         // name
         val_dada_ref_taxonomy = params.dada_ref_taxonomy.replace('=','_').replace('.','_')
         // taxlevels
         val_dada_taxlevels = params.dada_assign_taxlevels ? "${params.dada_assign_taxlevels}" :
-            params.dada_ref_databases.containsKey(params.dada_ref_taxonomy) && params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] ?
+            params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] ?
                 params.dada_ref_databases[params.dada_ref_taxonomy]["taxlevels"] : ""
     }
 
@@ -363,9 +367,10 @@ workflow AMPLISEQ {
         }
         val_qiime_ref_taxonomy = "user"
     } else if (params.qiime_ref_taxonomy && run_qiime2_taxonomy) {
-        ch_qiime_ref_taxonomy_url = params.qiime_ref_databases.containsKey(params.qiime_ref_taxonomy) ?
-            channel.fromList(params.qiime_ref_databases[params.qiime_ref_taxonomy]["file"]) : channel.empty()
-        ch_qiime_ref_taxonomy = DOWNLOAD_REFERENCE_QIIME( ch_qiime_ref_taxonomy_url ).db.collect()
+        ch_qiime_ref_taxonomy_url = channel.fromList(params.qiime_ref_databases[params.qiime_ref_taxonomy]["file"])
+        ch_qiime_ref_taxonomy = 
+            params.ref_taxonomy_storage ? DOWNLOAD_REFERENCE_QIIME( ch_qiime_ref_taxonomy_url ).db.collect() :
+                ch_qiime_ref_taxonomy_url.map { it -> file(it) }
         val_qiime_ref_taxonomy = params.qiime_ref_taxonomy.replace('=','_').replace('.','_')
     }
 
@@ -376,13 +381,14 @@ workflow AMPLISEQ {
 
     if (params.sintax_ref_taxonomy && !params.skip_taxonomy) {
         // database files
-        ch_sintax_ref_taxonomy_url = params.sintax_ref_databases.containsKey(params.sintax_ref_taxonomy) ?
-            channel.fromList(params.sintax_ref_databases[params.sintax_ref_taxonomy]["file"]) : channel.empty()
-        ch_sintax_ref_taxonomy = DOWNLOAD_REFERENCE_SINTAX( ch_sintax_ref_taxonomy_url ).db.collect()
+        ch_sintax_ref_taxonomy_url = channel.fromList(params.sintax_ref_databases[params.sintax_ref_taxonomy]["file"])
+        ch_sintax_ref_taxonomy = 
+            params.ref_taxonomy_storage ? DOWNLOAD_REFERENCE_SINTAX( ch_sintax_ref_taxonomy_url ).db.collect() :
+                ch_sintax_ref_taxonomy_url.map { it -> file(it) }
         // name
         val_sintax_ref_taxonomy = params.sintax_ref_taxonomy.replace('=','_').replace('.','_')
         // taxlevels
-        val_sintax_taxlevels = params.sintax_ref_databases.containsKey(params.sintax_ref_taxonomy) && params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] ?
+        val_sintax_taxlevels = params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] ?
             params.sintax_ref_databases[params.sintax_ref_taxonomy]["taxlevels"] : ""
     }
 
@@ -399,14 +405,15 @@ workflow AMPLISEQ {
     } else if (params.kraken2_ref_taxonomy && !params.skip_taxonomy) {
         //standard ref taxonomy input from params.dada_ref_taxonomy & conf/ref_databases.config
         // database files
-        ch_kraken2_ref_taxonomy_url = params.kraken2_ref_databases.containsKey(params.kraken2_ref_taxonomy) ?
-            channel.fromList(params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["file"]) : channel.empty()
-        ch_kraken2_ref_taxonomy = DOWNLOAD_REFERENCE_KRAKEN( ch_kraken2_ref_taxonomy_url ).db
+        ch_kraken2_ref_taxonomy_url = channel.fromList(params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["file"])
+        ch_kraken2_ref_taxonomy = 
+            params.ref_taxonomy_storage ? DOWNLOAD_REFERENCE_KRAKEN( ch_kraken2_ref_taxonomy_url ).db :
+                ch_kraken2_ref_taxonomy_url.map { it -> file(it) }
         // name
         val_kraken2_ref_taxonomy = params.kraken2_ref_taxonomy.replace('=','_').replace('.','_')
         // taxlevels
         val_kraken2_taxlevels = params.kraken2_assign_taxlevels ? "${params.kraken2_assign_taxlevels}" :
-            params.kraken2_ref_databases.containsKey(params.kraken2_ref_taxonomy) && params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] ?
+            params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] ?
                 params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["taxlevels"] : ""
     }
 

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -297,7 +297,7 @@ workflow AMPLISEQ {
     } else if (params.sidle_ref_taxonomy) {
         //standard ref taxonomy input from params.sidle_ref_taxonomy & conf/ref_databases.config
         ch_sidle_ref_taxonomy_url = channel.fromList(params.sidle_ref_databases[params.sidle_ref_taxonomy]["file"])
-        ch_sidle_ref_taxonomy = 
+        ch_sidle_ref_taxonomy =
             params.ref_taxonomy_storage ? DOWNLOAD_REFERENCE_SIDLE( ch_sidle_ref_taxonomy_url ).db.collect() :
                 ch_sidle_ref_taxonomy_url.map { it -> file(it) }
         ch_sidle_ref_taxonomy_tree =
@@ -330,7 +330,7 @@ workflow AMPLISEQ {
         //standard ref taxonomy input from params.dada_ref_taxonomy & conf/ref_databases.config
         // database files
         ch_dada_ref_taxonomy_url = channel.fromList(params.dada_ref_databases[params.dada_ref_taxonomy]["file"])
-        ch_dada_ref_taxonomy = 
+        ch_dada_ref_taxonomy =
             params.ref_taxonomy_storage ? DOWNLOAD_REFERENCE_DADA( ch_dada_ref_taxonomy_url ).db.collect() :
                 ch_dada_ref_taxonomy_url.map { it -> file(it) }
         // name
@@ -368,7 +368,7 @@ workflow AMPLISEQ {
         val_qiime_ref_taxonomy = "user"
     } else if (params.qiime_ref_taxonomy && run_qiime2_taxonomy) {
         ch_qiime_ref_taxonomy_url = channel.fromList(params.qiime_ref_databases[params.qiime_ref_taxonomy]["file"])
-        ch_qiime_ref_taxonomy = 
+        ch_qiime_ref_taxonomy =
             params.ref_taxonomy_storage ? DOWNLOAD_REFERENCE_QIIME( ch_qiime_ref_taxonomy_url ).db.collect() :
                 ch_qiime_ref_taxonomy_url.map { it -> file(it) }
         val_qiime_ref_taxonomy = params.qiime_ref_taxonomy.replace('=','_').replace('.','_')
@@ -382,7 +382,7 @@ workflow AMPLISEQ {
     if (params.sintax_ref_taxonomy && !params.skip_taxonomy) {
         // database files
         ch_sintax_ref_taxonomy_url = channel.fromList(params.sintax_ref_databases[params.sintax_ref_taxonomy]["file"])
-        ch_sintax_ref_taxonomy = 
+        ch_sintax_ref_taxonomy =
             params.ref_taxonomy_storage ? DOWNLOAD_REFERENCE_SINTAX( ch_sintax_ref_taxonomy_url ).db.collect() :
                 ch_sintax_ref_taxonomy_url.map { it -> file(it) }
         // name
@@ -406,7 +406,7 @@ workflow AMPLISEQ {
         //standard ref taxonomy input from params.dada_ref_taxonomy & conf/ref_databases.config
         // database files
         ch_kraken2_ref_taxonomy_url = channel.fromList(params.kraken2_ref_databases[params.kraken2_ref_taxonomy]["file"])
-        ch_kraken2_ref_taxonomy = 
+        ch_kraken2_ref_taxonomy =
             params.ref_taxonomy_storage ? DOWNLOAD_REFERENCE_KRAKEN( ch_kraken2_ref_taxonomy_url ).db :
                 ch_kraken2_ref_taxonomy_url.map { it -> file(it) }
         // name


### PR DESCRIPTION
Nextflow download is sometimes more reliable than wget, this PR makes sure that wget is only used with `--ref_taxonomy_storage`, allowing to essentially choose the download method for reference taxonomy databases. Amends https://github.com/nf-core/ampliseq/pull/964 for https://github.com/nf-core/ampliseq/issues/963.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
