### PR TITLE
Add ampliseq.counts.tsv.gz summary table, with Parquet sibling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1026](https://github.com/nf-core/ampliseq/pull/1026),[#1046](https://github.com/nf-core/ampliseq/pull/1046) - Add support for Oxford Nanopore Technology (ONT) R10.4 sequencing (preferably with SUP basecalling) with Savont (by @d4straub)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - DADA2 taxonomy tables (`ASV_tax.*.tsv`, `ASV_tax_species.*.tsv`) now include one `<rank>_confidence` column per rank, in addition to the existing overall `confidence` column (by @erikrikarddaniel)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - Added CI test coverage for `--addsh`, which previously had none (`test_pacbio_its` now also runs DADA2 taxonomy against the UNITE database it already uses for SINTAX) (by @erikrikarddaniel)
+- [#NN](https://github.com/nf-core/ampliseq/pull/NN) - Added `summary_tables/ampliseq.counts.tsv.gz`, ASV counts in long format with consistent, lower-case column names, ready for analysis in R, Python or similar without pipeline-specific parsing; also written as Parquet by default, skip with the hidden `--skip_parquet_summary` (by @erikrikarddaniel)
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1026](https://github.com/nf-core/ampliseq/pull/1026),[#1046](https://github.com/nf-core/ampliseq/pull/1046) - Add support for Oxford Nanopore Technology (ONT) R10.4 sequencing (preferably with SUP basecalling) with Savont (by @d4straub)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - DADA2 taxonomy tables (`ASV_tax.*.tsv`, `ASV_tax_species.*.tsv`) now include one `<rank>_confidence` column per rank, in addition to the existing overall `confidence` column (by @erikrikarddaniel)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - Added CI test coverage for `--addsh`, which previously had none (`test_pacbio_its` now also runs DADA2 taxonomy against the UNITE database it already uses for SINTAX) (by @erikrikarddaniel)
-- [#1052](https://github.com/nf-core/ampliseq/pull/1052) - Added `summary_tables/ampliseq.counts.tsv.gz`, ASV counts in long format with consistent, lower-case column names, ready for analysis in R, Python or similar without pipeline-specific parsing; also written as Parquet by default, skip with the hidden `--skip_parquet_summary` (by @erikrikarddaniel)
+- [#1052](https://github.com/nf-core/ampliseq/pull/1052) - Added `summary_tables/ampliseq.counts.tsv.gz`, ASV counts in long format with consistent, lower-case column names, ready for analysis in R, Python or similar without pipeline-specific parsing; also written as Parquet by default, skip with `--skip_parquet_summary` (by @erikrikarddaniel)
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1026](https://github.com/nf-core/ampliseq/pull/1026),[#1046](https://github.com/nf-core/ampliseq/pull/1046) - Add support for Oxford Nanopore Technology (ONT) R10.4 sequencing (preferably with SUP basecalling) with Savont (by @d4straub)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - DADA2 taxonomy tables (`ASV_tax.*.tsv`, `ASV_tax_species.*.tsv`) now include one `<rank>_confidence` column per rank, in addition to the existing overall `confidence` column (by @erikrikarddaniel)
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - Added CI test coverage for `--addsh`, which previously had none (`test_pacbio_its` now also runs DADA2 taxonomy against the UNITE database it already uses for SINTAX) (by @erikrikarddaniel)
-- [#NN](https://github.com/nf-core/ampliseq/pull/NN) - Added `summary_tables/ampliseq.counts.tsv.gz`, ASV counts in long format with consistent, lower-case column names, ready for analysis in R, Python or similar without pipeline-specific parsing; also written as Parquet by default, skip with the hidden `--skip_parquet_summary` (by @erikrikarddaniel)
+- [#1052](https://github.com/nf-core/ampliseq/pull/1052) - Added `summary_tables/ampliseq.counts.tsv.gz`, ASV counts in long format with consistent, lower-case column names, ready for analysis in R, Python or similar without pipeline-specific parsing; also written as Parquet by default, skip with the hidden `--skip_parquet_summary` (by @erikrikarddaniel)
 
 ### `Changed`
 

--- a/conf/containers_conda_lock_files_amd64.config
+++ b/conf/containers_conda_lock_files_amd64.config
@@ -1,2 +1,3 @@
+process { withName: 'DUCKDB_TABLE2PARQUET' { container = 'modules/nf-core/duckdb/table2parquet/.conda-lock/linux_amd64-bd-9c6d18d9f687a45d_1.txt' } }
 process { withName: 'FASTQC' { container = 'modules/nf-core/fastqc/.conda-lock/linux_amd64-bd-5cb1a2fa2f18c7c2_1.txt' } }
 process { withName: 'MULTIQC' { container = 'modules/nf-core/multiqc/.conda-lock/linux_amd64-bd-db7c73dae76bc9e6_1.txt' } }

--- a/conf/containers_docker_amd64.config
+++ b/conf/containers_docker_amd64.config
@@ -1,2 +1,3 @@
+process { withName: 'DUCKDB_TABLE2PARQUET' { container = 'community.wave.seqera.io/library/duckdb-cli:1.5.5--9c6d18d9f687a45d' } }
 process { withName: 'FASTQC' { container = 'community.wave.seqera.io/library/fastqc:0.12.1--5cb1a2fa2f18c7c2' } }
 process { withName: 'MULTIQC' { container = 'community.wave.seqera.io/library/multiqc:1.34--db7c73dae76bc9e6' } }

--- a/conf/containers_docker_arm64.config
+++ b/conf/containers_docker_arm64.config
@@ -1,2 +1,3 @@
+process { withName: 'DUCKDB_TABLE2PARQUET' { container = 'community.wave.seqera.io/library/duckdb-cli:1.5.5--9759cff58ac94478' } }
 process { withName: 'FASTQC' { container = 'community.wave.seqera.io/library/fastqc:0.12.1--e455e32f745abe68' } }
 process { withName: 'MULTIQC' { container = 'community.wave.seqera.io/library/multiqc:1.34--d167b8012595a136' } }

--- a/conf/containers_singularity_https_amd64.config
+++ b/conf/containers_singularity_https_amd64.config
@@ -1,2 +1,3 @@
+process { withName: 'DUCKDB_TABLE2PARQUET' { container = 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/68/68261e24307fdf80b9988d6fd13cf3551735e6dc0e7e38003259f7d8efa84cdb/data' } }
 process { withName: 'FASTQC' { container = 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/f2/f20b021476d1d87658820f971ebecc1e8cdbde0f338eb0d9cea2b0a8fc54a54b/data' } }
 process { withName: 'MULTIQC' { container = 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1b/1bef8af6be88c5733461959c46ac8ef73d18f65277f62a1695d0e1633054f9c2/data' } }

--- a/conf/containers_singularity_https_arm64.config
+++ b/conf/containers_singularity_https_arm64.config
@@ -1,2 +1,3 @@
+process { withName: 'DUCKDB_TABLE2PARQUET' { container = 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/92/92b4ee040ad1e494ed7c57b6d54b41105f49d79b50f966a2945e87c27d3fbf5e/data' } }
 process { withName: 'FASTQC' { container = 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/46daf2dad0169afd2ae047c3e50ed3776259f664bf07e5e06b045dc23449e994/data' } }
 process { withName: 'MULTIQC' { container = 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/9a/9a1fec9662a152683e6fcae440d0ce20920b3b89dc62d1e3a52e73f92eba0969/data' } }

--- a/conf/containers_singularity_oras_amd64.config
+++ b/conf/containers_singularity_oras_amd64.config
@@ -1,2 +1,3 @@
+process { withName: 'DUCKDB_TABLE2PARQUET' { container = 'oras://community.wave.seqera.io/library/duckdb-cli:1.5.5--f8bdd09321b4d7ab' } }
 process { withName: 'FASTQC' { container = 'oras://community.wave.seqera.io/library/fastqc:0.12.1--5c4bd442468d75dd' } }
 process { withName: 'MULTIQC' { container = 'oras://community.wave.seqera.io/library/multiqc:1.34--4fc8657c816047c0' } }

--- a/conf/containers_singularity_oras_arm64.config
+++ b/conf/containers_singularity_oras_arm64.config
@@ -1,2 +1,3 @@
+process { withName: 'DUCKDB_TABLE2PARQUET' { container = 'oras://community.wave.seqera.io/library/duckdb-cli:1.5.5--9ff691978ccb6109' } }
 process { withName: 'FASTQC' { container = 'oras://community.wave.seqera.io/library/fastqc:0.12.1--127a87fc06499035' } }
 process { withName: 'MULTIQC' { container = 'oras://community.wave.seqera.io/library/multiqc:1.34--7fbd82d945c06726' } }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -308,6 +308,22 @@ process {
         ]
     }
 
+    withName: SUMMARY_TABLE_COUNTS {
+        publishDir = [
+            path: { "${params.outdir}/summary_tables" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: DUCKDB_TABLE2PARQUET {
+        publishDir = [
+            path: { "${params.outdir}/summary_tables" },
+            mode: params.publish_dir_mode,
+            pattern: "*.parquet"
+        ]
+    }
+
     withName: DADA2_SPLITREGIONS {
         publishDir = [
             path: { "${params.outdir}/sidle/per_region" },

--- a/docs/output.md
+++ b/docs/output.md
@@ -23,6 +23,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
   - [Cutadapt](#cutadapt) - Primer trimming
   - [MultiQC](#multiqc) - Aggregate report describing results
 - [ASV inferrence with DADA2](#asv-inferrence-with-dada2) - Infer Amplicon Sequence Variants (ASVs)
+- [Summary tables](#summary-tables) - Consistently-formatted tables for downstream analysis in R, Python, etc.
 - [Optional ASV post processing](#optional-asv-post-processing) - Filter ASVs to optimize downstream analysis
   - [VSEARCH cluster](#vsearch-cluster) - Centroid fasta file, filtered asv table, and stats
   - [Barrnap](#barrnap) - Predict ribosomal RNA sequences and optional filtering
@@ -204,6 +205,19 @@ DADA2 reduces sequence errors and dereplicates sequences by quality filtering, d
 - `dada2/QC/`
   - `*.md.err.convergence.txt`: Convergence values for DADA2's dada command on monotone decreasing (corrected) quality scores, should reduce over several magnitudes and approaching 0.
   - `*.md.err.pdf`: Estimated error rates for each possible transition on monotone decreasing (corrected) quality scores. The black line shows the estimated error rates after convergence of the machine-learning algorithm. The red line shows the error rates expected under the nominal definition of the Q-score. The estimated error rates (black line) should be a good fit to the observed rates (points), and the error rates should drop with increased quality.
+
+</details>
+
+### Summary tables
+
+Tables with consistent, lower-case column names, ready to load into R, Python or another tool of choice without pipeline-specific parsing. These are sourced directly from DADA2's own raw output, before any of the optional post-processing filters below run.
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `summary_tables/`
+  - `ampliseq.counts.tsv.gz`: ASV counts in long format (`asv_id`, `sample`, `count`), rows with a count of 0 are dropped.
+  - `ampliseq.counts.parquet`: The same table in [Parquet](https://parquet.apache.org/) format. Skip this file with `--skip_parquet_summary`.
 
 </details>
 

--- a/main.nf
+++ b/main.nf
@@ -228,6 +228,7 @@ params {
     skip_tse: Boolean
     skip_multiqc: Boolean
     skip_report: Boolean
+    skip_parquet_summary: Boolean
     seed: Integer = 100
     version: Boolean
     publish_dir_mode: String

--- a/modules.json
+++ b/modules.json
@@ -21,6 +21,11 @@
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/cutadapt/cutadapt.diff"
                     },
+                    "duckdb/table2parquet": {
+                        "branch": "master",
+                        "git_sha": "a01390acb6fb8c7539c8d9126b16df24092db83c",
+                        "installed_by": ["modules"]
+                    },
                     "epang/place": {
                         "branch": "master",
                         "git_sha": "ac1f7b3aeb0eecfab0d13d85dcb7165ef301de1e",

--- a/modules/local/summary_table_counts/environment.yml
+++ b/modules/local/summary_table_counts/environment.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: summary_table_counts
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::r-base=4.3.1
+  - conda-forge::r-data.table=1.17.8
+  - conda-forge::r-dplyr=1.1.4
+  - conda-forge::r-dtplyr=1.3.2
+  - conda-forge::r-purrr=1.1.0
+  - conda-forge::r-readr=2.1.5
+  - conda-forge::r-stringr=1.5.2
+  - conda-forge::r-tidyr=1.3.1

--- a/modules/local/summary_table_counts/main.nf
+++ b/modules/local/summary_table_counts/main.nf
@@ -1,0 +1,54 @@
+process SUMMARY_TABLE_COUNTS {
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a0/a04c5424ce6fbf346430d99ae9f72d0bbb90e3a5cf4096df32fc1716f03973a4/data' :
+        'community.wave.seqera.io/library/r-base_r-data.table_r-dplyr_r-dtplyr_pruned:a6608bc81b0e6546' }"
+
+    input:
+    path(asv_table)
+
+    output:
+    path("ampliseq.counts.tsv.gz"), emit: tsv
+    path "versions.yml"           , emit: versions, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    """
+    #!/usr/bin/env Rscript
+    suppressPackageStartupMessages({
+        library(dplyr)
+        library(tidyr)
+        library(readr)
+    })
+
+    counts <- read_tsv("$asv_table", show_col_types = FALSE) |>
+        rename(asv_id = ASV_ID) |>
+        pivot_longer(-asv_id, names_to = "sample", values_to = "count") |>
+        filter(count > 0)
+
+    write_tsv(counts, "ampliseq.counts.tsv.gz")
+
+    writeLines(
+        c(
+            "\\"${task.process}\\":",
+            paste0("    R: ", paste0(R.Version()[c("major", "minor")], collapse = ".")),
+            paste0("    r-dplyr: ", packageVersion("dplyr"))
+        ),
+        "versions.yml"
+    )
+    """
+
+    stub:
+    """
+    echo -e "asv_id\\tsample\\tcount" | gzip > ampliseq.counts.tsv.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        R: stub
+    END_VERSIONS
+    """
+}

--- a/modules/local/summary_table_counts/meta.yml
+++ b/modules/local/summary_table_counts/meta.yml
@@ -1,0 +1,35 @@
+name: summary_table_counts
+description: Reformat DADA2's merged wide ASV table into a long-format counts summary table
+keywords:
+  - summary
+  - counts
+  - asv
+  - long format
+tools:
+  - dplyr:
+      description: A grammar of data manipulation
+      homepage: https://dplyr.tidyverse.org/
+      documentation: https://dplyr.tidyverse.org/
+      tool_dev_url: https://github.com/tidyverse/dplyr
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - asv_table:
+        type: file
+        description: DADA2's merged wide ASV table (ASV_ID column plus one column per sample)
+        pattern: "ASV_table.tsv"
+output:
+  - tsv:
+      - "ampliseq.counts.tsv.gz":
+          type: file
+          description: Long-format ASV counts (asv_id, sample, count), zero-count rows dropped
+          pattern: "ampliseq.counts.tsv.gz"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@erikrikarddaniel"
+maintainers:
+  - "@erikrikarddaniel"

--- a/modules/nf-core/duckdb/table2parquet/environment.yml
+++ b/modules/nf-core/duckdb/table2parquet/environment.yml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+dependencies:
+  - conda-forge::duckdb-cli=1.5.5

--- a/modules/nf-core/duckdb/table2parquet/main.nf
+++ b/modules/nf-core/duckdb/table2parquet/main.nf
@@ -1,0 +1,43 @@
+process DUCKDB_TABLE2PARQUET {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+?         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/68/68261e24307fdf80b9988d6fd13cf3551735e6dc0e7e38003259f7d8efa84cdb/data'
+:         'community.wave.seqera.io/library/duckdb-cli:1.5.5--9c6d18d9f687a45d' }"
+
+    input:
+    tuple val(meta), path(table)
+
+    output:
+    tuple val(meta), path("*.parquet"), emit: parquet
+    tuple val("${task.process}"), val('duckdb'), eval("duckdb --version | sed 's/^v//; s/ .*//'"), topic: versions, emit: versions_duckdb
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ? ", ${task.ext.args}"  : ''  // read_csv options
+    def args2  = task.ext.args2  ? ", ${task.ext.args2}" : ''  // Copy options
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def stem   = table.name.replaceAll(/\.(gz|zst)$/, '')
+    def delim  = stem.endsWith('.tsv') ? '\\t' : stem.endsWith('.csv') ? ',' : null
+    if ( ! delim ) {
+        error("DUCKDB_TABLE2PARQUET: cannot determine a delimiter for '${table.name}' -- expected a .csv or .tsv suffix, optionally followed by .gz or .zst")
+    }
+    """
+    duckdb -c "
+        SET threads=${task.cpus};
+        SET memory_limit='${task.memory.toGiga()}GB';
+        SET temp_directory='.';
+        COPY (SELECT * FROM read_csv('${table}', delim='${delim}', header=true${args})) TO '${prefix}.parquet' (FORMAT PARQUET${args2});
+    "
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.parquet
+    """
+}

--- a/modules/nf-core/duckdb/table2parquet/meta.yml
+++ b/modules/nf-core/duckdb/table2parquet/meta.yml
@@ -1,0 +1,91 @@
+name: "duckdb_table2parquet"
+description: Convert a delimited text table (CSV or TSV, gzipped or not) to Parquet
+keywords:
+  - parquet
+  - csv
+  - tsv
+  - conversion
+tools:
+  - "duckdb":
+      description: "An in-process SQL OLAP database management system"
+      homepage: "https://duckdb.org"
+      documentation: "https://duckdb.org/docs/"
+      tool_dev_url: "https://github.com/duckdb/duckdb"
+      licence:
+        - "MIT"
+      identifier: "biotools:duckdb"
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - table:
+        type: file
+        description: A delimited text table to convert. The delimiter is picked from the filename -- `.tsv`/`.tsv.gz`/`.tsv.zst` for tab, `.csv`/`.csv.gz`/`.csv.zst` for comma; any other suffix is an error.
+        pattern: "*.{csv,csv.gz,csv.zst,tsv,tsv.gz,tsv.zst}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752" # CSV
+          - edam: "http://edamontology.org/format_3475" # TSV
+output:
+  parquet:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.parquet":
+          type: file
+          description: The input table, converted to Parquet
+          pattern: "*.parquet"
+          ontologies: []
+  versions_duckdb:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - "duckdb":
+          type: string
+          description: The name of the tool
+      - "duckdb --version | sed 's/^v//; s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - "duckdb":
+          type: string
+          description: The name of the tool
+      - "duckdb --version | sed 's/^v//; s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@erikrikarddaniel"
+maintainers:
+  - "@erikrikarddaniel"
+containers:
+  docker:
+    linux/arm64:
+      name: community.wave.seqera.io/library/duckdb-cli:1.5.5--9759cff58ac94478
+      build_id: bd-9759cff58ac94478_1
+      scan_id: sc-d2d6d8ef62d545e0_1
+    linux/amd64:
+      name: community.wave.seqera.io/library/duckdb-cli:1.5.5--9c6d18d9f687a45d
+      build_id: bd-9c6d18d9f687a45d_1
+      scan_id: sc-0edb2b0562f99468_1
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/duckdb-cli:1.5.5--f8bdd09321b4d7ab
+      build_id: bd-f8bdd09321b4d7ab_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/68/68261e24307fdf80b9988d6fd13cf3551735e6dc0e7e38003259f7d8efa84cdb/data
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/duckdb-cli:1.5.5--9ff691978ccb6109
+      build_id: bd-9ff691978ccb6109_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/92/92b4ee040ad1e494ed7c57b6d54b41105f49d79b50f966a2945e87c27d3fbf5e/data
+  conda:
+    linux/amd64:
+      lock_file: modules/nf-core/duckdb/table2parquet/.conda-lock/linux_amd64-bd-9c6d18d9f687a45d_1.txt

--- a/modules/nf-core/duckdb/table2parquet/tests/main.nf.test
+++ b/modules/nf-core/duckdb/table2parquet/tests/main.nf.test
@@ -1,0 +1,147 @@
+nextflow_process {
+
+    name "Test Process DUCKDB_TABLE2PARQUET"
+    script "../main.nf"
+    process "DUCKDB_TABLE2PARQUET"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "duckdb"
+    tag "duckdb/table2parquet"
+    tag "pigz/compress"
+
+    test("csv") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file('https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/modules/data/generic/csv/test.csv', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("csv - gzipped") {
+
+        setup {
+            run("PIGZ_COMPRESS") {
+                script "../../../pigz/compress/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test' ],
+                        file('https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/modules/data/generic/csv/test.csv', checkIfExists: true),
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = PIGZ_COMPRESS.out.archive
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("tsv") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file('https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/modules/data/generic/tsv/test.tsv', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("tsv - gzipped") {
+
+        setup {
+            run("PIGZ_COMPRESS") {
+                script "../../../pigz/compress/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test' ],
+                        file('https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/modules/data/generic/tsv/test.tsv', checkIfExists: true),
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = PIGZ_COMPRESS.out.archive
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("csv - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file('https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/modules/data/generic/csv/test.csv', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/duckdb/table2parquet/tests/main.nf.test.snap
+++ b/modules/nf-core/duckdb/table2parquet/tests/main.nf.test.snap
@@ -1,0 +1,132 @@
+{
+    "csv - stub": {
+        "content": [
+            {
+                "parquet": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.parquet:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_duckdb": [
+                    [
+                        "DUCKDB_TABLE2PARQUET",
+                        "duckdb",
+                        "1.5.5"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-31T08:15:34.157728597",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "csv - gzipped": {
+        "content": [
+            {
+                "parquet": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.parquet:md5,62f39a0ec6f40def92860479260b4e16"
+                    ]
+                ],
+                "versions_duckdb": [
+                    [
+                        "DUCKDB_TABLE2PARQUET",
+                        "duckdb",
+                        "1.5.5"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-29T15:06:04.480768645",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "tsv": {
+        "content": [
+            {
+                "parquet": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.parquet:md5,180fa2a3c593e6486a26180242211b27"
+                    ]
+                ],
+                "versions_duckdb": [
+                    [
+                        "DUCKDB_TABLE2PARQUET",
+                        "duckdb",
+                        "1.5.5"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-29T15:06:11.882949593",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "tsv - gzipped": {
+        "content": [
+            {
+                "parquet": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.parquet:md5,180fa2a3c593e6486a26180242211b27"
+                    ]
+                ],
+                "versions_duckdb": [
+                    [
+                        "DUCKDB_TABLE2PARQUET",
+                        "duckdb",
+                        "1.5.5"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-29T15:06:19.318999993",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "csv": {
+        "content": [
+            {
+                "parquet": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.parquet:md5,62f39a0ec6f40def92860479260b4e16"
+                    ]
+                ],
+                "versions_duckdb": [
+                    [
+                        "DUCKDB_TABLE2PARQUET",
+                        "duckdb",
+                        "1.5.5"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-29T15:05:59.410185637",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1163,6 +1163,11 @@
                 "skip_report": {
                     "type": "boolean",
                     "description": "Skip Markdown summary report"
+                },
+                "skip_parquet_summary": {
+                    "type": "boolean",
+                    "description": "Skip writing summary tables as Parquet, alongside the default gzipped tsv",
+                    "hidden": true
                 }
             },
             "fa_icon": "fas fa-hand-paper"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1166,8 +1166,7 @@
                 },
                 "skip_parquet_summary": {
                     "type": "boolean",
-                    "description": "Skip writing summary tables as Parquet, alongside the default gzipped tsv",
-                    "hidden": true
+                    "description": "Skip writing summary tables as Parquet, alongside the default gzipped tsv"
                 }
             },
             "fa_icon": "fas fa-hand-paper"

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -40,6 +40,7 @@ nextflow_pipeline {
                     path("$outputDir/dada2/ref_taxonomy.gtdb_R07-RS207.txt"),
                     path("$outputDir/dada2/DADA2_stats.tsv"),
                     path("$outputDir/dada2/DADA2_table.tsv"),
+                    path("$outputDir/summary_tables/ampliseq.counts.tsv.gz").linesGzip.size(),
                     path("$outputDir/decontam/decontaminated.tsv"),
                     path("$outputDir/decontam/decontaminated_counts.tsv"),
                     path("$outputDir/decontam/decontaminated_details.tsv").readLines().size(),
@@ -60,6 +61,8 @@ nextflow_pipeline {
                     path("$outputDir/qiime2/ancombc2_formula/Category-treatment1-ASV/ASV-treatment1::a.volcano_plot.tsv")
                 ).match() },
                 { assert path("$outputDir/decontam/decontaminated_details.tsv").csv(sep: '\t', header: true).columns["freq"].sum() > 0.99999 },
+                { assert path("$outputDir/summary_tables/ampliseq.counts.parquet").exists() },
+                { assert path("$outputDir/summary_tables/ampliseq.counts.parquet").size() > 0 },
             )
         }
     }

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -61,7 +61,6 @@ nextflow_pipeline {
                     path("$outputDir/qiime2/ancombc2_formula/Category-treatment1-ASV/ASV-treatment1::a.volcano_plot.tsv")
                 ).match() },
                 { assert path("$outputDir/decontam/decontaminated_details.tsv").csv(sep: '\t', header: true).columns["freq"].sum() > 0.99999 },
-                { assert path("$outputDir/summary_tables/ampliseq.counts.parquet").exists() },
                 { assert path("$outputDir/summary_tables/ampliseq.counts.parquet").size() > 0 },
             )
         }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -78,6 +78,9 @@
                     "R": "4.5.2",
                     "decontam": "1.30.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -232,6 +235,10 @@
                 },
                 "SBDIEXPORTREANNOTATE": {
                     "R": "3.6.3"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",
@@ -2256,6 +2263,9 @@
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/dada2_TreeSummarizedExperiment.rds",
                 "treesummarizedexperiment/qiime2_TreeSummarizedExperiment.rds",
@@ -2285,6 +2295,7 @@
             "ref_taxonomy.gtdb_R07-RS207.txt:md5,965c6b1f9097128572a5ec2b8e9cef06",
             "DADA2_stats.tsv:md5,b61a945febb806ed63729bcaa8ae0575",
             "DADA2_table.tsv:md5,7ec2214a627e7492d31ac2672f82f94d",
+            439,
             "decontaminated.tsv:md5,3c94a1d7c56657fcbfaea344f0eae09e",
             "decontaminated_counts.tsv:md5,f519211d0ac2cb979b09d3803e8ca3fa",
             313,

--- a/tests/doubleprimers.nf.test.snap
+++ b/tests/doubleprimers.nf.test.snap
@@ -60,6 +60,9 @@
                     "R": "4.5.2",
                     "dada2": "1.38.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FILTER_STATS": {
                     "python": "3.9.1",
                     "pandas": "1.1.5"
@@ -113,6 +116,10 @@
                 },
                 "RENAME_RAW_DATA_FILES": {
                     "bash": "5.0.17(1)-release"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",
@@ -299,6 +306,9 @@
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/kraken2_TreeSummarizedExperiment.rds"
             ],

--- a/tests/failed.nf.test
+++ b/tests/failed.nf.test
@@ -10,6 +10,7 @@ nextflow_pipeline {
         when {
             params {
                 outdir = "$outputDir"
+                skip_parquet_summary = true
             }
         }
 
@@ -18,6 +19,7 @@ nextflow_pipeline {
             def stable_path = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
 
             assertAll(
+                { assert !file("$outputDir/summary_tables/ampliseq.counts.parquet").exists() },
                 { assert snapshot(
                     // pipeline versions.yml file for multiqc from which Nextflow version is removed because we test pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_ampliseq_software_mqc_versions.yml"),

--- a/tests/failed.nf.test
+++ b/tests/failed.nf.test
@@ -10,7 +10,6 @@ nextflow_pipeline {
         when {
             params {
                 outdir = "$outputDir"
-                skip_parquet_summary = true
             }
         }
 
@@ -19,7 +18,6 @@ nextflow_pipeline {
             def stable_path = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
 
             assertAll(
-                { assert !file("$outputDir/summary_tables/ampliseq.counts.parquet").exists() },
                 { assert snapshot(
                     // pipeline versions.yml file for multiqc from which Nextflow version is removed because we test pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/nf_core_ampliseq_software_mqc_versions.yml"),

--- a/tests/failed.nf.test.snap
+++ b/tests/failed.nf.test.snap
@@ -58,9 +58,6 @@
                     "R": "4.5.2",
                     "dada2": "1.38.0"
                 },
-                "DUCKDB_TABLE2PARQUET": {
-                    "duckdb": "1.5.5"
-                },
                 "FILTER_LEN_ASV": {
                     "R": "4.0.3",
                     "Biostrings": "2.58.0"
@@ -964,7 +961,6 @@
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
                 "summary_tables",
-                "summary_tables/ampliseq.counts.parquet",
                 "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/dada2_TreeSummarizedExperiment.rds"

--- a/tests/failed.nf.test.snap
+++ b/tests/failed.nf.test.snap
@@ -58,6 +58,9 @@
                     "R": "4.5.2",
                     "dada2": "1.38.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FILTER_LEN_ASV": {
                     "R": "4.0.3",
                     "Biostrings": "2.58.0"
@@ -961,6 +964,7 @@
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
                 "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
                 "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/dada2_TreeSummarizedExperiment.rds"

--- a/tests/failed.nf.test.snap
+++ b/tests/failed.nf.test.snap
@@ -58,6 +58,9 @@
                     "R": "4.5.2",
                     "dada2": "1.38.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FILTER_LEN_ASV": {
                     "R": "4.0.3",
                     "Biostrings": "2.58.0"
@@ -142,6 +145,10 @@
                 },
                 "RENAME_RAW_DATA_FILES": {
                     "bash": "5.0.17(1)-release"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",
@@ -956,6 +963,9 @@
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/dada2_TreeSummarizedExperiment.rds"
             ],

--- a/tests/glosed.nf.test.snap
+++ b/tests/glosed.nf.test.snap
@@ -170,6 +170,9 @@
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/dada2_TreeSummarizedExperiment.rds"
             ],

--- a/tests/iontorrent.nf.test.snap
+++ b/tests/iontorrent.nf.test.snap
@@ -48,6 +48,9 @@
                     "R": "4.5.2",
                     "dada2": "1.38.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -66,6 +69,10 @@
                 },
                 "RENAME_RAW_DATA_FILES": {
                     "bash": "5.0.17(1)-release"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",
@@ -224,6 +231,9 @@
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/sintax_TreeSummarizedExperiment.rds"
             ],

--- a/tests/multi.nf.test.snap
+++ b/tests/multi.nf.test.snap
@@ -39,6 +39,9 @@
                     "R": "4.5.2",
                     "dada2": "1.38.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -82,6 +85,10 @@
                 },
                 "RENAME_RAW_DATA_FILES": {
                     "bash": "5.0.17(1)-release"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "Workflow": {
                     "nf-core/ampliseq": "v2.19.0dev"
@@ -283,7 +290,10 @@
                 "summary_report/rrna_detection_with_barrnap.svg",
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
-                "summary_report/versions.yml"
+                "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz"
             ],
             "overall_summary.tsv:md5,bef502f98c592cb450636a16a1a730e0",
             "rrna.arc.gff:md5,ec70a291a1d801481d3311d200939b32",

--- a/tests/multiregion.nf.test.snap
+++ b/tests/multiregion.nf.test.snap
@@ -45,6 +45,9 @@
                     "R": "4.5.2",
                     "dada2": "1.38.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -148,6 +151,10 @@
                     "qiime2": "2021.4.0",
                     "qiime2 plugin sidle": 2020.08,
                     "q2-sidle": "2021.2.dev0"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TRUNCLEN": {
                     "python": "3.9.1",
@@ -596,7 +603,10 @@
                 "sidle/reconstructed/reconstruction_table/sample-frequencies.pdf",
                 "sidle/reconstructed/reconstruction_table/sample-frequencies.png",
                 "sidle/reconstructed/reconstruction_table/sample-frequency-detail.csv",
-                "sidle/reconstructed/reconstruction_table/sample-frequency-detail.html"
+                "sidle/reconstructed/reconstruction_table/sample-frequency-detail.html",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz"
             ],
             "samplesheet_multiregion_v3.tsv:md5,07e00b7352c5ecec1546c20c4d28f62e",
             "metadata_multiregion.tsv:md5,e2671821f0cf64f15a50d3ddac8f20d1",

--- a/tests/novaseq.nf.test.snap
+++ b/tests/novaseq.nf.test.snap
@@ -36,6 +36,9 @@
                     "R": "4.5.2",
                     "dada2": "1.38.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -48,6 +51,10 @@
                 },
                 "RENAME_RAW_DATA_FILES": {
                     "bash": "5.0.17(1)-release"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TRUNCLEN": {
                     "python": "3.9.1",
@@ -172,7 +179,10 @@
                 "summary_report",
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
-                "summary_report/versions.yml"
+                "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz"
             ],
             "ASV_seqs.fasta:md5,0ed4ce8c63b31ee3968232ded3da9875",
             "ASV_table.tsv:md5,0028da02541e474b4229e7776c091586",

--- a/tests/pacbio_its.nf.test.snap
+++ b/tests/pacbio_its.nf.test.snap
@@ -60,6 +60,9 @@
                     "R": "4.5.2",
                     "dada2": "1.38.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -100,6 +103,10 @@
                 },
                 "SBDIEXPORTREANNOTATE": {
                     "R": "3.6.3"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",
@@ -295,6 +302,9 @@
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/dada2_TreeSummarizedExperiment.rds",
                 "treesummarizedexperiment/sintax_TreeSummarizedExperiment.rds"

--- a/tests/pplace.nf.test.snap
+++ b/tests/pplace.nf.test.snap
@@ -59,6 +59,9 @@
                     "R": "4.5.2",
                     "decontam": "1.30.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "EPANG_PLACE": {
                     "epang": "0.3.8"
                 },
@@ -175,6 +178,10 @@
                 },
                 "RENAME_RAW_DATA_FILES": {
                     "bash": "5.0.17(1)-release"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",
@@ -1191,6 +1198,9 @@
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/pplace_TreeSummarizedExperiment.rds",
                 "treesummarizedexperiment/qiime2_TreeSummarizedExperiment.rds"

--- a/tests/pplace_sheet.nf.test.snap
+++ b/tests/pplace_sheet.nf.test.snap
@@ -65,6 +65,9 @@
                     "R": "4.5.2",
                     "decontam": "1.30.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "EPANG_PLACE": {
                     "epang": "0.3.8"
                 },
@@ -159,6 +162,10 @@
                 },
                 "SEQTK_SUBSEQ": {
                     "seqtk": "1.4-r122"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",
@@ -480,6 +487,9 @@
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/qiime2_TreeSummarizedExperiment.rds"
             ],

--- a/tests/qiimecustom.nf.test.snap
+++ b/tests/qiimecustom.nf.test.snap
@@ -55,6 +55,9 @@
                     "R": "4.5.2",
                     "decontam": "1.30.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -86,6 +89,10 @@
                 },
                 "RENAME_RAW_DATA_FILES": {
                     "bash": "5.0.17(1)-release"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",
@@ -286,6 +293,9 @@
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/qiime2_TreeSummarizedExperiment.rds"
             ],

--- a/tests/reftaxcustom.nf.test.snap
+++ b/tests/reftaxcustom.nf.test.snap
@@ -60,6 +60,9 @@
                     "R": "4.5.2",
                     "decontam": "1.30.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -95,6 +98,10 @@
                 },
                 "RENAME_RAW_DATA_FILES": {
                     "bash": "5.0.17(1)-release"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TRUNCLEN": {
                     "python": "3.9.1",
@@ -290,7 +297,10 @@
                 "summary_report/rrna_detection_with_barrnap.svg",
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
-                "summary_report/versions.yml"
+                "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz"
             ],
             "overall_summary.tsv:md5,788502ac905468319bcc8b1598b7e925",
             "rrna.arc.gff:md5,6dae470aace9293d5eb8c318584852dd",

--- a/tests/single.nf.test.snap
+++ b/tests/single.nf.test.snap
@@ -63,6 +63,9 @@
                     "R": "4.5.2",
                     "decontam": "1.30.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -79,6 +82,10 @@
                 },
                 "RENAME_RAW_DATA_FILES": {
                     "bash": "5.0.17(1)-release"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",
@@ -244,6 +251,9 @@
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/dada2_TreeSummarizedExperiment.rds"
             ],

--- a/tests/sintax.nf.test.snap
+++ b/tests/sintax.nf.test.snap
@@ -51,6 +51,9 @@
                     "R": "4.5.2",
                     "dada2": "1.38.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -162,6 +165,10 @@
                 },
                 "SBDIEXPORTREANNOTATE": {
                     "R": "3.6.3"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",
@@ -1355,6 +1362,9 @@
                 "summary_report/stacked_barchart_of_reads.svg",
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/sintax_TreeSummarizedExperiment.rds"
             ],

--- a/tests/vsearch_lca.nf.test.snap
+++ b/tests/vsearch_lca.nf.test.snap
@@ -51,6 +51,9 @@
                     "R": "4.5.2",
                     "dada2": "1.38.0"
                 },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -110,6 +113,10 @@
                 },
                 "RENAME_RAW_DATA_FILES": {
                     "bash": "5.0.17(1)-release"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
                 },
                 "TREESUMMARIZEDEXPERIMENT": {
                     "R": "4.3.2",
@@ -305,6 +312,9 @@
                 "summary_report/summary_report.html",
                 "summary_report/versions.yml",
                 "summary_report/vsearch_lca_taxonomic_classification_per_taxonomy_level.svg",
+                "summary_tables",
+                "summary_tables/ampliseq.counts.parquet",
+                "summary_tables/ampliseq.counts.tsv.gz",
                 "treesummarizedexperiment",
                 "treesummarizedexperiment/vsearch_lca_TreeSummarizedExperiment.rds",
                 "vsearch_lca",

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -79,6 +79,8 @@ include { PHYLOSEQ_INTAX as PHYLOSEQ_INTAX_PPLACE } from '../modules/local/phylo
 include { PHYLOSEQ_INTAX as PHYLOSEQ_INTAX_QIIME2 } from '../modules/local/phyloseq_intax'
 include { FILTER_CLUSTERS               } from '../modules/local/filter_clusters'
 include { HMMER_HMMEXTRACT              } from '../modules/local/hmmer/hmmextract'
+include { SUMMARY_TABLE_COUNTS          } from '../modules/local/summary_table_counts'
+include { DUCKDB_TABLE2PARQUET          } from '../modules/nf-core/duckdb/table2parquet'
 
 //
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
@@ -137,9 +139,10 @@ workflow AMPLISEQ {
 
     main:
     // set empty channels
-    ch_tax_for_robject = channel.empty()
-    ch_versions        = channel.empty()
-    ch_multiqc_files   = channel.empty()
+    ch_tax_for_robject   = channel.empty()
+    ch_versions          = channel.empty()
+    ch_multiqc_files     = channel.empty()
+    ch_summary_tables    = channel.empty()
 
     //
     // INPUT AND VARIABLES
@@ -622,6 +625,12 @@ workflow AMPLISEQ {
         }
         ch_asv_fasta = DADA2_MERGE.out.fasta
         ch_asv_table = DADA2_MERGE.out.asv
+
+        //
+        // MODULE: Long-format ASV counts summary table
+        //
+        SUMMARY_TABLE_COUNTS ( DADA2_MERGE.out.asv )
+        ch_summary_tables = ch_summary_tables.mix( SUMMARY_TABLE_COUNTS.out.tsv )
     }
 
     //
@@ -1206,6 +1215,15 @@ workflow AMPLISEQ {
             ch_expected_sequences,  // expected sequences (fasta)
             ch_expected_abundances, // expected sequences (abundance table)
             ch_expected_profile     // expected taxonomic profile
+        )
+    }
+
+    //
+    // MODULE: Also write the summary tables as Parquet
+    //
+    if ( !params.skip_parquet_summary ) {
+        DUCKDB_TABLE2PARQUET (
+            ch_summary_tables.map { tsv -> [ [ id: tsv.name.replaceAll(/\.tsv(\.gz)?$/, '') ], tsv ] }
         )
     }
 

--- a/workflows/ampliseq.nf
+++ b/workflows/ampliseq.nf
@@ -631,6 +631,15 @@ workflow AMPLISEQ {
         //
         SUMMARY_TABLE_COUNTS ( DADA2_MERGE.out.asv )
         ch_summary_tables = ch_summary_tables.mix( SUMMARY_TABLE_COUNTS.out.tsv )
+
+        //
+        // MODULE: Also write the summary tables as Parquet
+        //
+        if ( !params.skip_parquet_summary ) {
+            DUCKDB_TABLE2PARQUET (
+                ch_summary_tables.map { tsv -> [ [ id: tsv.name.replaceAll(/\.tsv(\.gz)?$/, '') ], tsv ] }
+            )
+        }
     }
 
     //
@@ -1215,15 +1224,6 @@ workflow AMPLISEQ {
             ch_expected_sequences,  // expected sequences (fasta)
             ch_expected_abundances, // expected sequences (abundance table)
             ch_expected_profile     // expected taxonomic profile
-        )
-    }
-
-    //
-    // MODULE: Also write the summary tables as Parquet
-    //
-    if ( !params.skip_parquet_summary ) {
-        DUCKDB_TABLE2PARQUET (
-            ch_summary_tables.map { tsv -> [ [ id: tsv.name.replaceAll(/\.tsv(\.gz)?$/, '') ], tsv ] }
         )
     }
 


### PR DESCRIPTION
<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

First of two PRs for #1033 ("Create summary tables") — see that issue for the full multi-database/consolidation design discussion, which is entirely out of scope here.

This PR adds `summary_tables/ampliseq.counts.tsv.gz`: ASV counts in long format (`asv_id`, `sample`, `count`), zero-count rows dropped, lower-case column names throughout — matching the same convention already used in nf-core/magmap and nf-core/metatdenovo, so the output is ready to load into R, Python, etc. without pipeline-specific parsing.

Sourced directly from DADA2's own merged output (`DADA2_MERGE.out.asv`), before any of the optional post-processing filters (length, codons, decontam, etc.) run — so the table reflects raw denoising output regardless of which filters a given run enables, rather than being tied to an unclear stack of downstream choices.

A Parquet sibling (`ampliseq.counts.parquet`) is written by default via the vendored `duckdb/table2parquet` module, skippable with the new hidden `--skip_parquet_summary`.

Scoped to the DADA2 `asv_calling` path only — Savont/Nanopore ASV counts are a natural fast-follow once its `feature-table.tsv` output shape is looked into separately.

Second PR (multi-database support + taxonomy consolidation + the taxonomy summary table) will follow once the open design questions on #1033 are settled.