### PR TITLE
Pass ancom/ancombc/ancombc2/qiime_adonis_formula as subworkflow args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1028](https://github.com/nf-core/ampliseq/pull/1028) - Multi-region sample sheet via `--multiregion` had its header changed from `FW_primer` and `RV_primer` to `primer_fwd` and `primer_rev`, respectively. (by @d4straub)
 - [#1032](https://github.com/nf-core/ampliseq/pull/1032) - Refactor the pipeline's parameter handling and initialization (by @erikrikarddaniel).
+- [#NN](https://github.com/nf-core/ampliseq/pull/NN) - Continue #1032's parameter-handling refactor: `qiime2_ancom` and `qiime2_diversity` subworkflows now take all their flags (`ancom`, `ancombc`, `ancombc2`, `qiime_adonis_formula`) as explicit arguments instead of reading some directly from `params.*`; no behaviour change (by @erikrikarddaniel).
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1028](https://github.com/nf-core/ampliseq/pull/1028) - Multi-region sample sheet via `--multiregion` had its header changed from `FW_primer` and `RV_primer` to `primer_fwd` and `primer_rev`, respectively. (by @d4straub)
 - [#1032](https://github.com/nf-core/ampliseq/pull/1032) - Refactor the pipeline's parameter handling and initialization (by @erikrikarddaniel).
-- [#NN](https://github.com/nf-core/ampliseq/pull/NN) - Continue #1032's parameter-handling refactor: `qiime2_ancom` and `qiime2_diversity` subworkflows now take all their flags (`ancom`, `ancombc`, `ancombc2`, `qiime_adonis_formula`) as explicit arguments instead of reading some directly from `params.*`; no behaviour change (by @erikrikarddaniel).
+- [#1051](https://github.com/nf-core/ampliseq/pull/1051) - Continue #1032's parameter-handling refactor: `qiime2_ancom` and `qiime2_diversity` subworkflows now take all their flags (`ancom`, `ancombc`, `ancombc2`, `qiime_adonis_formula`) as explicit arguments instead of reading some directly from `params.*`; no behaviour change (by @erikrikarddaniel).
 
 ### `Fixed`
 

--- a/subworkflows/local/qiime2_ancom.nf
+++ b/subworkflows/local/qiime2_ancom.nf
@@ -22,7 +22,10 @@ workflow QIIME2_ANCOM {
     ch_tax
     tax_agglom_min
     tax_agglom_max
+    ancom
+    ancombc
     ancombc_formula
+    ancombc2
     ancombc2_formula
 
     main:
@@ -35,7 +38,7 @@ workflow QIIME2_ANCOM {
             .combine( ch_metacolumn_all )
     QIIME2_FILTERSAMPLES_ANCOM ( ch_for_filtersamples )
 
-    if ( params.ancom ) {
+    if ( ancom ) {
         //ANCOM on various taxonomic levels
         ch_for_ancom_tax =
             ch_metadata
@@ -49,7 +52,7 @@ workflow QIIME2_ANCOM {
         QIIME2_ANCOM_ASV ( ch_metadata.combine( QIIME2_FILTERSAMPLES_ANCOM.out.qza.flatten() ) )
     }
 
-    if ( params.ancombc ) {
+    if ( ancombc ) {
         //ANCOMBC on various taxonomic levels
         ch_for_ancombc_tax =
             ch_metadata
@@ -82,7 +85,7 @@ workflow QIIME2_ANCOM {
         ANCOMBC_FORMULA_ASV ( ch_metadata.combine( ch_asv ).combine( ch_ancombc_formula ) )
     }
 
-    if ( params.ancombc2 ) {
+    if ( ancombc2 ) {
         //ANCOMBC2 on various taxonomic levels
         ch_for_ancombc2_tax =
             ch_metadata
@@ -116,9 +119,9 @@ workflow QIIME2_ANCOM {
     }
 
     emit:
-    ancom    = params.ancom ? QIIME2_ANCOM_ASV.out.ancom.mix(QIIME2_ANCOM_TAX.out.ancom) : channel.empty()
-    ancombc  = params.ancombc ? QIIME2_ANCOMBC_ASV.out.da_barplot.mix(QIIME2_ANCOMBC_TAX.out.da_barplot) : channel.empty()
+    ancom    = ancom ? QIIME2_ANCOM_ASV.out.ancom.mix(QIIME2_ANCOM_TAX.out.ancom) : channel.empty()
+    ancombc  = ancombc ? QIIME2_ANCOMBC_ASV.out.da_barplot.mix(QIIME2_ANCOMBC_TAX.out.da_barplot) : channel.empty()
     ancombc_formula = ancombc_formula ? ANCOMBC_FORMULA_ASV.out.da_barplot.mix(ANCOMBC_FORMULA_TAX.out.da_barplot) : channel.empty()
-    ancombc2  = params.ancombc2 ? QIIME2_ANCOMBC2_ASV.out.plot.mix(QIIME2_ANCOMBC2_TAX.out.plot) : channel.empty()
+    ancombc2  = ancombc2 ? QIIME2_ANCOMBC2_ASV.out.plot.mix(QIIME2_ANCOMBC2_TAX.out.plot) : channel.empty()
     ancombc2_formula = ancombc2_formula ? ANCOMBC2_FORMULA_ASV.out.plot.mix(ANCOMBC2_FORMULA_TAX.out.plot) : channel.empty()
 }

--- a/subworkflows/local/qiime2_diversity.nf
+++ b/subworkflows/local/qiime2_diversity.nf
@@ -22,6 +22,7 @@ workflow QIIME2_DIVERSITY {
     skip_alpha_rarefaction
     skip_diversity_indices
     diversity_rarefaction_depth
+    qiime_adonis_formula
 
     main:
     //Phylogenetic tree for beta & alpha diversities
@@ -55,8 +56,8 @@ workflow QIIME2_DIVERSITY {
         QIIME2_DIVERSITY_BETA ( ch_to_diversity_beta )
 
         //adonis ( ch_metadata, DIVERSITY_CORE.out.qza )
-        if (params.qiime_adonis_formula) {
-            ch_qiime_adonis_formula = channel.fromList(params.qiime_adonis_formula.tokenize(','))
+        if (qiime_adonis_formula) {
+            ch_qiime_adonis_formula = channel.fromList(qiime_adonis_formula.tokenize(','))
             ch_to_diversity_beta =
                 ch_metadata
                     .combine( QIIME2_DIVERSITY_CORE.out.distance.flatten() )
@@ -76,5 +77,5 @@ workflow QIIME2_DIVERSITY {
     alpha    = !skip_diversity_indices ? QIIME2_DIVERSITY_ALPHA.out.alpha : []
     beta     = !skip_diversity_indices ? QIIME2_DIVERSITY_BETA.out.beta : []
     betaord  = !skip_diversity_indices ? QIIME2_DIVERSITY_BETAORD.out.beta : []
-    adonis   = !skip_diversity_indices && params.qiime_adonis_formula ? QIIME2_DIVERSITY_ADONIS.out.html : []
+    adonis   = !skip_diversity_indices && qiime_adonis_formula ? QIIME2_DIVERSITY_ADONIS.out.html : []
 }

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -1116,7 +1116,8 @@ workflow AMPLISEQ {
                 ch_metacolumn_all,
                 params.skip_alpha_rarefaction,
                 params.skip_diversity_indices,
-                params.diversity_rarefaction_depth
+                params.diversity_rarefaction_depth,
+                params.qiime_adonis_formula
             )
         }
 
@@ -1129,7 +1130,10 @@ workflow AMPLISEQ {
                 ch_tax,
                 tax_agglom_min,
                 tax_agglom_max,
+                params.ancom,
+                params.ancombc,
                 params.ancombc_formula,
+                params.ancombc2,
                 params.ancombc2_formula
             )
         }


### PR DESCRIPTION
<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Continues #1029/#1032's parameter-handling refactor.

`subworkflows/local/qiime2_ancom.nf` already took `ancombc_formula`/`ancombc2_formula` as explicit `take:` args, but reached into `params.ancom`/`params.ancombc`/`params.ancombc2` directly instead of taking them the same way. Same inconsistency in `qiime2_diversity.nf`, which took `skip_alpha_rarefaction`/`skip_diversity_indices` as args but read `params.qiime_adonis_formula` directly.

Pure plumbing change, no behaviour change — both subworkflows now take all of their flags as explicit arguments, consistent with the pattern the rest of the pipeline is moving toward.

Verified via nf-test (`default.nf.test` covers ancombc/ancombc2/both formula variants/`qiime_adonis_formula`; `sintax.nf.test` covers plain `ancom=true`) — no snapshot changes.