### PR TITLE
Update nf-schema from 2.5.1 to 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#998](https://github.com/nf-core/ampliseq/pull/998) - Added taxonomic assignment with VSEARCH/LCA. Updates samtools and vsearch.
 - [#999](https://github.com/nf-core/ampliseq/pull/999) - MultiQC 1.33 to 1.34
 - [#1000](https://github.com/nf-core/ampliseq/pull/1000) - QIIME2 2024.10.1 to 2026.04.0
+- [#1006](https://github.com/nf-core/ampliseq/pull/1006) - nf-schema from 2.5.1 to 2.7.2
 
 | software | previously | now       |
 | -------- | ---------- | --------- |

--- a/nextflow.config
+++ b/nextflow.config
@@ -447,7 +447,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.5.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.7.2' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {


### PR DESCRIPTION
`NXF_VER=26.04.1 nextflow run nf-core/ampliseq -r 2.17.0 --outdir results -profile singularity,test --skip_qiime`
leads to 
```
ERROR ~ Validation of pipeline parameters failed!
The following invalid input values have been detected:
* --skip_qiime (true): Value is [string] but should be [boolean]

```
Same is true for the current `dev` branch or with `NXF_VER=26.04.0`, but `NXF_VER=25.10.4` yields no error.

nf-schema is updated here from 2.5.1 to 2.7.2 to resolve the issue with `NXF_VER=26.*`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
