### PR TITLE
Fix checking compatible databases for --sbdiexport

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
-          max_shards: 14
+          max_shards: 15
 
       - name: debug
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#706](https://github.com/nf-core/ampliseq/pull/706) - Ensure paired FASTQ files stay aligned by generating reverse paths from forward files instead of sorting independently
 - [#958](https://github.com/nf-core/ampliseq/pull/958) - Fix AWS tests
+- [#969](https://github.com/nf-core/ampliseq/pull/969) - Fix checking for sbdiexport compatibility for newer nextflow versions
 
 ### `Dependencies`
 

--- a/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
@@ -271,10 +271,10 @@ def validateInputParameters() {
     ]
     if (params.sbdiexport){
         if (params.sintax_ref_taxonomy ) {
-            if ( !Arrays.stream(sbdi_compatible_databases).any{ entry -> params.sintax_ref_taxonomy.toString().equals(entry) } ) {
+            if ( sbdi_compatible_databases.any{ entry -> params.sintax_ref_taxonomy.toString().equals(entry) } ) {
                 error("Incompatible parameters: `--sbdiexport` does not work with the chosen database of `--sintax_ref_taxonomy` because the expected taxonomic levels do not match.")
             }
-        } else if ( !Arrays.stream(sbdi_compatible_databases).any{ entry -> params.dada_ref_taxonomy.toString().equals(entry) } ) {
+        } else if ( !sbdi_compatible_databases.any{ entry -> params.dada_ref_taxonomy.toString().equals(entry) } ) {
             error("Incompatible parameters: `--sbdiexport` does not work with the chosen database of `--dada_ref_taxonomy` because the expected taxonomic levels do not match.")
         }
     }

--- a/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
@@ -271,10 +271,10 @@ def validateInputParameters() {
     ]
     if (params.sbdiexport){
         if (params.sintax_ref_taxonomy ) {
-            if ( sbdi_compatible_databases.any{ entry -> params.sintax_ref_taxonomy.toString().equals(entry) } ) {
+            if ( !sbdi_compatible_databases.contains(params.sintax_ref_taxonomy) ) {
                 error("Incompatible parameters: `--sbdiexport` does not work with the chosen database of `--sintax_ref_taxonomy` because the expected taxonomic levels do not match.")
             }
-        } else if ( !sbdi_compatible_databases.any{ entry -> params.dada_ref_taxonomy.toString().equals(entry) } ) {
+        } else if ( !sbdi_compatible_databases.contains(params.dada_ref_taxonomy) ) {
             error("Incompatible parameters: `--sbdiexport` does not work with the chosen database of `--dada_ref_taxonomy` because the expected taxonomic levels do not match.")
         }
     }


### PR DESCRIPTION
Closes https://github.com/nf-core/ampliseq/issues/967.
It appears that newer nextflow versions had trouble with the current syntax.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
