### PR TITLE
Update Savont 0.6.1c to 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1022](https://github.com/nf-core/ampliseq/issues/1022) - added new GloSED database for classification of Eukaryotic ITS. Not support for SH numbers as of yet. (by @tom-brekke)
 - [#1021](https://github.com/nf-core/ampliseq/pull/1021),[#1023](https://github.com/nf-core/ampliseq/pull/1023),[#1025](https://github.com/nf-core/ampliseq/pull/1025) - Comparison of observed ASVs against expected sequences or their abundance is now available with `--expected_*` parameters (by @d4straub, reviewed by @erikrikarddaniel)
-- [#1026](https://github.com/nf-core/ampliseq/pull/1026) - Add support for Oxford Nanopore Technology (ONT) R10.4 sequencing (preferably with SUP basecalling) with Savont (by @d4straub)
+- [#1026](https://github.com/nf-core/ampliseq/pull/1026),[#1045](https://github.com/nf-core/ampliseq/pull/1045) - Add support for Oxford Nanopore Technology (ONT) R10.4 sequencing (preferably with SUP basecalling) with Savont (by @d4straub)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - DADA2 taxonomy tables (`ASV_tax.*.tsv`, `ASV_tax_species.*.tsv`) now include one `<rank>_confidence` column per rank, in addition to the existing overall `confidence` column (by @erikrikarddaniel)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - Added CI test coverage for `--addsh`, which previously had none (`test_pacbio_its` now also runs DADA2 taxonomy against the UNITE database it already uses for SINTAX) (by @erikrikarddaniel)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1022](https://github.com/nf-core/ampliseq/issues/1022) - added new GloSED database for classification of Eukaryotic ITS. Not support for SH numbers as of yet. (by @tom-brekke)
 - [#1021](https://github.com/nf-core/ampliseq/pull/1021),[#1023](https://github.com/nf-core/ampliseq/pull/1023),[#1025](https://github.com/nf-core/ampliseq/pull/1025) - Comparison of observed ASVs against expected sequences or their abundance is now available with `--expected_*` parameters (by @d4straub, reviewed by @erikrikarddaniel)
-- [#1026](https://github.com/nf-core/ampliseq/pull/1026),[#1045](https://github.com/nf-core/ampliseq/pull/1045) - Add support for Oxford Nanopore Technology (ONT) R10.4 sequencing (preferably with SUP basecalling) with Savont (by @d4straub)
+- [#1026](https://github.com/nf-core/ampliseq/pull/1026),[#1046](https://github.com/nf-core/ampliseq/pull/1046) - Add support for Oxford Nanopore Technology (ONT) R10.4 sequencing (preferably with SUP basecalling) with Savont (by @d4straub)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - DADA2 taxonomy tables (`ASV_tax.*.tsv`, `ASV_tax_species.*.tsv`) now include one `<rank>_confidence` column per rank, in addition to the existing overall `confidence` column (by @erikrikarddaniel)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - Added CI test coverage for `--addsh`, which previously had none (`test_pacbio_its` now also runs DADA2 taxonomy against the UNITE database it already uses for SINTAX) (by @erikrikarddaniel)
 

--- a/modules/local/savont_asv.nf
+++ b/modules/local/savont_asv.nf
@@ -3,10 +3,10 @@ process SAVONT_ASV {
     label 'process_medium'
     label 'process_long'
 
-    conda "bioconda::savont=0.6.1c"
+    conda "bioconda::savont=0.6.3"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/savont:0.6.1c--hec9b1f2_0' :
-        'biocontainers/savont:0.6.1c--hec9b1f2_0' }"
+        'https://depot.galaxyproject.org/singularity/savont:0.6.3--hec9b1f2_0' :
+        'biocontainers/savont:0.6.3--hec9b1f2_0' }"
 
     input:
     tuple val(meta), path(reads), val(sample_string)

--- a/modules/local/savont_export.nf
+++ b/modules/local/savont_export.nf
@@ -2,10 +2,10 @@ process SAVONT_EXPORT {
     tag "$prefix"
     label 'process_low'
 
-    conda "bioconda::savont=0.6.1c"
+    conda "bioconda::savont=0.6.3"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/savont:0.6.1c--hec9b1f2_0' :
-        'biocontainers/savont:0.6.1c--hec9b1f2_0' }"
+        'https://depot.galaxyproject.org/singularity/savont:0.6.3--hec9b1f2_0' :
+        'biocontainers/savont:0.6.3--hec9b1f2_0' }"
 
     input:
     tuple val(prefix), path(output_folders), val(sample_string)

--- a/tests/savont.nf.test.snap
+++ b/tests/savont.nf.test.snap
@@ -106,7 +106,7 @@
                     "bash": "5.0.17(1)-release"
                 },
                 "SAVONT_ASV": {
-                    "savont": "0.6.1"
+                    "savont": "0.6.3"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",


### PR DESCRIPTION
ONT analysis depends on Savont. Savont had a substantial bug fix release with 0.6.3, so that PR updates it.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
