### PR TITLE
Do not interpret # in taxonomy tables as comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1019](https://github.com/nf-core/ampliseq/pull/1019) - Improve channel assignment & improve some version reporting (by @d4straub)
 - [#1027](https://github.com/nf-core/ampliseq/pull/1027) - SBDI's file `dna.tsv` recorded "paired" as lib_layout if `--single_end` was not specified alongside `--pacbio` or `--iontorrent`; now reports "single" in that cases (by @d4straub)
+- [#1034](https://github.com/nf-core/ampliseq/pull/1034) - Fix reading taxonomy tables when taxon names contain `#` (by @pieterprovoost)
 
 ### `Dependencies`
 

--- a/assets/report_template.Rmd
+++ b/assets/report_template.Rmd
@@ -1168,7 +1168,7 @@ if ( !isFALSE(params$cut_dada_ref_taxonomy) ) {
 }
 
 # make statistics of taxonomic classification
-asv_tax <- read.table(params$dada2_taxonomy, header = TRUE, sep = "\t")
+asv_tax <- read.table(params$dada2_taxonomy, header = TRUE, sep = "\t", comment.char = "")
 
 # Calculate the classified numbers/percent of asv
 level <- subset(asv_tax, select = -c(ASV_ID,confidence,sequence))
@@ -1232,7 +1232,7 @@ if ( !isFALSE(params$qiime2_ref_tax_title) ) {
 }
 
 # Read file and prepare table
-asv_tax <- read.table(params$qiime2_taxonomy, header = TRUE, sep = "\t")
+asv_tax <- read.table(params$qiime2_taxonomy, header = TRUE, sep = "\t", comment.char = "")
 #asv_tax <- data.frame(do.call('rbind', strsplit(as.character(asv_tax$Taxon),'; ',fixed=TRUE)))
 asv_tax <- subset(asv_tax, select = Taxon)
 
@@ -1302,7 +1302,7 @@ cat("The taxonomic classification was performed by [SINTAX](https://doi.org/10.1
     using the database: `", params$sintax_ref_tax_title, "`.
     More details about the reference taxonomy database can be found in the ['Methods section'](#methods).\n\n", sep = "")
 
-asv_tax <- read.table(params$sintax_taxonomy, header = TRUE, sep = "\t")
+asv_tax <- read.table(params$sintax_taxonomy, header = TRUE, sep = "\t", comment.char = "")
 
 # Calculate the classified numbers/percent of asv
 level <- subset(asv_tax, select = -c(ASV_ID,confidence,sequence))
@@ -1359,7 +1359,7 @@ cat("The taxonomic classification was performed by [VSEARCH](https://github.com/
     `usearch_global` with `--lcaout`, using the reference database: `", params$vsearch_lca_ref_tax_title, "`.
     More details about the reference taxonomy database can be found in the ['Methods section'](#methods).\n\n", sep = "")
 
-asv_tax <- read.table(params$vsearch_lca_taxonomy, header = TRUE, sep = "\t")
+asv_tax <- read.table(params$vsearch_lca_taxonomy, header = TRUE, sep = "\t", comment.char = "")
 
 # Calculate the classified numbers/percent of asv
 level <- subset(asv_tax, select = -c(ASV_ID,confidence,sequence))
@@ -1423,7 +1423,7 @@ if ( params$kraken2_confidence != "0" ) {
     cat("A confidence score threshold of",params$kraken2_confidence,"was applied for taxonomic classifications.\n\n")
 }
 
-asv_tax <- read.table(params$kraken2_taxonomy, header = TRUE, sep = "\t")
+asv_tax <- read.table(params$kraken2_taxonomy, header = TRUE, sep = "\t", comment.char = "")
 
 # Calculate the classified numbers/percent of asv
 level <- subset(asv_tax, select = -c(ASV_ID,lowest_match))
@@ -1482,7 +1482,7 @@ Extraction of taxonomic classification was performed with [EPA-NG](https://githu
 "))
 
 # Read file and prepare table
-asv_tax <- read.table(params$pplace_taxonomy, header = TRUE, sep = "\t")
+asv_tax <- read.table(params$pplace_taxonomy, header = TRUE, sep = "\t", comment.char = "")
 
 # get maximum amount of taxa levels per ASV
 max_taxa <- lengths(regmatches(asv_tax$taxonomy, gregexpr(";", asv_tax$taxonomy)))+1

--- a/modules/local/phyloseq.nf
+++ b/modules/local/phyloseq.nf
@@ -21,7 +21,7 @@ process PHYLOSEQ {
     suppressPackageStartupMessages(library(phyloseq))
 
     otu_df  <- read.table("$otu_tsv", sep="\\t", header=TRUE, row.names=1)
-    tax_df  <- read.table("$tax_tsv", sep="\\t", header=TRUE, row.names=1)
+    tax_df  <- read.table("$tax_tsv", sep="\\t", header=TRUE, row.names=1, comment.char = "")
     otu_mat <- as.matrix(otu_df)
     tax_mat <- as.matrix(tax_df)
 

--- a/modules/local/treesummarizedexperiment.nf
+++ b/modules/local/treesummarizedexperiment.nf
@@ -26,7 +26,7 @@ process TREESUMMARIZEDEXPERIMENT {
     otu_mat <- as.matrix(otu_mat)
     assays <- SimpleList(counts = otu_mat)
     # Read taxonomy table. Correct format for it is DataFrame.
-    taxonomy_table  <- read.table("$tax_tsv", sep="\\t", header=TRUE, row.names=1)
+    taxonomy_table  <- read.table("$tax_tsv", sep="\\t", header=TRUE, row.names=1, comment.char = "")
     taxonomy_table <- DataFrame(taxonomy_table)
 
     # Match rownames between taxonomy table and abundance matrix.

--- a/tests/taxonomy_hash.nf
+++ b/tests/taxonomy_hash.nf
@@ -12,4 +12,5 @@ workflow TAXONOMY_HASH {
     emit:
     phyloseq = PHYLOSEQ.out.rds
     tse      = TREESUMMARIZEDEXPERIMENT.out.rds
+    versions = PHYLOSEQ.out.versions_phyloseq.mix(TREESUMMARIZEDEXPERIMENT.out.versions_treesummarizedexperiment)
 }

--- a/tests/taxonomy_hash.nf
+++ b/tests/taxonomy_hash.nf
@@ -1,0 +1,15 @@
+include { PHYLOSEQ                 } from '../modules/local/phyloseq'
+include { TREESUMMARIZEDEXPERIMENT } from '../modules/local/treesummarizedexperiment'
+
+workflow TAXONOMY_HASH {
+    take:
+    ch_input
+
+    main:
+    PHYLOSEQ(ch_input)
+    TREESUMMARIZEDEXPERIMENT(ch_input)
+
+    emit:
+    phyloseq = PHYLOSEQ.out.rds
+    tse      = TREESUMMARIZEDEXPERIMENT.out.rds
+}

--- a/tests/taxonomy_hash.nf.test
+++ b/tests/taxonomy_hash.nf.test
@@ -8,6 +8,10 @@ nextflow_workflow {
     test("taxonomy with # does not break phyloseq or TreeSummarizedExperiment") {
 
         when {
+            params {
+                outdir = "$outputDir"
+            }
+
             def tmp = File.createTempDir("taxonomy_hash_")
             def otu = new File(tmp, "ASV_table.tsv")
             def tax = new File(tmp, "ASV_tax.tsv")
@@ -41,6 +45,8 @@ nextflow_workflow {
             assert workflow.success
             assert path(workflow.out.phyloseq.get(0).get(1)).exists()
             assert path(workflow.out.tse.get(0).get(1)).exists()
+            // Snapshot process versions.yml outputs (PHYLOSEQ + TreeSummarizedExperiment)
+            assert snapshot(workflow.out.versions).match()
         }
     }
 }

--- a/tests/taxonomy_hash.nf.test
+++ b/tests/taxonomy_hash.nf.test
@@ -1,0 +1,46 @@
+nextflow_workflow {
+
+    name "Test R object exports with hash in taxon name"
+    script "tests/taxonomy_hash.nf"
+    workflow "TAXONOMY_HASH"
+    tag "pipeline"
+
+    test("taxonomy with # does not break phyloseq or TreeSummarizedExperiment") {
+
+        when {
+            def tmp = File.createTempDir("taxonomy_hash_")
+            def otu = new File(tmp, "ASV_table.tsv")
+            def tax = new File(tmp, "ASV_tax.tsv")
+
+            otu.text = [
+                "ASV_ID\tsample1",
+                "asv1\t10",
+                "asv2\t5"
+            ].join("\n") + "\n"
+
+            tax.text = [
+                "ASV_ID\tKingdom\tPhylum\tClass\tOrder\tFamily\tGenus\tSpecies\tconfidence\tsequence",
+                "asv1\tBacteria\tNA\tNA\tNA\tNA\tNA\tuncultured_bacterium_#0319-7L14\t1.00\tACGT",
+                "asv2\tBacteria\tFirmicutes\tBacilli\tNA\tNA\tNA\tLactobacillus_sp\t0.9\tTGCA"
+            ].join("\n") + "\n"
+
+            workflow {
+                """
+                input[0] = Channel.of([
+                    'sintax',
+                    file('${tax}'),
+                    file('${otu}'),
+                    [],
+                    []
+                ])
+                """
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path(workflow.out.phyloseq.get(0).get(1)).exists()
+            assert path(workflow.out.tse.get(0).get(1)).exists()
+        }
+    }
+}

--- a/tests/taxonomy_hash.nf.test.snap
+++ b/tests/taxonomy_hash.nf.test.snap
@@ -1,0 +1,15 @@
+{
+    "taxonomy with # does not break phyloseq or TreeSummarizedExperiment": {
+        "content": [
+            [
+                "versions.yml:md5,d4c5d7155062dc7387368f11411f192e",
+                "versions.yml:md5,f288d71f2c63271b2247aaf7d9a1b62e"
+            ]
+        ],
+        "timestamp": "2026-07-29T22:46:22.924006",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}


### PR DESCRIPTION
This sets `comment.char = ''` where taxonomy tables are read using `read.table` to avoid parsing issues with taxon names containing hash symbols, such as [uncultured bacterium #0319-7L14](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=117765). This is consistent with for example https://github.com/nf-core/ampliseq/blob/master/bin/parse_dada2_taxonomy.r#L14.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
