### PR TITLE
Update strict syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#706](https://github.com/nf-core/ampliseq/pull/706) - Ensure paired FASTQ files stay aligned by generating reverse paths from forward files instead of sorting independently
 - [#958](https://github.com/nf-core/ampliseq/pull/958),[#970](https://github.com/nf-core/ampliseq/pull/970),[#971](https://github.com/nf-core/ampliseq/pull/971) - Fix AWS tests
 - [#969](https://github.com/nf-core/ampliseq/pull/969) - Fix checking for sbdiexport compatibility for newer nextflow versions
+- [#984](https://github.com/nf-core/ampliseq/pull/984) - Adhere to strict syntax, incl. update to nf-core modules
 
 ### `Dependencies`
 

--- a/modules.json
+++ b/modules.json
@@ -80,7 +80,7 @@
                     },
                     "kraken2/kraken2": {
                         "branch": "master",
-                        "git_sha": "1a9dc0fd9f8f61099b3c912df1ab97fac72a1f86",
+                        "git_sha": "71a39f3598935d64ffd65f0960e4d2d4a42ab778",
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/kraken2/kraken2/kraken2-kraken2.diff"
                     },
@@ -96,9 +96,8 @@
                     },
                     "pigz/uncompress": {
                         "branch": "master",
-                        "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
-                        "installed_by": ["modules"],
-                        "patch": "modules/nf-core/pigz/uncompress/pigz-uncompress.diff"
+                        "git_sha": "145b0a6fb5e6b56bccd9a030a1baf75b207ac250",
+                        "installed_by": ["modules"]
                     },
                     "seqtk/subseq": {
                         "branch": "master",
@@ -112,7 +111,7 @@
                     },
                     "vsearch/cluster": {
                         "branch": "master",
-                        "git_sha": "3bc4793d82c7bf7b10d29b1aa49a5ebe10c0cdd9",
+                        "git_sha": "694b2cdc2d695926dc10ac149e59b7b5b563cef9",
                         "installed_by": ["modules"]
                     },
                     "vsearch/sintax": {

--- a/modules/local/hmmer/hmmextract/main.nf
+++ b/modules/local/hmmer/hmmextract/main.nf
@@ -47,7 +47,6 @@ process HMMER_HMMEXTRACT {
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix  = task.ext.prefix ?: "${meta.id}"
 
     """

--- a/modules/nf-core/kraken2/kraken2/kraken2-kraken2.diff
+++ b/modules/nf-core/kraken2/kraken2/kraken2-kraken2.diff
@@ -3,7 +3,7 @@ Changes in component 'nf-core/kraken2/kraken2'
 Changes in 'kraken2/kraken2/main.nf':
 --- modules/nf-core/kraken2/kraken2/main.nf
 +++ modules/nf-core/kraken2/kraken2/main.nf
-@@ -39,7 +39,6 @@
+@@ -40,7 +40,6 @@
          --db $db \\
          --threads $task.cpus \\
          --report ${prefix}.kraken2.report.txt \\

--- a/modules/nf-core/kraken2/kraken2/main.nf
+++ b/modules/nf-core/kraken2/kraken2/main.nf
@@ -18,7 +18,8 @@ process KRAKEN2_KRAKEN2 {
     tuple val(meta), path('*.unclassified{.,_}*')   , optional:true, emit: unclassified_reads_fastq
     tuple val(meta), path('*classifiedreads.txt')   , optional:true, emit: classified_reads_assignment
     tuple val(meta), path('*report.txt')                           , emit: report
-    path "versions.yml"                                            , emit: versions
+    tuple val("${task.process}"), val('kraken2'), eval('kraken2 --version 2>&1 | head -1 | sed "s/^.*Kraken version //; s/ .*//"'), topic: versions, emit: versions_kraken2
+    tuple val("${task.process}"), val('pigz'), eval('pigz --version 2>&1 | sed "s/pigz //g"'), topic: versions, emit: versions_pigz
 
     when:
     task.ext.when == null || task.ext.when
@@ -47,22 +48,12 @@ process KRAKEN2_KRAKEN2 {
         $reads
 
     $compress_reads_command
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kraken2: \$(echo \$(kraken2 --version 2>&1) | sed 's/^.*Kraken version //; s/ .*\$//')
-        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def paired       = meta.single_end ? "" : "--paired"
     def classified   = meta.single_end ? "${prefix}.classified.fastq.gz"   : "${prefix}.classified_1.fastq.gz ${prefix}.classified_2.fastq.gz"
     def unclassified = meta.single_end ? "${prefix}.unclassified.fastq.gz" : "${prefix}.unclassified_1.fastq.gz ${prefix}.unclassified_2.fastq.gz"
-    def readclassification_option = save_reads_assignment ? "--output ${prefix}.kraken2.classifiedreads.txt" : "--output /dev/null"
-    def compress_reads_command = save_output_fastqs ? "pigz -p $task.cpus *.fastq" : ""
 
     """
     touch ${prefix}.kraken2.report.txt
@@ -73,12 +64,6 @@ process KRAKEN2_KRAKEN2 {
     if [ "$save_reads_assignment" == "true" ]; then
         touch ${prefix}.kraken2.classifiedreads.txt
     fi
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kraken2: \$(echo \$(kraken2 --version 2>&1) | sed 's/^.*Kraken version //; s/ .*\$//')
-        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-    END_VERSIONS
     """
 
 }

--- a/modules/nf-core/kraken2/kraken2/meta.yml
+++ b/modules/nf-core/kraken2/kraken2/meta.yml
@@ -91,13 +91,48 @@ output:
             and not classified reads.
           pattern: "*.{report.txt}"
           ontologies: []
+  versions_kraken2:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - kraken2:
+          type: string
+          description: The tool name
+      - kraken2 --version 2>&1 | head -1 | sed "s/^.*Kraken version //; s/ .*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_pigz:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - pigz:
+          type: string
+          description: The tool name
+      - pigz --version 2>&1 | sed "s/pigz //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - kraken2:
+          type: string
+          description: The tool name
+      - kraken2 --version 2>&1 | head -1 | sed "s/^.*Kraken version //; s/ .*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - pigz:
+          type: string
+          description: The tool name
+      - pigz --version 2>&1 | sed "s/pigz //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/kraken2/kraken2/tests/main.nf.test
+++ b/modules/nf-core/kraken2/kraken2/tests/main.nf.test
@@ -48,7 +48,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                 ).match()
             },
             { assert process.out.classified_reads_fastq.get(0).get(1) ==~ ".*/test.classified.fastq.gz" },
@@ -91,7 +91,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                 ).match()
             },
             { assert process.out.classified_reads_fastq.get(0).get(1).get(0)
@@ -133,7 +133,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                     process.out.classified_reads_assignment,
                 ).match()
             },
@@ -164,7 +164,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                 ).match()
             },
             { assert process.out.classified_reads_fastq.get(0).get(1) ==~ ".*/test.classified.fastq.gz" },
@@ -196,7 +196,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                 ).match()
             },
             { assert process.out.classified_reads_fastq.get(0).get(1).get(0)

--- a/modules/nf-core/kraken2/kraken2/tests/main.nf.test.snap
+++ b/modules/nf-core/kraken2/kraken2/tests/main.nf.test.snap
@@ -10,15 +10,28 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ]
             ],
-            [
-                "versions.yml:md5,3f1efbca96594bcbd7759bd992f3ffda"
-            ]
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.04.8"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-29T10:39:33.16840511"
+        "timestamp": "2026-01-19T17:22:36.682041524"
     },
     "paired_end - stub": {
         "content": [
@@ -31,15 +44,28 @@
                     "test.kraken2.report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
-            [
-                "versions.yml:md5,3f1efbca96594bcbd7759bd992f3ffda"
-            ]
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.04.8"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-29T10:57:46.285333986"
+        "timestamp": "2026-01-19T17:22:59.824433284"
     },
     "sarscov2 custom_prefix - stub": {
         "content": [
@@ -76,15 +102,28 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ]
             ],
-            [
-                "versions.yml:md5,3f1efbca96594bcbd7759bd992f3ffda"
-            ]
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-09-26T10:40:12.99538483"
+        "timestamp": "2026-01-19T17:22:42.807626617"
     },
     "sarscov2 illumina single end [fastq] + save_reads_assignment": {
         "content": [
@@ -97,9 +136,22 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ]
             ],
-            [
-                "versions.yml:md5,3f1efbca96594bcbd7759bd992f3ffda"
-            ],
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            },
             [
                 [
                     {
@@ -111,10 +163,10 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-04T16:53:38.496195464"
+        "timestamp": "2026-01-19T17:22:48.87201447"
     },
     "single_end - stub": {
         "content": [
@@ -127,14 +179,27 @@
                     "test.kraken2.report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
-            [
-                "versions.yml:md5,3f1efbca96594bcbd7759bd992f3ffda"
-            ]
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.04.8"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-29T10:44:44.698158761"
+        "timestamp": "2026-01-19T17:22:54.351663948"
     }
 }

--- a/modules/nf-core/pigz/uncompress/main.nf
+++ b/modules/nf-core/pigz/uncompress/main.nf
@@ -13,7 +13,7 @@ process PIGZ_UNCOMPRESS {
 
     output:
     tuple val(meta), path("${uncompressed_filename}") , emit: file
-    path "versions.yml"                               , emit: versions
+    tuple val("${task.process}"), val('pigz'), eval('pigz --version 2>&1 | sed "s/^.*pigz[[:space:]]*//"'), emit: versions_pigz, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,21 +29,11 @@ process PIGZ_UNCOMPRESS {
         $args \\
         ${zip}
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        pigz: \$(echo \$(pigz --version 2>&1) | sed 's/^.*pigz[[:space:]]*//' )
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     uncompressed_filename = zip.toString() - '.gz'
     """
     touch $uncompressed_filename
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        pigz: \$(echo \$(pigz --version 2>&1) | sed 's/^.*pigz[[:space:]]*//' )
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/pigz/uncompress/meta.yml
+++ b/modules/nf-core/pigz/uncompress/meta.yml
@@ -10,7 +10,7 @@ tools:
       description: "Parallel implementation of the gzip algorithm."
       homepage: "https://zlib.net/pigz/"
       documentation: "https://zlib.net/pigz/pigz.pdf"
-
+      licence: ["Zlib"]
       identifier: ""
 input:
   - - meta:
@@ -36,12 +36,27 @@ output:
           description: File to compress
           pattern: "*"
           ontologies: []
+  versions_pigz:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pigz:
+          type: string
+          description: The name of the tool
+      - pigz --version 2>&1 | sed "s/^.*pigz[[:space:]]*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pigz:
+          type: string
+          description: The name of the tool
+      - pigz --version 2>&1 | sed "s/^.*pigz[[:space:]]*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@lrauschning"

--- a/modules/nf-core/pigz/uncompress/tests/main.nf.test.snap
+++ b/modules/nf-core/pigz/uncompress/tests/main.nf.test.snap
@@ -11,7 +11,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,e0c776f8d0bfa6d8e49e02aeb0728355"
+                    [
+                        "PIGZ_UNCOMPRESS",
+                        "pigz",
+                        "2.8"
+                    ]
                 ],
                 "file": [
                     [
@@ -21,16 +25,20 @@
                         "test_1.fastq:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e0c776f8d0bfa6d8e49e02aeb0728355"
+                "versions_pigz": [
+                    [
+                        "PIGZ_UNCOMPRESS",
+                        "pigz",
+                        "2.8"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-12T14:09:47.6005396",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-03-11T11:24:38.144787334"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "Should run without failures": {
         "content": [
@@ -44,7 +52,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,e0c776f8d0bfa6d8e49e02aeb0728355"
+                    [
+                        "PIGZ_UNCOMPRESS",
+                        "pigz",
+                        "2.8"
+                    ]
                 ],
                 "file": [
                     [
@@ -54,15 +66,19 @@
                         "test_1.fastq:md5,4161df271f9bfcd25d5845a1e220dbec"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e0c776f8d0bfa6d8e49e02aeb0728355"
+                "versions_pigz": [
+                    [
+                        "PIGZ_UNCOMPRESS",
+                        "pigz",
+                        "2.8"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-12T14:09:40.395155052",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-03-11T11:23:17.620127425"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/vsearch/cluster/meta.yml
+++ b/modules/nf-core/vsearch/cluster/meta.yml
@@ -1,17 +1,18 @@
 name: "vsearch_cluster"
-description: Cluster sequences using a single-pass, greedy centroid-based clustering
-  algorithm.
+description: Cluster sequences using a single-pass, greedy centroid-based
+  clustering algorithm.
 keywords:
   - vsearch
   - clustering
   - microbiome
 tools:
   - vsearch:
-      description: VSEARCH is a versatile open-source tool for microbiome analysis,
-        including chimera detection, clustering, dereplication and rereplication, extraction,
-        FASTA/FASTQ/SFF file processing, masking, orienting, pair-wise alignment, restriction
-        site cutting, searching, shuffling, sorting, subsampling, and taxonomic classification
-        of amplicon sequences for metagenomics, genomics, and population genetics. (USEARCH
+      description: VSEARCH is a versatile open-source tool for microbiome
+        analysis, including chimera detection, clustering, dereplication and
+        rereplication, extraction, FASTA/FASTQ/SFF file processing, masking,
+        orienting, pair-wise alignment, restriction site cutting, searching,
+        shuffling, sorting, subsampling, and taxonomic classification of amplicon
+        sequences for metagenomics, genomics, and population genetics. (USEARCH
         alternative)
       homepage: https://github.com/torognes/vsearch
       documentation: https://github.com/torognes/vsearch/releases/download/v2.21.1/vsearch_manual.pdf
@@ -61,8 +62,8 @@ output:
             e.g. [ id:'test' ]
       - "*.mothur.tsv.gz":
           type: file
-          description: Results in an OTU table in the mothur ’shared’ tab-separated
-            plain text file format
+          description: Results in an OTU table in the mothur ’shared’
+            tab-separated plain text file format
           pattern: "*.mothur.tsv.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
@@ -74,8 +75,8 @@ output:
             e.g. [ id:'test' ]
       - "*.otu.tsv.gz":
           type: file
-          description: Results in an OTU table in the classic tab-separated plain text
-            format
+          description: Results in an OTU table in the classic tab-separated plain
+            text format
           pattern: "*.otu.tsv.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
@@ -122,7 +123,8 @@ output:
             e.g. [ id:'test' ]
       - "*.uc.tsv.gz":
           type: file
-          description: Tab delimited results in a uclust-like format with 10 columns
+          description: Tab delimited results in a uclust-like format with 10
+            columns
           pattern: "*.uc.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
@@ -174,13 +176,29 @@ output:
           pattern: "*.msa.fasta.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
+  versions_vsearch:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - vsearch:
+          type: string
+          description: The tool name
+      - vsearch --version 2>&1 | sed -n "1s/.*v\([0-9.]*\).*/\\1/p":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - vsearch:
+          type: string
+          description: The tool name
+      - vsearch --version 2>&1 | sed -n "1s/.*v\([0-9.]*\).*/\\1/p":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@mirpedrol"
 maintainers:

--- a/modules/nf-core/vsearch/cluster/tests/main.nf.test
+++ b/modules/nf-core/vsearch/cluster/tests/main.nf.test
@@ -32,7 +32,8 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(process.out).match() },
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith("versions") }).match("versions") }
             )
         }
 

--- a/modules/nf-core/vsearch/cluster/tests/main.nf.test.snap
+++ b/modules/nf-core/vsearch/cluster/tests/main.nf.test.snap
@@ -15,7 +15,11 @@
                     
                 ],
                 "12": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ],
                 "2": [
                     
@@ -89,16 +93,20 @@
                 "uc": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                "versions_vsearch": [
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2023-12-06T14:35:18.210433"
+        "timestamp": "2026-02-13T10:35:39.665177612"
     },
     "sarscov2 - fastq - cluster userout": {
         "content": [
@@ -116,7 +124,11 @@
                     
                 ],
                 "12": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ],
                 "2": [
                     
@@ -190,16 +202,20 @@
                 "uc": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                "versions_vsearch": [
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2023-12-06T14:35:27.471744"
+        "timestamp": "2026-02-13T10:35:54.538041255"
     },
     "sarscov2 - fastq - cluster size - stub": {
         "content": [
@@ -217,7 +233,11 @@
                     
                 ],
                 "12": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ],
                 "2": [
                     
@@ -291,16 +311,38 @@
                 "uc": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                "versions_vsearch": [
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2025-08-07T15:01:40.029544"
+        "timestamp": "2026-02-13T10:36:09.229901854"
+    },
+    "versions": {
+        "content": [
+            {
+                "versions_vsearch": [
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-13T10:35:24.197694337"
     },
     "sarscov2 - fastq - cluster size": {
         "content": [
@@ -318,7 +360,11 @@
                     
                 ],
                 "12": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ],
                 "2": [
                     
@@ -392,16 +438,20 @@
                 "uc": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                "versions_vsearch": [
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2023-12-06T14:35:13.922868"
+        "timestamp": "2026-02-13T10:35:31.811335455"
     },
     "sarscov2 - fastq - cluster unoise": {
         "content": [
@@ -419,7 +469,11 @@
                     
                 ],
                 "12": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ],
                 "2": [
                     
@@ -493,16 +547,20 @@
                 "uc": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                "versions_vsearch": [
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2023-12-06T14:35:22.849537"
+        "timestamp": "2026-02-13T10:35:47.041096957"
     },
     "sarscov2 - fastq - cluster fast - stub": {
         "content": [
@@ -520,7 +578,11 @@
                     
                 ],
                 "12": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ],
                 "2": [
                     
@@ -594,16 +656,20 @@
                 "uc": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                "versions_vsearch": [
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2025-08-07T14:59:06.666076"
+        "timestamp": "2026-02-13T10:36:01.905883862"
     },
     "sarscov2 - fastq - cluster fast": {
         "content": [
@@ -621,7 +687,11 @@
                     
                 ],
                 "12": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ],
                 "2": [
                     
@@ -695,15 +765,19 @@
                 "uc": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,c9f7c3c0952e510ae64bf71dc85c3c0f"
+                "versions_vsearch": [
+                    [
+                        "VSEARCH_CLUSTER",
+                        "vsearch",
+                        "2.21.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2023-12-06T14:35:07.719346"
+        "timestamp": "2026-02-13T10:35:24.173804599"
     }
 }

--- a/subworkflows/local/dada2_preprocessing.nf
+++ b/subworkflows/local/dada2_preprocessing.nf
@@ -55,7 +55,7 @@ workflow DADA2_PREPROCESSING {
         TRUNCLEN.out.trunc
             .toSortedList()
             .set { ch_trunc }
-        ch_versions_dada2_preprocessing = ch_versions_dada2_preprocessing.mix(TRUNCLEN.out.versions.first())
+        ch_versions_dada2_preprocessing = ch_versions_dada2_preprocessing.mix(TRUNCLEN.out.versions)
         //add one more warning or reminder that trunclenf and trunclenr were chosen automatically
         ch_trunc.subscribe { it ->
             if ( "${it[0][1]}".toInteger() + "${it[1][1]}".toInteger() <= 10 ) { log.warn "`--trunclenf` was set to ${it[0][1]} and `--trunclenr` to ${it[1][1]}, this is too low! Please either change `--trunc_qmin` (and `--trunc_rmin`), or set `--trunclenf` and `--trunclenr`." }
@@ -72,7 +72,7 @@ workflow DADA2_PREPROCESSING {
 
     //filter reads
     DADA2_FILTNTRIM ( ch_trimmed_reads.dump(tag: 'into_filtntrim')  )
-    ch_versions_dada2_preprocessing = ch_versions_dada2_preprocessing.mix(DADA2_FILTNTRIM.out.versions.first())
+    ch_versions_dada2_preprocessing = ch_versions_dada2_preprocessing.mix(DADA2_FILTNTRIM.out.versions)
 
     //Filter empty files
     DADA2_FILTNTRIM.out.reads_logs_args

--- a/subworkflows/local/kraken2_taxonomy_wf.nf
+++ b/subworkflows/local/kraken2_taxonomy_wf.nf
@@ -46,7 +46,6 @@ workflow KRAKEN2_TAXONOMY_WF {
                 [ meta, fasta ] }
         .set { ch_fasta_kraken2 }
     KRAKEN2_KRAKEN2( ch_fasta_kraken2, ch_kraken2db, false, true )
-    ch_versions_kraken2_taxonomy = ch_versions_kraken2_taxonomy.mix(KRAKEN2_KRAKEN2.out.versions)
 
     // convert kraken2 output to ASV taxonomy table
     FORMAT_TAXRESULTS_KRAKEN2( KRAKEN2_KRAKEN2.out.report, KRAKEN2_KRAKEN2.out.classified_reads_assignment, kraken2_taxlevels )

--- a/subworkflows/local/qiime2_preptax.nf
+++ b/subworkflows/local/qiime2_preptax.nf
@@ -30,7 +30,6 @@ workflow QIIME2_PREPTAX {
             ch_qiime_ref_tax_branched.failed.subscribe { it -> error "$it is neither a compressed (ends with `.gz`) or decompressed sequence (ends with `.fna`) or taxonomy file (ends with `.tax`). Please review input." }
 
             PIGZ_UNCOMPRESS(ch_qiime_ref_tax_branched.compressed.map{ it -> [[:], it] })
-            ch_qiime2_preptax_versions = ch_qiime2_preptax_versions.mix(PIGZ_UNCOMPRESS.out.versions)
 
             ch_qiime_db_files = PIGZ_UNCOMPRESS.out.file.map{ it -> it[1] }
             ch_qiime_db_files = ch_qiime_db_files.mix(ch_qiime_ref_tax_branched.decompressed)

--- a/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_ampliseq_pipeline/main.nf
@@ -371,7 +371,7 @@ def validateInputParameters() {
     def allFiles = [:]
     params.each { sectionName, sectionValue ->
         // Check if this section contains database configurations (nested maps with 'file' key)
-        if (sectionValue instanceof Map && sectionValue.any { it.value instanceof Map && it.value.containsKey('file') }) {
+        if (sectionValue instanceof Map && sectionValue.any { it -> it.value instanceof Map && it.value.containsKey('file') }) {
             sectionValue.each { dbKey, dbConfig ->
                 if (dbConfig.containsKey('file')) {
                     dbConfig.file.each { fileUrl ->
@@ -405,7 +405,7 @@ def validateInputParameters() {
             } else {
                 // This is allowed: same database 'file' under different keys
                 passed_duplication << "  - File '${fileName}' with multiple keys: " +
-                    occurrences.collect { "${it.section}['${it.key}']" }.join(", ")
+                    occurrences.collect { it -> "${it.section}['${it.key}']" }.join(", ")
             }
         }
     }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -100,6 +100,9 @@
                 "FORMAT_TAXONOMY": {
                     "sed": 4.7
                 },
+                "FORMAT_TAXONOMY_QIIME": {
+                    "sed": 4.7
+                },
                 "MERGE_STATS_DECONTAM": {
                     "R": "4.5.2"
                 },
@@ -164,6 +167,9 @@
                 "QIIME2_EXPORT_RELTAX": {
                     "qiime2": "2024.10.1"
                 },
+                "QIIME2_EXTRACT": {
+                    "qiime2": "2024.10.1"
+                },
                 "QIIME2_FEATURETABLE_GROUP": {
                     "qiime2": "2024.10.1"
                 },
@@ -183,6 +189,9 @@
                     "qiime2": "2024.10.1"
                 },
                 "QIIME2_TABLEFILTERTAXA": {
+                    "qiime2": "2024.10.1"
+                },
+                "QIIME2_TRAIN": {
                     "qiime2": "2024.10.1"
                 },
                 "QIIME2_TREE": {

--- a/tests/pplace.nf.test.snap
+++ b/tests/pplace.nf.test.snap
@@ -79,6 +79,9 @@
                     "python": "3.9.1",
                     "pandas": "1.1.5"
                 },
+                "FORMAT_TAXONOMY_QIIME": {
+                    "sed": 4.7
+                },
                 "GAPPA_ASSIGN": {
                     "gappa": "0.8.0"
                 },
@@ -134,6 +137,9 @@
                 "QIIME2_EXPORT_RELTAX": {
                     "qiime2": "2024.10.1"
                 },
+                "QIIME2_EXTRACT": {
+                    "qiime2": "2024.10.1"
+                },
                 "QIIME2_INASV": {
                     "qiime2": "2024.10.1"
                 },
@@ -147,6 +153,9 @@
                     "qiime2": "2024.10.1"
                 },
                 "QIIME2_TABLEFILTERTAXA": {
+                    "qiime2": "2024.10.1"
+                },
+                "QIIME2_TRAIN": {
                     "qiime2": "2024.10.1"
                 },
                 "RENAME_RAW_DATA_FILES": {

--- a/tests/pplace_sheet.nf.test.snap
+++ b/tests/pplace_sheet.nf.test.snap
@@ -75,6 +75,9 @@
                     "python": "3.9.1",
                     "pandas": "1.1.5"
                 },
+                "FORMAT_TAXONOMY_QIIME": {
+                    "sed": 4.7
+                },
                 "GAPPA_ASSIGN": {
                     "gappa": "0.8.0"
                 },
@@ -123,6 +126,9 @@
                 "QIIME2_EXPORT_RELTAX": {
                     "qiime2": "2024.10.1"
                 },
+                "QIIME2_EXTRACT": {
+                    "qiime2": "2024.10.1"
+                },
                 "QIIME2_INASV": {
                     "qiime2": "2024.10.1"
                 },
@@ -133,6 +139,9 @@
                     "qiime2": "2024.10.1"
                 },
                 "QIIME2_TABLEFILTERTAXA": {
+                    "qiime2": "2024.10.1"
+                },
+                "QIIME2_TRAIN": {
                     "qiime2": "2024.10.1"
                 },
                 "RENAME_RAW_DATA_FILES": {

--- a/tests/qiimecustom.nf.test.snap
+++ b/tests/qiimecustom.nf.test.snap
@@ -62,10 +62,19 @@
                     "R": "4.4.2",
                     "phyloseq": "1.50.0"
                 },
+                "PIGZ_UNCOMPRESS": {
+                    "pigz": 2.8
+                },
                 "QIIME2_CLASSIFY": {
                     "qiime2": "2024.10.1"
                 },
+                "QIIME2_EXTRACT": {
+                    "qiime2": "2024.10.1"
+                },
                 "QIIME2_INSEQ": {
+                    "qiime2": "2024.10.1"
+                },
+                "QIIME2_TRAIN": {
                     "qiime2": "2024.10.1"
                 },
                 "RENAME_RAW_DATA_FILES": {

--- a/tests/reftaxcustom.nf.test.snap
+++ b/tests/reftaxcustom.nf.test.snap
@@ -73,7 +73,13 @@
                 "QIIME2_CLASSIFY": {
                     "qiime2": "2024.10.1"
                 },
+                "QIIME2_EXTRACT": {
+                    "qiime2": "2024.10.1"
+                },
                 "QIIME2_INSEQ": {
+                    "qiime2": "2024.10.1"
+                },
+                "QIIME2_TRAIN": {
                     "qiime2": "2024.10.1"
                 },
                 "RENAME_RAW_DATA_FILES": {

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -424,7 +424,7 @@ workflow AMPLISEQ {
     // MODULE: Rename files
     //
     RENAME_RAW_DATA_FILES ( ch_reads )
-    ch_versions = ch_versions.mix(RENAME_RAW_DATA_FILES.out.versions.first())
+    ch_versions = ch_versions.mix(RENAME_RAW_DATA_FILES.out.versions)
 
     //
     // MODULE: Run FastQC
@@ -789,63 +789,64 @@ workflow AMPLISEQ {
     //
     // Multiple references with hmms
     //
+    if ( params.pplace_sheet ) {
+        // For search entries with a named hmm to extract, call extraction
+        ch_pplace_sheet
+            .filter { it -> it.data.extract_hmm }
+            .map { it -> [ it.meta, it.data.hmm, it.data.extract_hmm ] }
+            .set { ch_hmmextract }
 
-    // For search entries with a named hmm to extract, call extraction
-    ch_pplace_sheet
-        .filter { it -> it.data.extract_hmm }
-        .map { it -> [ it.meta, it.data.hmm, it.data.extract_hmm ] }
-        .set { ch_hmmextract }
+        HMMER_HMMEXTRACT(ch_hmmextract)
+        ch_versions = ch_versions.mix(HMMER_HMMEXTRACT.out.versions)
 
-    HMMER_HMMEXTRACT(ch_hmmextract)
-    ch_versions = ch_versions.mix(HMMER_HMMEXTRACT.out.versions)
+        // Create an input channel for FASTA_HMMSEARCH_RANK_FASTAS by adding the non-keyed entries from the original channel to the output of the extracted
+        ch_search_profiles = HMMER_HMMEXTRACT.out.hmm
+            .mix(
+                ch_pplace_sheet
+                    .filter { it -> ! it.data.extract_hmm }
+                    .map { it -> [ it.meta, it.data.hmm ] }
+            )
 
-    // Create an input channel for FASTA_HMMSEARCH_RANK_FASTAS by adding the non-keyed entries from the original channel to the output of the extracted
-    ch_search_profiles = HMMER_HMMEXTRACT.out.hmm
-        .mix(
-            ch_pplace_sheet
-                .filter { it -> ! it.data.extract_hmm }
-                .map { it -> [ it.meta, it.data.hmm ] }
-        )
+        //
+        // SUBWORKFLOW: Search the ASV fasta with the hmms for phyloplacement
+        //
+        FASTA_HMMSEARCH_RANK_FASTAS(ch_search_profiles, ch_fasta)
+        ch_versions = ch_versions.mix(FASTA_HMMSEARCH_RANK_FASTAS.out.versions)
 
-    //
-    // SUBWORKFLOW: Search the ASV fasta with the hmms for phyloplacement
-    //
-    FASTA_HMMSEARCH_RANK_FASTAS(ch_search_profiles, ch_fasta)
-    ch_versions = ch_versions.mix(FASTA_HMMSEARCH_RANK_FASTAS.out.versions)
+        ch_phyloplace_data = FASTA_HMMSEARCH_RANK_FASTAS.out.seqfastas
+            .join(
+                ch_pplace_sheet
+                    .filter { it -> it.data.alignmethod && it.data.refseqfile && it.data.refphylogeny }
+                    .map { it -> [ [ id: it.meta.id ], it ] }
+            )
+            .map { it -> [
+                meta: it[2].meta,
+                data: [
+                    alignmethod: it[2].data.alignmethod,
+                    queryseqfile: it[1],
+                    refseqfile: it[2].data.refseqfile,
+                    refphylogeny: it[2].data.refphylogeny,
+                    model: it[2].data.model,
+                    taxonomy: it[2].data.taxonomy
+                ]
+            ] }
 
-    ch_phyloplace_data = FASTA_HMMSEARCH_RANK_FASTAS.out.seqfastas
-        .join(
-            ch_pplace_sheet
-                .filter { it -> it.data.alignmethod && it.data.refseqfile && it.data.refphylogeny }
-                .map { it -> [ [ id: it.meta.id ], it ] }
-        )
-        .map { it -> [
-            meta: it[2].meta,
-            data: [
-                alignmethod: it[2].data.alignmethod,
-                queryseqfile: it[1],
-                refseqfile: it[2].data.refseqfile,
-                refphylogeny: it[2].data.refphylogeny,
-                model: it[2].data.model,
-                taxonomy: it[2].data.taxonomy
-            ]
-        ] }
+        //
+        // SUBWORKFLOW: Run phylogenetic placement
+        //
+        PPLACE_SHEET(ch_phyloplace_data)
+        ch_versions = ch_versions.mix(PPLACE_SHEET.out.versions)
 
-    //
-    // SUBWORKFLOW: Run phylogenetic placement
-    //
-    PPLACE_SHEET(ch_phyloplace_data)
-    ch_versions = ch_versions.mix(PPLACE_SHEET.out.versions)
+        PPLACEFORMATTAX_SHEET(PPLACE_SHEET.out.taxonomy_per_query)
+        ch_versions = ch_versions.mix(PPLACEFORMATTAX_SHEET.out.versions)
 
-    PPLACEFORMATTAX_SHEET(PPLACE_SHEET.out.taxonomy_per_query)
-    ch_versions = ch_versions.mix(PPLACEFORMATTAX_SHEET.out.versions)
-
-    // Currently, this channel used only for QIIME2_EXPORT and not QIIME2_INTAX since the call to the latter is wrapped in an if clause checking params.pplace_tree
-    if ( ! params.pplace_tree ) {
-        ch_pplace_tax = PPLACEFORMATTAX_SHEET.out.tsv
-            .splitCsv(sep: '\t', header: true)
-            .map { r -> "${r.ASV_ID}\t${r.taxonomy}\n" }
-            .collectFile(name: 'concatenated_taxonomy.tsv', seed: "ASV_ID\ttaxonomy\n")
+        // Currently, this channel used only for QIIME2_EXPORT and not QIIME2_INTAX since the call to the latter is wrapped in an if clause checking params.pplace_tree
+        if ( ! params.pplace_tree ) {
+            ch_pplace_tax = PPLACEFORMATTAX_SHEET.out.tsv
+                .splitCsv(sep: '\t', header: true)
+                .map { r -> "${r.ASV_ID}\t${r.taxonomy}\n" }
+                .collectFile(name: 'concatenated_taxonomy.tsv', seed: "ASV_ID\ttaxonomy\n")
+        }
     }
 
     //QIIME2
@@ -1058,7 +1059,7 @@ workflow AMPLISEQ {
             db_version = params.dada_ref_databases[params.dada_ref_taxonomy]["dbversion"]
             SBDIEXPORTREANNOTATE ( ch_dada2_tax, "dada2", db_version, params.cut_its, ch_barrnapsummary.ifEmpty([]) )
         }
-        ch_versions = ch_versions.mix(SBDIEXPORT.out.versions.first())
+        ch_versions = ch_versions.mix(SBDIEXPORT.out.versions)
     }
 
     //

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -187,7 +187,7 @@ workflow AMPLISEQ {
     // Parse the --pplace_sheet file if present
     ch_pplace_sheet = channel.empty()
     if ( params.pplace_sheet ) {
-        ch_pplace_sheet = Channel.fromPath(params.pplace_sheet)
+        ch_pplace_sheet = channel.fromPath(params.pplace_sheet)
             .splitCsv(header: true)
             .map { it ->
                 [
@@ -556,7 +556,6 @@ workflow AMPLISEQ {
                     meta.id = "ASV_post_clustering"
                     [ meta, fasta ] }
         VSEARCH_CLUSTER ( ch_fasta_for_clustering )
-        ch_versions = ch_versions.mix(VSEARCH_CLUSTER.out.versions)
         FILTER_CLUSTERS ( VSEARCH_CLUSTER.out.clusters, ch_dada2_asv )
         ch_versions = ch_versions.mix(FILTER_CLUSTERS.out.versions)
         ch_dada2_fasta = FILTER_CLUSTERS.out.fasta
@@ -793,8 +792,8 @@ workflow AMPLISEQ {
 
     // For search entries with a named hmm to extract, call extraction
     ch_pplace_sheet
-        .filter { it.data.extract_hmm }
-        .map { [ it.meta, it.data.hmm, it.data.extract_hmm ] }
+        .filter { it -> it.data.extract_hmm }
+        .map { it -> [ it.meta, it.data.hmm, it.data.extract_hmm ] }
         .set { ch_hmmextract }
 
     HMMER_HMMEXTRACT(ch_hmmextract)

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -858,6 +858,7 @@ workflow AMPLISEQ {
                 params.RV_primer
             )
             ch_qiime_classifier = QIIME2_PREPTAX.out.classifier
+            ch_versions = ch_versions.mix( QIIME2_PREPTAX.out.versions )
         }
         QIIME2_TAXONOMY (
             ch_fasta,


### PR DESCRIPTION
Essentially this turned into general maintenance without any impact on anaysis output.

(1) Fixed all warning that appear with `NXF_VER=26.03.2-edge nextflow lint ampliseq -exclude ".git,.nf-test,nf-test.config"` except 
```
Warn  ampliseq/subworkflows/nf-core/utils_nfcore_pipeline/main.nf:16:5: Variable was declared but not used
│  16 |     valid_config = checkConfigProvided()
╰     |     ^^^^^^
```
updating 'nf-core/utils_nfcore_pipeline' from 271e7fc14eb1320364416d996fb077421f3faed2 to f0b535b3ae20080f8db03dd5388876ad1ec29d70 introduces additional syntax _errors_, so I keep it as is for now.

Essentially, the linting summary for `NXF_VER=26.03.2-edge nextflow lint ampliseq -exclude ".git,.nf-test,nf-test.config"` is now:
```
Nextflow linting complete!
 ⚠️  1 file had 1 warning
 ✅ 171 files had no errors
```

(2) Version output was completed (some versions were omitted previously), that caused additions to some `.snap` files.

(3) removed all `.first()` from `.versions.first()`. Two nf-core subworkflows still include those (`FASTA_HMMSEARCH_RANK_FASTAS` & `FASTA_NEWICK_EPANG_GAPPA`), and I put them behind an if clause to only include them when actually needed (input available), that also cleans up the command line output considerably.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
