### PR TITLE
Fix confidence columns leaking into summary_report.html taxonomy levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1027](https://github.com/nf-core/ampliseq/pull/1027) - SBDI's file `dna.tsv` recorded "paired" as lib_layout if `--single_end` was not specified alongside `--pacbio` or `--iontorrent`; now reports "single" in that cases (by @d4straub)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - DADA2's `confidence` column was incorrectly included as an extra, spurious rank when building the taxonomy string imported into QIIME2; no longer included (by @erikrikarddaniel)
 - [#1038](https://github.com/nf-core/ampliseq/pull/1038) - Ensure that the ASV count matrix in exported R objects is consistently stored as integer regardless of the pipeline parameters (by @hindrek)
+- [#1044](https://github.com/nf-core/ampliseq/issues/1044) - Fixed a regression introduced by [#1042](https://github.com/nf-core/ampliseq/pull/1042) (not yet released) that showed the new per-rank `confidence` columns as if they were taxonomic levels in the DADA2/SINTAX/VSEARCH-LCA sections of `summary_report.html` (by @erikrikarddaniel)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - DADA2's `confidence` column was incorrectly included as an extra, spurious rank when building the taxonomy string imported into QIIME2; no longer included (by @erikrikarddaniel)
 - [#1045](https://github.com/nf-core/ampliseq/pull/1045) - Fixed a regression introduced by [#1042](https://github.com/nf-core/ampliseq/pull/1042) (not yet released) that made `DADA2_ADDSPECIES` crash with "Non-ACGT characters present in the query sequences" whenever two or more ASVs ended up with an identical sequence (e.g. after `--cut_its` trimming) (by @erikrikarddaniel)
 - [#1038](https://github.com/nf-core/ampliseq/pull/1038) - Ensure that the ASV count matrix in exported R objects is consistently stored as integer regardless of the pipeline parameters (by @hindrek)
-- [#1044](https://github.com/nf-core/ampliseq/issues/1044) - Fixed a regression introduced by [#1042](https://github.com/nf-core/ampliseq/pull/1042) (not yet released) that showed the new per-rank `confidence` columns as if they were taxonomic levels in the DADA2/SINTAX/VSEARCH-LCA sections of `summary_report.html` (by @erikrikarddaniel)
+- [#1050](https://github.com/nf-core/ampliseq/pull/1050) - Fixed a regression introduced by [#1042](https://github.com/nf-core/ampliseq/pull/1042) (not yet released) that showed the new per-rank `confidence` columns as if they were taxonomic levels in the DADA2/SINTAX/VSEARCH-LCA sections of `summary_report.html` (by @erikrikarddaniel)
 
 ### `Dependencies`
 

--- a/assets/report_template.Rmd
+++ b/assets/report_template.Rmd
@@ -1171,8 +1171,8 @@ if ( !isFALSE(params$cut_dada_ref_taxonomy) ) {
 asv_tax <- read.table(params$dada2_taxonomy, header = TRUE, sep = "\t")
 
 # Calculate the classified numbers/percent of asv
-level <- subset(asv_tax, select = -c(ASV_ID,confidence,sequence))
-level <- colnames(level)
+non_rank_cols <- colnames(asv_tax) %in% c("ASV_ID", "confidence", "sequence") | grepl("_confidence$", colnames(asv_tax))
+level <- colnames(asv_tax)[!non_rank_cols]
 
 n_asv_tax = nrow(asv_tax)
 
@@ -1305,8 +1305,8 @@ cat("The taxonomic classification was performed by [SINTAX](https://doi.org/10.1
 asv_tax <- read.table(params$sintax_taxonomy, header = TRUE, sep = "\t")
 
 # Calculate the classified numbers/percent of asv
-level <- subset(asv_tax, select = -c(ASV_ID,confidence,sequence))
-level <- colnames(level)
+non_rank_cols <- colnames(asv_tax) %in% c("ASV_ID", "confidence", "sequence") | grepl("_confidence$", colnames(asv_tax))
+level <- colnames(asv_tax)[!non_rank_cols]
 
 n_asv_tax = nrow(asv_tax)
 
@@ -1362,8 +1362,8 @@ cat("The taxonomic classification was performed by [VSEARCH](https://github.com/
 asv_tax <- read.table(params$vsearch_lca_taxonomy, header = TRUE, sep = "\t")
 
 # Calculate the classified numbers/percent of asv
-level <- subset(asv_tax, select = -c(ASV_ID,confidence,sequence))
-level <- colnames(level)
+non_rank_cols <- colnames(asv_tax) %in% c("ASV_ID", "confidence", "sequence") | grepl("_confidence$", colnames(asv_tax))
+level <- colnames(asv_tax)[!non_rank_cols]
 
 n_asv_tax = nrow(asv_tax)
 


### PR DESCRIPTION
<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Closes #1044.

Fixes a regression introduced by #1042 (not yet released): the DADA2, SINTAX, and VSEARCH-LCA sections of `assets/report_template.Rmd` each derived their "% Classification" breakdown by taking every column except `ASV_ID`/`confidence`/`sequence` and treating the rest as taxonomic ranks. The new per-rank `<rank>_confidence` columns added in #1042 got swept up too, showing as extra bogus levels (`kingdom_confidence`, `phylum_confidence`, ...) in both the text summary and the barplot.

KRAKEN2's section uses a different, unaffected column pattern (no `confidence`/`sequence` columns in its tsv shape) — left untouched.

Validated: an isolated R logic check confirms SINTAX/VSEARCH-LCA are unaffected in practice today (no per-rank confidence columns for them yet, so old and new logic produce identical output), and a full `tests/default.nf.test` run confirms the rendered `summary_report.html` no longer contains `kingdom_confidence`/etc. text.
