### PR TITLE
Update ITSxRust to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | software | previously | now   |
 | -------- | ---------- | ----- |
 | ITSxRust | 0.2.2      | 0.3.0 |
+
 ### `Removed`
 
 - [#1028](https://github.com/nf-core/ampliseq/pull/1028) - Removed support for the legacy sample sheet to simplify parsing (by @d4straub)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
+- [#XXXX](https://github.com/nf-core/ampliseq/pull/XXXX) - ITSxRust 0.2.2 to 0.3.0, reducing peak memory approximately six-fold on large inputs; extraction output is unchanged (by @ayobi)
+
+| software | previously | now   |
+| -------- | ---------- | ----- |
+| ITSxRust | 0.2.2      | 0.3.0 |
 ### `Removed`
 
 - [#1028](https://github.com/nf-core/ampliseq/pull/1028) - Removed support for the legacy sample sheet to simplify parsing (by @d4straub)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
-- [#XXXX](https://github.com/nf-core/ampliseq/pull/XXXX) - ITSxRust 0.2.2 to 0.3.0, reducing peak memory approximately six-fold on large inputs; extraction output is unchanged (by @ayobi)
+- [#1035](https://github.com/nf-core/ampliseq/pull/1035) - ITSxRust 0.2.2 to 0.3.0, reducing peak memory approximately six-fold on large inputs; extraction output is unchanged (by @ayobi)
 
 | software | previously | now   |
 | -------- | ---------- | ----- |

--- a/modules/local/itsxrust_cutasv.nf
+++ b/modules/local/itsxrust_cutasv.nf
@@ -1,10 +1,10 @@
 process ITSXRUST_CUTASV {
     label 'process_medium'
 
-    conda "bioconda::itsxrust=0.2.2 bioconda::hmmer=3.4"
+    conda "bioconda::itsxrust=0.3.0 bioconda::hmmer=3.4"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/itsxrust:0.2.2--hdd79491_1' :
-        'quay.io/biocontainers/itsxrust:0.2.2--hdd79491_1' }"
+        'https://depot.galaxyproject.org/singularity/itsxrust:0.3.0--h70df5c0_0' :
+        'quay.io/biocontainers/itsxrust:0.3.0--h70df5c0_0' }"
 
     input:
     path fasta

--- a/tests/pacbio_its.nf.test.snap
+++ b/tests/pacbio_its.nf.test.snap
@@ -63,7 +63,7 @@
                     "python": "3.9.1"
                 },
                 "ITSXRUST_CUTASV": {
-                    "ITSxRust": "0.2.2"
+                    "ITSxRust": "0.3.0"
                 },
                 "MERGE_STATS_DADA": {
                     "R": "4.5.2"


### PR DESCRIPTION
<html><head></head><body><p>Bumps ITSxRust from 0.2.2 to 0.3.0 in <code>modules/local/itsxrust_cutasv.nf</code>. Three lines: the conda pin and the two container URLs (<code>0.3.0--h70df5c0_0</code>).</p>
<h3>Why</h3>
<p>The main change upstream is a memory fix. ITSxRust invokes <code>nhmmer</code> as a subprocess and parses its <code>--tblout</code> output, but the wrapper was also capturing <code>nhmmer</code>'s human-readable report into memory and discarding it. On a 230 Mbp Nanopore ITS dataset that accounted for roughly 6 GB of a 7 GB peak.</p>

  | 0.2.2 | 0.3.0
-- | -- | --
Peak RSS, 108,000 reads / 230 Mbp | 7.07 GB | 1.10 GB
Peak RSS, 54,659 reads / 45.9 Mbp | 3.76 GB | 0.52 GB
Wall time | unchanged | unchanged


<p>Peak memory now scales at roughly 10 kB per input read and is independent of read length, so it can be estimated from read count in advance. That seemed worth bumping for, given ampliseq is often run on shared schedulers.</p>
<h3>Verification</h3>
<p>Extraction counts are <strong>identical between 0.2.2 and 0.3.0 in every field</strong>, checked on two datasets (54,659 and 108,000 reads): kept, full-chain, partial, skipped, and per-region ITS1/ITS2/full ITS counts all match exactly. The captured stream was never read, so nothing downstream changes and no snapshots need updating.</p>
<h3>Also in 0.3.0, not used by this module</h3>
<ul>
<li><code>--region ssu</code> and <code>--region lsu</code> to export the flanking ribosomal genes</li>
<li><code>--plain-ids</code> to omit the coordinate suffix from output headers</li>
<li>a warning when supplied HMM profile names don't map to a recognised anchor type, rather than silently under-detecting anchors</li>
</ul>
<p>The module's invocation is unchanged, so none of these alter ampliseq behaviour. <code>--preset</code> selection via <code>params.sequencing_type</code> in <code>conf/modules.config</code> is untouched.</p>
<h3>Notes</h3>
<ul>
<li>CHANGELOG entry added under <code>Dependencies</code> for 3.0.0dev, with the version table.</li>
<li>No parameter, schema or documentation changes.</li>
<li>Disclosure: I maintain ITSxRust and added the module in #957 / #979.</li>
</ul>
<p>Release notes: https://github.com/ayobi/ITSxRust/blob/main/CHANGELOG.md</p>
<h2>PR checklist</h2>
<ul>
<li>[x] This comment contains a description of changes (with reason).</li>
<li>[ ] Make sure your code lints (<code>nf-core pipelines lint</code>) — deferred to CI; local <code>nf-core</code> install has a pydantic v1/v2 conflict.</li>
<li>[ ] Ensure the test suite passes — deferred to CI. The default <code>test</code> profile does not exercise ITSxRust, which requires <code>its_extractor = 'itsxrust'</code> (<code>test_pacbio_its</code>).</li>
<li>[x] <code>CHANGELOG.md</code> is updated.</li>
</ul></body></html>