### PR TITLE
Hardcode AWS test env to `aws_ireland_s3_cpu_spot`

### DIFF
--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           workspace_id: ${{ vars.TOWER_WORKSPACE_ID }}
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute_env: ${{ vars.TOWER_COMPUTE_ENV_NO_FUSION }}
+          compute_env: "aws_ireland_s3_cpu_spot"
           revision: ${{ steps.revision.outputs.revision }}
           workdir: s3://${{ vars.AWS_S3_BUCKET }}/work/ampliseq/work-${{ steps.revision.outputs.revision }}
           parameters: |

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           workspace_id: ${{ vars.TOWER_WORKSPACE_ID }}
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute_env: ${{ vars.TOWER_COMPUTE_ENV_NO_FUSION }}
+          compute_env: "aws_ireland_s3_cpu_spot"
           revision: ${{ github.sha }}
           workdir: s3://${{ vars.AWS_S3_BUCKET }}/work/ampliseq/work-${{ github.sha }}
           parameters: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#706](https://github.com/nf-core/ampliseq/pull/706) - Ensure paired FASTQ files stay aligned by generating reverse paths from forward files instead of sorting independently
-- [#958](https://github.com/nf-core/ampliseq/pull/958) - Fix AWS tests
+- [#958](https://github.com/nf-core/ampliseq/pull/958),[#970](https://github.com/nf-core/ampliseq/pull/970) - Fix AWS tests
 
 ### `Dependencies`
 


### PR DESCRIPTION
Aims to make AWS tests work out of the box again. Hardcode `compute_env` to `aws_ireland_s3_cpu_spot`
Amends https://github.com/nf-core/ampliseq/pull/958.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
