### PR TITLE
Update scilifelab urls for reference taxonomy databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#966](https://github.com/nf-core/ampliseq/pull/966) - In multiregion analysis, omit samples with few reads across all regions
 - [#969](https://github.com/nf-core/ampliseq/pull/969) - Fix checking for sbdiexport compatibility for newer nextflow versions
 - [#984](https://github.com/nf-core/ampliseq/pull/984) - Adhere to strict syntax, incl. update to nf-core modules
+- [#986](https://github.com/nf-core/ampliseq/pull/986) - Update database links from `https://scilifelab.figshare.com/ndownloader/files/` to `https://ndownloader.figshare.com/files/` to alleviate download issues.
 
 ### `Dependencies`
 

--- a/conf/ref_databases.config
+++ b/conf/ref_databases.config
@@ -244,7 +244,7 @@ params {
         }
         'sbdi-gtdb=R07-RS207-1' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R07-RS207-1"
-            file = [ "https://scilifelab.figshare.com/ndownloader/files/36980767", "https://scilifelab.figshare.com/ndownloader/files/36980788" ]
+            file = [ "https://ndownloader.figshare.com/files/36980767", "https://ndownloader.figshare.com/files/36980788" ]
             citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v4"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
             dbversion = "SBDI-GTDB-R07-RS207-1 (https://scilifelab.figshare.com/articles/dataset/SBDI_Sativa_curated_16S_GTDB_database/14869077/4)"
@@ -252,7 +252,7 @@ params {
         }
         'sbdi-gtdb=R06-RS202-3' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R06-RS202-1"
-            file = [ "https://scilifelab.figshare.com/ndownloader/files/31370437", "https://scilifelab.figshare.com/ndownloader/files/31370434" ]
+            file = [ "https://ndownloader.figshare.com/files/31370437", "https://ndownloader.figshare.com/files/31370434" ]
             citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v3"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
             dbversion = "SBDI-GTDB-R06-RS202-3 (https://scilifelab.figshare.com/articles/dataset/SBDI_Sativa_curated_16S_GTDB_database/14869077/3)"
@@ -260,7 +260,7 @@ params {
         }
         'sbdi-gtdb=R06-RS202-1' {
             title = "SBDI-GTDB - Sativa curated 16S GTDB database - Release R06-RS202-1"
-            file = [ "https://scilifelab.figshare.com/ndownloader/files/28624479", "https://scilifelab.figshare.com/ndownloader/files/28624482" ]
+            file = [ "https://ndownloader.figshare.com/files/28624479", "https://ndownloader.figshare.com/files/28624482" ]
             citation = "Lundin D, Andersson A. SBDI Sativa curated 16S GTDB database. FigShare. doi: 10.17044/scilifelab.14869077.v1"
             fmtscript = "taxref_reformat_sbdi-gtdb.sh"
             dbversion = "SBDI-GTDB-R06-RS202-1 (https://scilifelab.figshare.com/articles/dataset/SBDI_Sativa_curated_16S_GTDB_database/14869077/1)"
@@ -324,7 +324,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2021): UNITE general FASTA release for Fungi. Version 10.05.2021. UNITE Community. https://doi.org/10.15156/BIO/1280049"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = "UNITE-fungi v8.3 (https://doi.org/10.15156/BIO/1280049)"
-            shfile = [ "https://scilifelab.figshare.com/ndownloader/files/34497977", "https://scilifelab.figshare.com/ndownloader/files/34497980"]
+            shfile = [ "https://ndownloader.figshare.com/files/34497977", "https://ndownloader.figshare.com/files/34497980"]
         }
         'unite-fungi=8.2' {
             title = "UNITE general FASTA release for Fungi - Version 8.2"
@@ -332,7 +332,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2020): UNITE general FASTA release for Fungi. Version 04.02.2020. UNITE Community. https://doi.org/10.15156/BIO/786368"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = "UNITE-fungi v8.2 (https://doi.plutof.ut.ee/doi/10.15156/BIO/786368)"
-            shfile = [ "https://scilifelab.figshare.com/ndownloader/files/34497971", "https://scilifelab.figshare.com/ndownloader/files/34497974"]
+            shfile = [ "https://ndownloader.figshare.com/files/34497971", "https://ndownloader.figshare.com/files/34497974"]
         }
         'unite-alleuk' {
             title = "UNITE general FASTA release for eukaryotes - Version 10.0"
@@ -364,7 +364,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2021): UNITE general FASTA release for eukaryotes. Version 10.05.2021. UNITE Community. https://doi.org/10.15156/BIO/1280127"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = "UNITE-alleuk v8.3 (https://doi.org/10.15156/BIO/1280127)"
-            shfile = [ "https://scilifelab.figshare.com/ndownloader/files/34994575", "https://scilifelab.figshare.com/ndownloader/files/34994578"]
+            shfile = [ "https://ndownloader.figshare.com/files/34994575", "https://ndownloader.figshare.com/files/34994578"]
         }
         'unite-alleuk=8.2' {
             title = "UNITE general FASTA release for eukaryotes - Version 8.2"
@@ -372,7 +372,7 @@ params {
             citation = "Abarenkov, Kessy; Zirk, Allan; Piirmann, Timo; Pöhönen, Raivo; Ivanov, Filipp; Nilsson, R. Henrik; Kõljalg, Urmas (2020): UNITE general FASTA release for eukaryotes. Version 04.02.2020. UNITE Community. https://doi.org/10.15156/BIO/786370"
             fmtscript = "taxref_reformat_unite.sh"
             dbversion = "UNITE-alleuk v8.2 (https://doi.org/10.15156/BIO/786370)"
-            shfile = [ "https://scilifelab.figshare.com/ndownloader/files/34994569", "https://scilifelab.figshare.com/ndownloader/files/34994572"]
+            shfile = [ "https://ndownloader.figshare.com/files/34994569", "https://ndownloader.figshare.com/files/34994572"]
         }
         'zehr-nifh' {
             title = "Zehr lab nifH database - version 2.5.0"


### PR DESCRIPTION
Update scilifelab urls for reference taxonomy databases from `https://scilifelab.figshare.com/ndownloader/files/` to `https://ndownloader.figshare.com/files/` to alleviate download issues.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
