### PR TITLE
Add --max_ee_r to set DADA2 maxEE separately for reverse reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1042](https://github.com/nf-core/ampliseq/pull/1042) - Added CI test coverage for `--addsh`, which previously had none (`test_pacbio_its` now also runs DADA2 taxonomy against the UNITE database it already uses for SINTAX) (by @erikrikarddaniel)
 - [#1052](https://github.com/nf-core/ampliseq/pull/1052) - Added `summary_tables/ampliseq.counts.tsv.gz`, ASV counts in long format with consistent, lower-case column names, ready for analysis in R, Python or similar without pipeline-specific parsing; also written as Parquet by default, skip with `--skip_parquet_summary` (by @erikrikarddaniel)
 - [#1056](https://github.com/nf-core/ampliseq/pull/1056) - `--dada_ref_taxonomy` now accepts a comma-separated list of databases (e.g. `gtdb,silva`), running DADA2 taxonomic classification against each; one full set of output files is published per listed database, and the first-listed database feeds every downstream step that expects a single taxonomy (consolidating multiple databases into one is planned as a future addition) (by @erikrikarddaniel)
+- [#NN](https://github.com/nf-core/ampliseq/pull/NN) - New `--max_ee_r` overrides `--max_ee` for reverse reads only (paired-end Illumina data), for runs where read quality drops on the reverse read only (fixes [#1037](https://github.com/nf-core/ampliseq/issues/1037)) (by @erikrikarddaniel)
 
 ### `Changed`
 

--- a/assets/report_template.Rmd
+++ b/assets/report_template.Rmd
@@ -34,6 +34,7 @@ params:
     trunclenf: ""
     trunclenr: ""
     max_ee: ""
+    max_ee_r: ""
     trunc_qmin: FALSE
     trunc_rmin: ""
     dada_sample_inference: ""
@@ -463,9 +464,15 @@ if (params$trunc_qmin) {
 } else if (params$trunclenr != 0) {
     cat("Reverse reads were trimmed at ", params$trunclenr," bp, reads shorter than this were discarded. ", sep = "")
 }
-cat("Reads with more than", params$max_ee,"expected errors were discarded.",
-    "Read counts passing the filter are shown in section ['Read counts per sample'](#read-counts-per-sample)",
-    "column 'filtered'.", sep = " ")
+if (isFALSE(params$flag_single_end) && params$max_ee_r != "") {
+    cat("Reads with more than", params$max_ee, "(forward) or", params$max_ee_r, "(reverse) expected errors were discarded.",
+        "Read counts passing the filter are shown in section ['Read counts per sample'](#read-counts-per-sample)",
+        "column 'filtered'.", sep = " ")
+} else {
+    cat("Reads with more than", params$max_ee,"expected errors were discarded.",
+        "Read counts passing the filter are shown in section ['Read counts per sample'](#read-counts-per-sample)",
+        "column 'filtered'.", sep = " ")
+}
 ```
 
 <!-- Subsection on DADA2 QC visualisation -->
@@ -2065,7 +2072,9 @@ if (params$trunc_qmin) {
 } else if (params$trunclenr != 0) {
     cat("trim reads (reverse reads at ", params$trunclenr," bp, reads shorter than this were discarded), ", sep = "")
 }
-if ( as.integer(params$max_ee) > 0 ) {
+if (isFALSE(params$flag_single_end) && params$max_ee_r != "") {
+    cat("discard reads with >", params$max_ee, "(forward) or >", params$max_ee_r, "(reverse) expected errors, ")
+} else if ( as.integer(params$max_ee) > 0 ) {
     cat("discard reads with >", params$max_ee,"expected errors, ")
 }
 cat("correct errors, ")

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -194,7 +194,7 @@ process {
             "minLen = ${params.min_len}",
             params.max_len ? "maxLen = ${params.max_len}" : "maxLen = Inf",
             params.sequencing_type == "iontorrent" ? "trimLeft = 15" : "trimLeft = 0",
-            params.sequencing_type in ["pacbio","iontorrent","illumina_se"] ? "maxEE = ${params.max_ee}" : "maxEE = c(${params.max_ee}, ${params.max_ee})",
+            params.sequencing_type in ["pacbio","iontorrent","illumina_se"] ? "maxEE = ${params.max_ee}" : "maxEE = c(${params.max_ee}, ${params.max_ee_r ?: params.max_ee})",
             params.sequencing_type == "pacbio" ? "rm.phix = FALSE" : "rm.phix = TRUE"
         ].join(',').replaceAll('(,)*$', "") }
         publishDir = [

--- a/conf/test_max_ee_r.config
+++ b/conf/test_max_ee_r.config
@@ -1,0 +1,46 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Purpose: check that --max_ee_r overrides --max_ee for reverse reads only, on paired-end
+    Illumina data (issue #1037). Taxonomic classification and QIIME2 are not needed to cover
+    this -- only DADA2's own read filtering (DADA2_FILTNTRIM) is exercised, so both are
+    skipped to keep this profile fast.
+
+    Use as follows:
+        nextflow run nf-core/ampliseq -profile test_max_ee_r,<docker/singularity> --outdir <OUTDIR>
+
+----------------------------------------------------------------------------------------
+*/
+
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+}
+
+params {
+    config_profile_name = 'Test profile for --max_ee_r'
+    config_profile_description = 'Minimal test dataset to check --max_ee_r overrides --max_ee for reverse reads only'
+
+    // Input data
+    primer_fwd = "GTGYCAGCMGCCGCGGTAA"
+    primer_rev = "GGACTACNVGGGTWTCTAAT"
+    input = params.pipelines_testdata_base_path + "ampliseq/samplesheets/Samplesheet_v3.tsv"
+    metadata = params.pipelines_testdata_base_path + "ampliseq/samplesheets/Metadata.tsv"
+
+    // ASV generation
+    sample_inference = "independent"
+
+    // Reverse-read-only relaxed threshold, kept clearly different from the (default) --max_ee
+    // so a test assertion can tell the two apart unambiguously
+    max_ee_r = 5
+
+    // no taxonomy or QIIME2 needed -- this test only exercises DADA2 read filtering
+    skip_taxonomy = true
+    skip_fastqc = true
+}

--- a/main.nf
+++ b/main.nf
@@ -105,6 +105,7 @@ params {
     trunc_qmin: Integer = 25
     trunc_rmin: Float = 0.75
     max_ee: Integer = 2
+    max_ee_r: Integer?
     min_len: Integer = 50
     max_len: Integer?
     ignore_failed_filtering: Boolean

--- a/modules/local/summary_report.nf
+++ b/modules/local/summary_report.nf
@@ -110,6 +110,7 @@ process SUMMARY_REPORT  {
         "trunclenf='$params.trunclenf'",
         "trunclenr='$params.trunclenr'",
         "max_ee=$params.max_ee",
+        params.max_ee_r ? "max_ee_r=$params.max_ee_r" : "",
         dada_qual_stats && meta.single_end ? "dada_qc_f_path='$dada_qual_stats',dada_pp_qc_f_path='$dada_pp_qual_stats'" :
             dada_qual_stats ? "dada_qc_f_path='FW_qual_stats.svg',dada_qc_r_path='RV_qual_stats.svg',dada_pp_qc_f_path='FW_preprocessed_qual_stats.svg',dada_pp_qc_r_path='RV_preprocessed_qual_stats.svg'" : "",
         dada_filtntrim_args ? "dada_filtntrim_args='$dada_filtntrim_args'" : "",

--- a/nextflow.config
+++ b/nextflow.config
@@ -171,6 +171,7 @@ profiles {
     test_savont                   { includeConfig 'conf/test_savont.config'                   }
     test_savont_independent       { includeConfig 'conf/test_savont_independent.config'       }
     test_multidb                  { includeConfig 'conf/test_multidb.config'                  }
+    test_max_ee_r                 { includeConfig 'conf/test_max_ee_r.config'                 }
 }
 
 // Load nf-core custom profiles from different institutions

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -248,7 +248,13 @@
                     "type": "integer",
                     "default": 2,
                     "description": "DADA2 read filtering option",
-                    "help_text": "After truncation, reads with higher than `max_ee` \"expected errors\" will be discarded. In case of very long reads, you might want to increase this value.  We recommend (to start with) a value corresponding to approximately 1 expected error per 100-200 bp (default: 2)",
+                    "help_text": "After truncation, reads with higher than `max_ee` \"expected errors\" will be discarded. In case of very long reads, you might want to increase this value.  We recommend (to start with) a value corresponding to approximately 1 expected error per 100-200 bp (default: 2)\n\nFor paired-end data, this value is used for both forward and reverse reads unless `--max_ee_r` is also set, in which case `--max_ee_r` applies to the reverse reads only.",
+                    "fa_icon": "fas fa-equals"
+                },
+                "max_ee_r": {
+                    "type": "integer",
+                    "description": "DADA2 read filtering option for reverse reads, overriding --max_ee for reverse reads only (paired-end Illumina data only)",
+                    "help_text": "Only relevant for paired-end Illumina data. By default, `--max_ee` is applied to both forward and reverse reads. Some sequencing runs show a quality drop restricted to the reverse read (e.g. a known Illumina NextSeq behaviour); `--max_ee_r` lets the reverse read use a separate, typically more permissive, expected-error threshold instead of discarding those reads outright. If not set, `--max_ee` is used for the reverse reads too, unchanged from previous pipeline versions.",
                     "fa_icon": "fas fa-equals"
                 },
                 "min_len": {

--- a/tests/max_ee_r.nf.test
+++ b/tests/max_ee_r.nf.test
@@ -1,0 +1,27 @@
+nextflow_pipeline {
+
+    name "Test pipeline"
+    script "../main.nf"
+    tag "pipeline"
+    profile "test_max_ee_r"
+
+    test("-profile test_max_ee_r") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assert workflow.success
+            // filterAndTrim.args.txt records the exact R arguments DADA2_FILTNTRIM was called
+            // with -- "maxEE = c(2, 5)" confirms --max_ee_r (5) overrode --max_ee (2, default)
+            // for the reverse read only, rather than both reads sharing one value
+            def filtntrim_args = path("$outputDir/dada2/args/filterAndTrim.args.txt").text
+            assertAll(
+                { assert filtntrim_args.contains("maxEE = c(2, 5)") }
+            )
+        }
+    }
+}

--- a/tests/max_ee_r.nf.test
+++ b/tests/max_ee_r.nf.test
@@ -20,6 +20,10 @@ nextflow_pipeline {
             // for the reverse read only, rather than both reads sharing one value
             def filtntrim_args = path("$outputDir/dada2/args/filterAndTrim.args.txt").text
             assertAll(
+                { assert snapshot(
+                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we test pipelines on multiple Nextflow versions
+                    removeNextflowVersion("$outputDir/pipeline_info/nf_core_ampliseq_software_mqc_versions.yml")
+                ).match() },
                 { assert filtntrim_args.contains("maxEE = c(2, 5)") }
             )
         }

--- a/tests/max_ee_r.nf.test.snap
+++ b/tests/max_ee_r.nf.test.snap
@@ -1,0 +1,83 @@
+{
+    "-profile test_max_ee_r": {
+        "content": [
+            {
+                "BARRNAP": {
+                    "barrnap": 0.9
+                },
+                "BARRNAPSUMMARY": {
+                    "python": "Python 3.9.1"
+                },
+                "CUTADAPT_BASIC": {
+                    "cutadapt": 5.2
+                },
+                "CUTADAPT_SUMMARY_STD": {
+                    "python": "Python 3.8.3"
+                },
+                "DADA2_DENOISING": {
+                    "R": "4.5.2",
+                    "dada2": "1.38.0"
+                },
+                "DADA2_ERR": {
+                    "R": "4.5.2",
+                    "dada2": "1.38.0"
+                },
+                "DADA2_FILTNTRIM": {
+                    "R": "4.5.2",
+                    "dada2": "1.38.0"
+                },
+                "DADA2_MERGE": {
+                    "R": "4.5.2",
+                    "dada2": "1.38.0"
+                },
+                "DADA2_QUALITY1": {
+                    "R": "4.5.2",
+                    "dada2": "1.38.0",
+                    "ShortRead": "1.68.0"
+                },
+                "DADA2_QUALITY2": {
+                    "R": "4.5.2",
+                    "dada2": "1.38.0",
+                    "ShortRead": "1.68.0"
+                },
+                "DADA2_RMCHIMERA": {
+                    "R": "4.5.2",
+                    "dada2": "1.38.0"
+                },
+                "DADA2_STATS": {
+                    "R": "4.5.2",
+                    "dada2": "1.38.0"
+                },
+                "DECONTAM": {
+                    "R": "4.5.2",
+                    "decontam": "1.30.0"
+                },
+                "DUCKDB_TABLE2PARQUET": {
+                    "duckdb": "1.5.5"
+                },
+                "MERGE_STATS_DADA": {
+                    "R": "4.5.2"
+                },
+                "RENAME_RAW_DATA_FILES": {
+                    "bash": "5.0.17(1)-release"
+                },
+                "SUMMARY_TABLE_COUNTS": {
+                    "R": "4.3.1",
+                    "r-dplyr": "1.1.4"
+                },
+                "TRUNCLEN": {
+                    "python": "3.9.1",
+                    "pandas": "1.1.5"
+                },
+                "Workflow": {
+                    "nf-core/ampliseq": "v2.19.0dev"
+                }
+            }
+        ],
+        "timestamp": "2026-08-26T08:13:13.453887771",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}


### PR DESCRIPTION
<!--
# nf-core/ampliseq pull request

Many thanks for contributing to nf-core/ampliseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ampliseq/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ampliseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Closes #1037.

On paired-end Illumina data, `--max_ee` currently applies to both forward and reverse reads via one shared `filterAndTrim(maxEE = c(x, x))` call. Some sequencing runs show a quality drop restricted to the reverse read only (a known Illumina NextSeq behaviour, per the issue), for which a single shared threshold forces an unwanted trade-off between the two reads.

This adds `--max_ee_r`, which lets the reverse read use its own, typically more permissive, expected-error threshold instead — mirroring the existing `--trunclenf`/`--trunclenr` precedent for separate forward/reverse truncation lengths.

- `--max_ee_r` unset (default): behaviour is unchanged. `conf/modules.config`'s new ternary renders byte-identical `ext.args` output to before, and `default.nf.test`'s snapshot needed no update.
- `--max_ee_r` set: overrides `--max_ee` for the reverse read only, for paired-end Illumina data (the only sequencing type with a separate reverse read in the first place).
- `modules/local/summary_report.nf` / `assets/report_template.Rmd`: the report now states forward/reverse thresholds separately when `--max_ee_r` is set, instead of always reporting one shared value.

### Test coverage

Added a small, dedicated `test_max_ee_r` profile (`conf/test_max_ee_r.config` + `tests/max_ee_r.nf.test`) rather than a module-level `nf-test` for `DADA2_FILTNTRIM`. This repo's local modules are flat single-file, and a module-level test would require converting to the nested `main.nf`/`meta.yml`/`tests` layout that only vendored `modules/nf-core/**` components use — and this repo's own `nf-test.config` explicitly ignores tests under that path, so it wouldn't even run in CI. The new profile skips taxonomy and QIIME2 entirely (not needed to exercise DADA2 read filtering), keeping it one of the cheaper test profiles in the suite (~2.5 min locally), and asserts directly on the published `dada2/args/filterAndTrim.args.txt` content.
