### PR TITLE
Fix DADA2_ADDSPECIES crash on ITS-trimmed sequence collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1019](https://github.com/nf-core/ampliseq/pull/1019) - Improve channel assignment & improve some version reporting (by @d4straub)
 - [#1027](https://github.com/nf-core/ampliseq/pull/1027) - SBDI's file `dna.tsv` recorded "paired" as lib_layout if `--single_end` was not specified alongside `--pacbio` or `--iontorrent`; now reports "single" in that cases (by @d4straub)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - DADA2's `confidence` column was incorrectly included as an extra, spurious rank when building the taxonomy string imported into QIIME2; no longer included (by @erikrikarddaniel)
+- [#1043](https://github.com/nf-core/ampliseq/issues/1043) - `DADA2_ADDSPECIES` crashed with "Non-ACGT characters present in the query sequences" when `--cut_its` caused two or more ASVs to become identical once trimmed to just the ITS region; each unique sequence is now classified once, with the result mapped back to every ASV sharing it (by @erikrikarddaniel)
 - [#1038](https://github.com/nf-core/ampliseq/pull/1038) - Ensure that the ASV count matrix in exported R objects is consistently stored as integer regardless of the pipeline parameters (by @hindrek)
 
 ### `Dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1019](https://github.com/nf-core/ampliseq/pull/1019) - Improve channel assignment & improve some version reporting (by @d4straub)
 - [#1027](https://github.com/nf-core/ampliseq/pull/1027) - SBDI's file `dna.tsv` recorded "paired" as lib_layout if `--single_end` was not specified alongside `--pacbio` or `--iontorrent`; now reports "single" in that cases (by @d4straub)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - DADA2's `confidence` column was incorrectly included as an extra, spurious rank when building the taxonomy string imported into QIIME2; no longer included (by @erikrikarddaniel)
-- [#1043](https://github.com/nf-core/ampliseq/issues/1043) - `DADA2_ADDSPECIES` crashed with "Non-ACGT characters present in the query sequences" when `--cut_its` caused two or more ASVs to become identical once trimmed to just the ITS region; each unique sequence is now classified once, with the result mapped back to every ASV sharing it (by @erikrikarddaniel)
+- [#1045](https://github.com/nf-core/ampliseq/pull/1045) - `DADA2_ADDSPECIES` crashed with "Non-ACGT characters present in the query sequences" when `--cut_its` caused two or more ASVs to become identical once trimmed to just the ITS region; each unique sequence is now classified once, with the result mapped back to every ASV sharing it (by @erikrikarddaniel)
 - [#1038](https://github.com/nf-core/ampliseq/pull/1038) - Ensure that the ASV count matrix in exported R objects is consistently stored as integer regardless of the pipeline parameters (by @hindrek)
 
 ### `Dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1019](https://github.com/nf-core/ampliseq/pull/1019) - Improve channel assignment & improve some version reporting (by @d4straub)
 - [#1027](https://github.com/nf-core/ampliseq/pull/1027) - SBDI's file `dna.tsv` recorded "paired" as lib_layout if `--single_end` was not specified alongside `--pacbio` or `--iontorrent`; now reports "single" in that cases (by @d4straub)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - DADA2's `confidence` column was incorrectly included as an extra, spurious rank when building the taxonomy string imported into QIIME2; no longer included (by @erikrikarddaniel)
-- [#1045](https://github.com/nf-core/ampliseq/pull/1045) - `DADA2_ADDSPECIES` crashed with "Non-ACGT characters present in the query sequences" when `--cut_its` caused two or more ASVs to become identical once trimmed to just the ITS region; each unique sequence is now classified once, with the result mapped back to every ASV sharing it (by @erikrikarddaniel)
+- [#1045](https://github.com/nf-core/ampliseq/pull/1045) - Fixed a regression introduced by [#1042](https://github.com/nf-core/ampliseq/pull/1042) (not yet released) that made `DADA2_ADDSPECIES` crash with "Non-ACGT characters present in the query sequences" whenever two or more ASVs ended up with an identical sequence (e.g. after `--cut_its` trimming) (by @erikrikarddaniel)
 - [#1038](https://github.com/nf-core/ampliseq/pull/1038) - Ensure that the ASV count matrix in exported R objects is consistently stored as integer regardless of the pipeline parameters (by @hindrek)
 
 ### `Dependencies`

--- a/conf/test_pacbio_its.config
+++ b/conf/test_pacbio_its.config
@@ -37,14 +37,11 @@ params {
 
     // Also runs DADA2 taxonomy (against the same UNITE database as --sintax_ref_taxonomy above)
     // specifically to exercise --addsh, which requires a database with precomputed SH lookup
-    // files (UNITE only) and is otherwise not covered by any other test profile.
+    // files (UNITE only) and is otherwise not covered by any other test profile. addSpecies runs
+    // too (left enabled, not skipped): a few ASVs here become identical once trimmed to just the
+    // ITS region, which used to crash addSpecies(); this profile is now real regression coverage
+    // for that fix.
     addsh = true
-    // dada2's addSpecies() fails here: a few ASVs in this dataset become identical once
-    // trimmed to just the ITS region, so R appends ".1" to the second occurrence to keep
-    // taxtable rownames unique, and that literal ".1" then gets rejected as a non-ACGT
-    // character. Unrelated to --addsh; addSpecies itself is already covered by the default
-    // test profile.
-    skip_dada_addspecies = true
     skip_qiime = true
     sbdiexport = true
 

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -44,29 +44,14 @@ process DADA2_ADDSPECIES {
     #remove Species annotation from assignTaxonomy
     taxa_nospecies <- taxtable[,!colnames(taxtable) %in% 'Species']
 
-    # Some ASVs can end up with an identical sequence once trimmed to just the ITS
-    # region (they differ only in flanking rDNA, which gets discarded); addSpecies()
-    # requires unique ACGT row names, so classify each unique sequence once and map
-    # the result back onto every ASV that shares it.
-    is_first <- !duplicated(taxa_nospecies\$sequence)
-    taxa_unique <- taxa_nospecies[is_first, , drop = FALSE]
-    rownames(taxa_unique) <- taxa_unique\$sequence
-    taxa_unique\$sequence <- NULL
-
-    tx_unique <- addSpecies(taxa_unique, \"$database\", $args, verbose=TRUE)
-
-    # addSpecies() only adds a "Species" column; map it onto every original row by
-    # sequence, keeping each row's own original columns (ASV_ID, ranks, confidence,
-    # ...) untouched -- rows sharing a sequence get the same Species call, but
-    # nothing else is merged between them.
-    tx <- taxa_nospecies
-    tx\$Species <- tx_unique\$Species[match(taxa_nospecies\$sequence, rownames(tx_unique))]
+    tx <- addSpecies(taxa_nospecies, \"$database\", $args, verbose=TRUE)
 
     # Create a table with specified column order
+    tmp <- data.frame(row.names(tx)) # To separate ASV_ID from sequence
     expected_order <- c("ASV_ID",taxlevels,"confidence",rank_confidence_cols)
     taxa <- as.data.frame( subset(tx, select = expected_order) )
-    taxa\$sequence <- tx\$sequence
-    row.names(taxa) <- NULL
+    taxa\$sequence <- tmp[,1]
+    row.names(taxa) <- row.names(tmp)
 
     #rename Species annotation to Species_exact
     colnames(taxa)[which(names(taxa) == "Species")] <- "Species_exact"

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -44,10 +44,30 @@ process DADA2_ADDSPECIES {
     #remove Species annotation from assignTaxonomy
     taxa_nospecies <- taxtable[,!colnames(taxtable) %in% 'Species']
 
-    tx <- addSpecies(taxa_nospecies, \"$database\", $args, verbose=TRUE)
+    # Some ASVs can end up with an identical sequence once trimmed to just the ITS
+    # region (they differ only in flanking rDNA, which gets discarded); since row
+    # names must be unique, R disambiguates the second occurrence by appending
+    # ".N" when this table is built, which addSpecies() then rejects as a
+    # non-ACGT sequence. Recover the true (possibly duplicated) sequence per row,
+    # classify each unique sequence once, then map the result back to every row
+    # that shares it.
+    true_seqs <- sub("\\\\.[0-9]+\$", "", rownames(taxa_nospecies))
+    is_first <- !duplicated(true_seqs)
+    taxa_unique <- taxa_nospecies[is_first, , drop = FALSE]
+    rownames(taxa_unique) <- true_seqs[is_first]
+
+    tx_unique <- addSpecies(taxa_unique, \"$database\", $args, verbose=TRUE)
+
+    # addSpecies() only adds a "Species" column; take that per unique sequence and
+    # map it onto every original row (including rows that shared a sequence above),
+    # while keeping each row's own original columns (ASV_ID, ranks, confidence, ...)
+    # untouched -- rows sharing a sequence get the same Species call, but keep their
+    # own distinct ASV_ID and confidence values.
+    tx <- taxa_nospecies
+    tx\$Species <- tx_unique\$Species[match(true_seqs, rownames(tx_unique))]
 
     # Create a table with specified column order
-    tmp <- data.frame(row.names(tx)) # To separate ASV_ID from sequence
+    tmp <- data.frame(true_seqs) # To separate ASV_ID from sequence
     expected_order <- c("ASV_ID",taxlevels,"confidence",rank_confidence_cols)
     taxa <- as.data.frame( subset(tx, select = expected_order) )
     taxa\$sequence <- tmp[,1]

--- a/modules/local/dada2_addspecies.nf
+++ b/modules/local/dada2_addspecies.nf
@@ -45,33 +45,28 @@ process DADA2_ADDSPECIES {
     taxa_nospecies <- taxtable[,!colnames(taxtable) %in% 'Species']
 
     # Some ASVs can end up with an identical sequence once trimmed to just the ITS
-    # region (they differ only in flanking rDNA, which gets discarded); since row
-    # names must be unique, R disambiguates the second occurrence by appending
-    # ".N" when this table is built, which addSpecies() then rejects as a
-    # non-ACGT sequence. Recover the true (possibly duplicated) sequence per row,
-    # classify each unique sequence once, then map the result back to every row
-    # that shares it.
-    true_seqs <- sub("\\\\.[0-9]+\$", "", rownames(taxa_nospecies))
-    is_first <- !duplicated(true_seqs)
+    # region (they differ only in flanking rDNA, which gets discarded); addSpecies()
+    # requires unique ACGT row names, so classify each unique sequence once and map
+    # the result back onto every ASV that shares it.
+    is_first <- !duplicated(taxa_nospecies\$sequence)
     taxa_unique <- taxa_nospecies[is_first, , drop = FALSE]
-    rownames(taxa_unique) <- true_seqs[is_first]
+    rownames(taxa_unique) <- taxa_unique\$sequence
+    taxa_unique\$sequence <- NULL
 
     tx_unique <- addSpecies(taxa_unique, \"$database\", $args, verbose=TRUE)
 
-    # addSpecies() only adds a "Species" column; take that per unique sequence and
-    # map it onto every original row (including rows that shared a sequence above),
-    # while keeping each row's own original columns (ASV_ID, ranks, confidence, ...)
-    # untouched -- rows sharing a sequence get the same Species call, but keep their
-    # own distinct ASV_ID and confidence values.
+    # addSpecies() only adds a "Species" column; map it onto every original row by
+    # sequence, keeping each row's own original columns (ASV_ID, ranks, confidence,
+    # ...) untouched -- rows sharing a sequence get the same Species call, but
+    # nothing else is merged between them.
     tx <- taxa_nospecies
-    tx\$Species <- tx_unique\$Species[match(true_seqs, rownames(tx_unique))]
+    tx\$Species <- tx_unique\$Species[match(taxa_nospecies\$sequence, rownames(tx_unique))]
 
     # Create a table with specified column order
-    tmp <- data.frame(true_seqs) # To separate ASV_ID from sequence
     expected_order <- c("ASV_ID",taxlevels,"confidence",rank_confidence_cols)
     taxa <- as.data.frame( subset(tx, select = expected_order) )
-    taxa\$sequence <- tmp[,1]
-    row.names(taxa) <- row.names(tmp)
+    taxa\$sequence <- tx\$sequence
+    row.names(taxa) <- NULL
 
     #rename Species annotation to Species_exact
     colnames(taxa)[which(names(taxa) == "Species")] <- "Species_exact"

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -71,8 +71,12 @@ process DADA2_TAXONOMY {
 
     write.table(taxa_export, file = \"${fasta.baseName}${outfile}.tsv\", sep = "\\t", row.names = FALSE, col.names = TRUE, quote = FALSE, na = '')
 
-    # Save a version with rownames for addSpecies
-    taxa_export <- cbind( ASV_ID = tx\$ASV_ID, taxa\$tax, confidence = tx\$confidence, rank_confidence)
+    # Save a version for addSpecies. Row names are ASV_ID (always unique); the actual
+    # sequence is kept as its own column rather than being encoded in row names,
+    # since two different ASVs can share an identical sequence once trimmed to just
+    # the ITS region, and a data.frame's row names must be unique.
+    taxa_export <- cbind( ASV_ID = tx\$ASV_ID, taxa\$tax, confidence = tx\$confidence, rank_confidence, sequence = tx\$sequence)
+    rownames(taxa_export) <- tx\$ASV_ID
     saveRDS(taxa_export, "${fasta.baseName}${outfile}.rds")
 
     write.table('assignTaxonomy\t$args\ntaxlevels\t$taxlevels\nseed\t$seed', file = "assignTaxonomy.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')

--- a/modules/local/dada2_taxonomy.nf
+++ b/modules/local/dada2_taxonomy.nf
@@ -71,12 +71,13 @@ process DADA2_TAXONOMY {
 
     write.table(taxa_export, file = \"${fasta.baseName}${outfile}.tsv\", sep = "\\t", row.names = FALSE, col.names = TRUE, quote = FALSE, na = '')
 
-    # Save a version for addSpecies. Row names are ASV_ID (always unique); the actual
-    # sequence is kept as its own column rather than being encoded in row names,
-    # since two different ASVs can share an identical sequence once trimmed to just
-    # the ITS region, and a data.frame's row names must be unique.
-    taxa_export <- cbind( ASV_ID = tx\$ASV_ID, taxa\$tax, confidence = tx\$confidence, rank_confidence, sequence = tx\$sequence)
-    rownames(taxa_export) <- tx\$ASV_ID
+    # Save a version with rownames for addSpecies. Coercing rank_confidence to a
+    # matrix keeps this cbind() a plain matrix rather than a data.frame -- matrices
+    # tolerate duplicate row names, data.frames don't. Two different ASVs can end up
+    # with an identical sequence after any sequence-subsetting step (e.g. ITS
+    # trimming), and a data.frame would silently corrupt the second occurrence's
+    # row name to make it unique, which addSpecies() then rejects as non-ACGT.
+    taxa_export <- cbind( ASV_ID = tx\$ASV_ID, taxa\$tax, confidence = tx\$confidence, as.matrix(rank_confidence))
     saveRDS(taxa_export, "${fasta.baseName}${outfile}.rds")
 
     write.table('assignTaxonomy\t$args\ntaxlevels\t$taxlevels\nseed\t$seed', file = "assignTaxonomy.args.txt", row.names = FALSE, col.names = FALSE, quote = FALSE, na = '')

--- a/tests/pacbio_its.nf.test.snap
+++ b/tests/pacbio_its.nf.test.snap
@@ -18,6 +18,10 @@
                 "CUTADAPT_SUMMARY_STD": {
                     "python": "Python 3.8.3"
                 },
+                "DADA2_ADDSPECIES": {
+                    "R": "4.5.2",
+                    "dada2": "1.38.0"
+                },
                 "DADA2_DENOISING": {
                     "R": "4.5.2",
                     "dada2": "1.38.0"
@@ -71,6 +75,10 @@
                     "bash": "5.0.16(1)-release",
                     "sed": 4.7
                 },
+                "FORMAT_TAXRESULTS_ADDSP": {
+                    "python": "3.9.1",
+                    "pandas": "1.1.5"
+                },
                 "FORMAT_TAXRESULTS_SINTAX": {
                     "python": "3.9.1"
                 },
@@ -116,7 +124,7 @@
                 "SBDI/event.tsv",
                 "assignsh",
                 "assignsh/ASV_ITS_tax.vsearch.txt",
-                "assignsh/ASV_tax_SH.unite-fungi_8_2.tsv",
+                "assignsh/ASV_tax_species_SH.unite-fungi_8_2.tsv",
                 "barrnap",
                 "barrnap/rrna.arc.gff",
                 "barrnap/rrna.bac.gff",
@@ -130,9 +138,11 @@
                 "cutadapt/pb3.trimmed.cutadapt.log",
                 "dada2",
                 "dada2/ASV_ITS_tax.unite-fungi_8_2.tsv",
+                "dada2/ASV_ITS_tax_species.unite-fungi_8_2.tsv",
                 "dada2/ASV_seqs.fasta",
                 "dada2/ASV_table.tsv",
                 "dada2/ASV_tax.unite-fungi_8_2.tsv",
+                "dada2/ASV_tax_species.unite-fungi_8_2.tsv",
                 "dada2/DADA2_stats.tsv",
                 "dada2/DADA2_table.rds",
                 "dada2/DADA2_table.tsv",
@@ -147,6 +157,7 @@
                 "dada2/QC/svg/single_end_preprocessed_qual_stats.svg",
                 "dada2/QC/svg/single_end_qual_stats.svg",
                 "dada2/args",
+                "dada2/args/addSpecies.args.txt",
                 "dada2/args/assignTaxonomy.args.txt",
                 "dada2/args/dada.args.txt",
                 "dada2/args/filterAndTrim.args.txt",
@@ -155,6 +166,7 @@
                 "dada2/args/single_end_plotQualityProfile.args.txt",
                 "dada2/args/single_end_preprocessed_plotQualityProfile.args.txt",
                 "dada2/chunks",
+                "dada2/chunks/ASV_seqs.len.1.ASV_ITS_tax.unite-fungi_8_2.species.tsv",
                 "dada2/chunks/ASV_seqs.len.1.ASV_ITS_tax.unite-fungi_8_2.tsv",
                 "dada2/log",
                 "dada2/log/1.dada.log",
@@ -308,7 +320,7 @@
             "emof.tsv:md5,c6599c76a70fe5458db56ff8c2e89a37",
             "event.tsv:md5,bfcf7d8ac2a3c6b48d075d6dc235f0e4"
         ],
-        "timestamp": "2026-08-04T14:42:56.02771259",
+        "timestamp": "2026-08-05T13:38:48.578799722",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"


### PR DESCRIPTION
<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Closes #1043.

`addSpecies()` requires its taxtable's row names to be unique ACGT sequences. When `--cut_its` causes two ASVs to become identical once trimmed to just the ITS region (they differ only in flanking rDNA, which gets discarded), R silently disambiguates the duplicate row name by appending `.N` — and that literal `.N` then fails `addSpecies()`'s ACGT check, crashing the whole run with a misleading "Non-ACGT characters present in the query sequences" error.

Fix: classify each unique sequence once, then map the resulting `Species` call back onto every original row — keeping each row's own `ASV_ID` and confidence values intact (rows sharing a sequence get the same `Species` result, but nothing else is merged between them; an earlier version of this fix got that wrong and accidentally merged `ASV_ID`s too, caught by a downstream `TREESUMMARIZEDEXPERIMENT` failure on duplicate row names).

`conf/test_pacbio_its.config` previously worked around this by setting `skip_dada_addspecies = true` — that workaround is removed, so this profile is now real regression coverage for the bug. Verified the common, non-colliding case is unaffected by re-running `tests/default.nf.test` *without* `--update-snapshot` (zero diff against the existing snapshot).
