### PR TITLE
Warn about binned quality scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#992](https://github.com/nf-core/ampliseq/pull/992) - Slack notification on status of AWS full test
 - [#998](https://github.com/nf-core/ampliseq/pull/998) - Added taxonomic assignment with VSEARCH/LCA. This adds parameters `--vsearch_lca_ref_taxonomy` for built-in reference databases (supports `coidb`, `midori2-co1`, `unite-fungi`, `unite-alleuk`) and `--vsearch_lca_ref_tax_custom` for custom reference databases, as well as other VSEARCH/LCA related parameters.
 - [#1009](https://github.com/nf-core/ampliseq/pull/1009) - Add SBDI-GTDB and GTDB databases for release R11-RS232
-- [#1011](https://github.com/nf-core/ampliseq/pull/1011) - Warn if read quality scores might be binned, but allow override with `--ignore_binned_quality`
+- [#1011](https://github.com/nf-core/ampliseq/pull/1011) - Warn if read quality scores appear binned, but allow override with `--ignore_binned_quality`
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#992](https://github.com/nf-core/ampliseq/pull/992) - Slack notification on status of AWS full test
 - [#998](https://github.com/nf-core/ampliseq/pull/998) - Added taxonomic assignment with VSEARCH/LCA. This adds parameters `--vsearch_lca_ref_taxonomy` for built-in reference databases (supports `coidb`, `midori2-co1`, `unite-fungi`, `unite-alleuk`) and `--vsearch_lca_ref_tax_custom` for custom reference databases, as well as other VSEARCH/LCA related parameters.
 - [#1009](https://github.com/nf-core/ampliseq/pull/1009) - Add SBDI-GTDB and GTDB databases for release R11-RS232
+- [#1011](https://github.com/nf-core/ampliseq/pull/1011) - Warn if read quality scores might be binned, but allow override with `--ignore_binned_quality`
 
 ### `Changed`
 

--- a/modules/local/dada2_quality.nf
+++ b/modules/local/dada2_quality.nf
@@ -17,6 +17,7 @@ process DADA2_QUALITY {
     path "versions.yml"                      , emit: versions_dada2_quality, topic: versions
     path "*.args.txt"                        , emit: args
     path "*plotQualityProfile.txt"           , emit: warning
+    path "*QualityScores.txt"                , emit: unique_qscores
 
     script:
     def args = task.ext.args ?: ''
@@ -45,6 +46,10 @@ process DADA2_QUALITY {
 
     plot <- plotQualityProfile(readfiles$args)
     data <- plot\$data
+
+    # collect quality scores
+    quality_scores <- unique( plot\$data\$Score )  |> sort()
+    write.table(paste(quality_scores, sep='\\n'), file = "${prefix}_QualityScores.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')
 
     #aggregate data for each sequencing cycle
     df <- data.frame(Cycle=character(), Count=character(), Median=character(), stringsAsFactors=FALSE)

--- a/nextflow.config
+++ b/nextflow.config
@@ -47,6 +47,7 @@ params {
     single_end                                = false
     sample_inference                          = "independent"
     binned_quality                            = null
+    ignore_binned_quality                     = false
     illumina_pe_its                           = false
     mergepairs_strategy                       = "merge"
     mergepairs_consensus_minoverlap           = 12

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -107,6 +107,11 @@
                     "fa_icon": "fas fa-align-justify",
                     "pattern": "^[0-9]+(,[0-9]+)*$"
                 },
+                "ignore_binned_quality": {
+                    "type": "boolean",
+                    "description": "Ignore warnings about binned quality scores.",
+                    "fa_icon": "fas fa-arrow-right"
+                },
                 "pacbio": {
                     "type": "boolean",
                     "description": "If data is single-ended PacBio reads instead of Illumina",

--- a/subworkflows/local/dada2_preprocessing.nf
+++ b/subworkflows/local/dada2_preprocessing.nf
@@ -44,6 +44,28 @@ workflow DADA2_PREPROCESSING {
         DADA2_QUALITY1 ( ch_all_trimmed_reads.dump(tag: 'into_dada2_quality') )
         DADA2_QUALITY1.out.warning.subscribe { it -> if ( it.baseName.toString().startsWith("WARNING") ) log.warn it.baseName.toString().replace("WARNING ","DADA2_QUALITY1: ") }
         ch_DADA2_QUALITY1_SVG = DADA2_QUALITY1.out.svg
+
+        // Warn based on the number of distinct quality scores
+        DADA2_QUALITY1.out.unique_qscores
+            .collectFile(name: 'all_numbers.txt', newLine: true)
+            .map { file ->
+                def uniqueNumbers = file.text
+                    .split('\n')
+                    .findAll { it.trim() }  // Remove empty lines
+                    .collect { it.trim().toInteger() }
+                    .unique()
+                uniqueNumbers }
+            .subscribe { it ->
+                if ( !params.ignore_binned_quality && params.binned_quality && params.binned_quality.tokenize(',').size() < it.size() ) {
+                    error("Over all samples, ${it.size()} $it distinct quality scores were found. Quality scores might not be binned?\nConsider adapting --binned_quality or skip this check with --ignore_binned_quality")
+                } else if ( params.ignore_binned_quality && params.binned_quality && params.binned_quality.tokenize(',').size() < it.size() ) {
+                    log.warn "Over all samples, ${it.size()} $it distinct quality scores were found. Quality scores might not be binned? The issue is ignored\n"
+                } else if ( !params.ignore_binned_quality && !params.binned_quality && it.size() < 6 ) {
+                    error("Over all samples, ${it.size()} $it distinct quality scores were found. Quality scores seem binned!\nConsider using --binned_quality or skip this check with --ignore_binned_quality")
+                } else if ( params.ignore_binned_quality && !params.binned_quality && it.size() < 6 ) {
+                    log.warn "Over all samples, ${it.size()} $it distinct quality scores were found. Quality scores seem binned!\nThe issue is ignored"
+                }
+            }
     }
 
     //find truncation values in case they are not supplied


### PR DESCRIPTION
Binned quality scores can be a surprising feature of a dataset, here basic tests are added if settings could fit the data. Not all issues can be captured obviously, but at least the most common (for me).

The way of least resistance was via DADA2's plotQualityProfile (advantage: done anyway, disadvantage: can be skipped).

Closes https://github.com/nf-core/ampliseq/issues/1007

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
