### PR TITLE
Prevent raising the stack size on AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#706](https://github.com/nf-core/ampliseq/pull/706) - Ensure paired FASTQ files stay aligned by generating reverse paths from forward files instead of sorting independently
-- [#958](https://github.com/nf-core/ampliseq/pull/958),[#970](https://github.com/nf-core/ampliseq/pull/970) - Fix AWS tests
+- [#958](https://github.com/nf-core/ampliseq/pull/958),[#970](https://github.com/nf-core/ampliseq/pull/970),[#971](https://github.com/nf-core/ampliseq/pull/971) - Fix AWS tests
 
 ### `Dependencies`
 

--- a/conf/aws_scratch.config
+++ b/conf/aws_scratch.config
@@ -15,3 +15,6 @@ process {
         memory = '40.GB'
     }
 }
+params {
+    raise_filter_stacksize = false
+}


### PR DESCRIPTION
Aims to make AWS test work out of the box again. Prevent raising the stack size on AWS, that made "nf-core AWS test" fail.
Amends https://github.com/nf-core/ampliseq/pull/958 & https://github.com/nf-core/ampliseq/pull/970.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
